### PR TITLE
Cleanup resource type string usage sites

### DIFF
--- a/internal/biz/hosts/hosts.go
+++ b/internal/biz/hosts/hosts.go
@@ -6,6 +6,10 @@ import (
 	"github.com/go-kratos/kratos/v2/log"
 )
 
+const (
+	ResourceType = "rhel-host"
+)
+
 // HostRepo is a Host repo.
 type HostRepo interface {
 	Save(context.Context, *Host) (*Host, error)

--- a/internal/biz/k8sclusters/k8sclusters.go
+++ b/internal/biz/k8sclusters/k8sclusters.go
@@ -6,6 +6,10 @@ import (
 	"github.com/go-kratos/kratos/v2/log"
 )
 
+const (
+	ResourceType = "k8s-cluster"
+)
+
 type K8sCluster struct {
 	Hello string
 }

--- a/internal/biz/notificationsintegrations/notificationsintegrations.go
+++ b/internal/biz/notificationsintegrations/notificationsintegrations.go
@@ -6,6 +6,10 @@ import (
 	"github.com/go-kratos/kratos/v2/log"
 )
 
+const (
+	ResourceType = "notifications-integration"
+)
+
 // NotificationsIntegration is a NotificationsIntegration repo.
 type NotificationsIntegrationRepo interface {
 	Save(context.Context, *NotificationsIntegration) (*NotificationsIntegration, error)

--- a/internal/biz/policies/policies.go
+++ b/internal/biz/policies/policies.go
@@ -6,6 +6,10 @@ import (
 	"github.com/go-kratos/kratos/v2/log"
 )
 
+const (
+	ResourceType = "policy"
+)
+
 type Policy struct {
 	Hello string
 }

--- a/internal/data/hosts/hosts.go
+++ b/internal/data/hosts/hosts.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-kratos/kratos/v2/log"
 
 	authzapi "github.com/project-kessel/inventory-api/internal/authz/api"
-	models "github.com/project-kessel/inventory-api/internal/biz/hosts"
+	biz "github.com/project-kessel/inventory-api/internal/biz/hosts"
 	eventingapi "github.com/project-kessel/inventory-api/internal/eventing/api"
 	"github.com/project-kessel/inventory-api/internal/middleware"
 )
@@ -32,7 +32,7 @@ func New(g *gorm.DB, a authzapi.Authorizer, e eventingapi.Manager, l *log.Helper
 	}
 }
 
-func (r *hostsRepo) Save(ctx context.Context, model *models.Host) (*models.Host, error) {
+func (r *hostsRepo) Save(ctx context.Context, model *biz.Host) (*biz.Host, error) {
 	identity, err := middleware.GetIdentity(ctx)
 	if err != nil {
 		return nil, nil
@@ -45,10 +45,10 @@ func (r *hostsRepo) Save(ctx context.Context, model *models.Host) (*models.Host,
 	if r.Eventer != nil {
 		// TODO: handle eventing errors
 		// TODO: Update the Object that's sent.  This is going to be what we actually emit.
-		producer, _ := r.Eventer.Lookup(identity, "rhelhost", model.ID)
+		producer, _ := r.Eventer.Lookup(identity, biz.ResourceType, model.ID)
 		evt := &eventingapi.Event{
 			EventType:    "Create",
-			ResourceType: "rhelhost",
+			ResourceType: biz.ResourceType,
 			Object:       model,
 		}
 		producer.Produce(ctx, evt)
@@ -56,7 +56,7 @@ func (r *hostsRepo) Save(ctx context.Context, model *models.Host) (*models.Host,
 	return model, nil
 }
 
-func (r *hostsRepo) Update(context.Context, *models.Host, string) (*models.Host, error) {
+func (r *hostsRepo) Update(context.Context, *biz.Host, string) (*biz.Host, error) {
 	return nil, nil
 }
 
@@ -64,18 +64,18 @@ func (r *hostsRepo) Delete(context.Context, string) error {
 	return nil
 }
 
-func (r *hostsRepo) FindByID(context.Context, string) (*models.Host, error) {
+func (r *hostsRepo) FindByID(context.Context, string) (*biz.Host, error) {
 	return nil, nil
 }
 
-func (r *hostsRepo) ListAll(context.Context) ([]*models.Host, error) {
-	// var model models.Host
+func (r *hostsRepo) ListAll(context.Context) ([]*biz.Host, error) {
+	// var model biz.Host
 	// var count int64
 	// if err := r.Db.Model(&model).Count(&count).Error; err != nil {
 	// 	return nil, err
 	// }
 
-	var results []*models.Host
+	var results []*biz.Host
 	if err := r.Db.Preload(clause.Associations).Find(&results).Error; err != nil {
 		return nil, err
 	}

--- a/internal/data/k8sclusters/k8sclusters.go
+++ b/internal/data/k8sclusters/k8sclusters.go
@@ -2,11 +2,12 @@ package k8sclusters
 
 import (
 	"context"
+
 	"gorm.io/gorm"
 
 	"github.com/go-kratos/kratos/v2/log"
 
-	models "github.com/project-kessel/inventory-api/internal/biz/k8sclusters"
+	biz "github.com/project-kessel/inventory-api/internal/biz/k8sclusters"
 )
 
 type k8sclustersRepo struct {
@@ -21,11 +22,11 @@ func New(g *gorm.DB, l *log.Helper) *k8sclustersRepo {
 	}
 }
 
-func (r *k8sclustersRepo) Save(context.Context, *models.K8sCluster) (*models.K8sCluster, error) {
+func (r *k8sclustersRepo) Save(context.Context, *biz.K8sCluster) (*biz.K8sCluster, error) {
 	return nil, nil
 }
 
-func (r *k8sclustersRepo) Update(context.Context, *models.K8sCluster) (*models.K8sCluster, error) {
+func (r *k8sclustersRepo) Update(context.Context, *biz.K8sCluster) (*biz.K8sCluster, error) {
 	return nil, nil
 }
 
@@ -33,10 +34,10 @@ func (r *k8sclustersRepo) Delete(context.Context, int64) error {
 	return nil
 }
 
-func (r *k8sclustersRepo) FindByID(context.Context, int64) (*models.K8sCluster, error) {
+func (r *k8sclustersRepo) FindByID(context.Context, int64) (*biz.K8sCluster, error) {
 	return nil, nil
 }
 
-func (r *k8sclustersRepo) ListAll(context.Context) ([]*models.K8sCluster, error) {
+func (r *k8sclustersRepo) ListAll(context.Context) ([]*biz.K8sCluster, error) {
 	return nil, nil
 }

--- a/internal/data/notificationsintegrations/notificationsintegrations.go
+++ b/internal/data/notificationsintegrations/notificationsintegrations.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-kratos/kratos/v2/log"
 
 	authzapi "github.com/project-kessel/inventory-api/internal/authz/api"
-	models "github.com/project-kessel/inventory-api/internal/biz/notificationsintegrations"
+	biz "github.com/project-kessel/inventory-api/internal/biz/notificationsintegrations"
 	eventingapi "github.com/project-kessel/inventory-api/internal/eventing/api"
 	"github.com/project-kessel/inventory-api/internal/middleware"
 )
@@ -32,7 +32,7 @@ func New(g *gorm.DB, a authzapi.Authorizer, e eventingapi.Manager, l *log.Helper
 	}
 }
 
-func (r *notificationsIntegrationsRepo) Save(ctx context.Context, model *models.NotificationsIntegration) (*models.NotificationsIntegration, error) {
+func (r *notificationsIntegrationsRepo) Save(ctx context.Context, model *biz.NotificationsIntegration) (*biz.NotificationsIntegration, error) {
 	identity, err := middleware.GetIdentity(ctx)
 	if err != nil {
 		return nil, nil
@@ -45,10 +45,10 @@ func (r *notificationsIntegrationsRepo) Save(ctx context.Context, model *models.
 	if r.Eventer != nil {
 		// TODO: handle eventing errors
 		// TODO: Update the Object that's sent.  This is going to be what we actually emit.
-		producer, _ := r.Eventer.Lookup(identity, "notificationsintegration", model.ID)
+		producer, _ := r.Eventer.Lookup(identity, biz.ResourceType, model.ID)
 		evt := &eventingapi.Event{
 			EventType:    "Create",
-			ResourceType: "notificationsintegration",
+			ResourceType: biz.ResourceType,
 			Object:       model,
 		}
 		producer.Produce(ctx, evt)
@@ -56,7 +56,7 @@ func (r *notificationsIntegrationsRepo) Save(ctx context.Context, model *models.
 	return model, nil
 }
 
-func (r *notificationsIntegrationsRepo) Update(context.Context, *models.NotificationsIntegration, string) (*models.NotificationsIntegration, error) {
+func (r *notificationsIntegrationsRepo) Update(context.Context, *biz.NotificationsIntegration, string) (*biz.NotificationsIntegration, error) {
 	return nil, nil
 }
 
@@ -64,18 +64,18 @@ func (r *notificationsIntegrationsRepo) Delete(context.Context, string) error {
 	return nil
 }
 
-func (r *notificationsIntegrationsRepo) FindByID(context.Context, string) (*models.NotificationsIntegration, error) {
+func (r *notificationsIntegrationsRepo) FindByID(context.Context, string) (*biz.NotificationsIntegration, error) {
 	return nil, nil
 }
 
-func (r *notificationsIntegrationsRepo) ListAll(context.Context) ([]*models.NotificationsIntegration, error) {
-	// var model models.NotificationsIntegration
+func (r *notificationsIntegrationsRepo) ListAll(context.Context) ([]*biz.NotificationsIntegration, error) {
+	// var model biz.NotificationsIntegration
 	// var count int64
 	// if err := r.Db.Model(&model).Count(&count).Error; err != nil {
 	// 	return nil, err
 	// }
 
-	var results []*models.NotificationsIntegration
+	var results []*biz.NotificationsIntegration
 	if err := r.Db.Preload(clause.Associations).Find(&results).Error; err != nil {
 		return nil, err
 	}

--- a/internal/data/policies/policies.go
+++ b/internal/data/policies/policies.go
@@ -2,11 +2,12 @@ package policies
 
 import (
 	"context"
+
 	"gorm.io/gorm"
 
 	"github.com/go-kratos/kratos/v2/log"
 
-	models "github.com/project-kessel/inventory-api/internal/biz/policies"
+	biz "github.com/project-kessel/inventory-api/internal/biz/policies"
 )
 
 type policiesRepo struct {
@@ -21,11 +22,11 @@ func New(g *gorm.DB, l *log.Helper) *policiesRepo {
 	}
 }
 
-func (r *policiesRepo) Save(context.Context, *models.Policy) (*models.Policy, error) {
+func (r *policiesRepo) Save(context.Context, *biz.Policy) (*biz.Policy, error) {
 	return nil, nil
 }
 
-func (r *policiesRepo) Update(context.Context, *models.Policy) (*models.Policy, error) {
+func (r *policiesRepo) Update(context.Context, *biz.Policy) (*biz.Policy, error) {
 	return nil, nil
 }
 
@@ -33,10 +34,10 @@ func (r *policiesRepo) Delete(context.Context, int64) error {
 	return nil
 }
 
-func (r *policiesRepo) FindByID(context.Context, int64) (*models.Policy, error) {
+func (r *policiesRepo) FindByID(context.Context, int64) (*biz.Policy, error) {
 	return nil, nil
 }
 
-func (r *policiesRepo) ListAll(context.Context) ([]*models.Policy, error) {
+func (r *policiesRepo) ListAll(context.Context) ([]*biz.Policy, error) {
 	return nil, nil
 }

--- a/internal/data/relationships/relationships.go
+++ b/internal/data/relationships/relationships.go
@@ -2,11 +2,12 @@ package relationships
 
 import (
 	"context"
+
 	"gorm.io/gorm"
 
 	"github.com/go-kratos/kratos/v2/log"
 
-	models "github.com/project-kessel/inventory-api/internal/biz/relationships"
+	biz "github.com/project-kessel/inventory-api/internal/biz/relationships"
 )
 
 type relationshipsRepo struct {
@@ -21,11 +22,11 @@ func New(g *gorm.DB, l *log.Helper) *relationshipsRepo {
 	}
 }
 
-func (r *relationshipsRepo) Save(context.Context, *models.Relationship) (*models.Relationship, error) {
+func (r *relationshipsRepo) Save(context.Context, *biz.Relationship) (*biz.Relationship, error) {
 	return nil, nil
 }
 
-func (r *relationshipsRepo) Update(context.Context, *models.Relationship) (*models.Relationship, error) {
+func (r *relationshipsRepo) Update(context.Context, *biz.Relationship) (*biz.Relationship, error) {
 	return nil, nil
 }
 
@@ -33,10 +34,10 @@ func (r *relationshipsRepo) Delete(context.Context, int64) error {
 	return nil
 }
 
-func (r *relationshipsRepo) FindByID(context.Context, int64) (*models.Relationship, error) {
+func (r *relationshipsRepo) FindByID(context.Context, int64) (*biz.Relationship, error) {
 	return nil, nil
 }
 
-func (r *relationshipsRepo) ListAll(context.Context) ([]*models.Relationship, error) {
+func (r *relationshipsRepo) ListAll(context.Context) ([]*biz.Relationship, error) {
 	return nil, nil
 }

--- a/internal/service/common/resource.go
+++ b/internal/service/common/resource.go
@@ -5,16 +5,16 @@ import (
 
 	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1"
 	authnapi "github.com/project-kessel/inventory-api/internal/authn/api"
-	models "github.com/project-kessel/inventory-api/internal/biz/common"
+	biz "github.com/project-kessel/inventory-api/internal/biz/common"
 )
 
-func MetadataFromPb(in *pb.Metadata, reporter *pb.ReporterData, identity *authnapi.Identity) *models.Metadata {
-	var tags []*models.Tag
+func MetadataFromPb(in *pb.Metadata, reporter *pb.ReporterData, identity *authnapi.Identity) *biz.Metadata {
+	var tags []*biz.Tag
 	for _, t := range in.Tags {
-		tags = append(tags, &models.Tag{Key: t.Key, Value: t.Value})
+		tags = append(tags, &biz.Tag{Key: t.Key, Value: t.Value})
 	}
 
-	return &models.Metadata{
+	return &biz.Metadata{
 		ID:        in.Id,
 		NaturalId: in.NaturalId,
 
@@ -25,12 +25,12 @@ func MetadataFromPb(in *pb.Metadata, reporter *pb.ReporterData, identity *authna
 		FirstReportedBy: identity.Principal,
 		LastReportedBy:  identity.Principal,
 
-		Reporters: []*models.Reporter{ReporterFromPb(reporter, identity)},
+		Reporters: []*biz.Reporter{ReporterFromPb(reporter, identity)},
 	}
 }
 
-func ReporterFromPb(in *pb.ReporterData, identity *authnapi.Identity) *models.Reporter {
-	return &models.Reporter{
+func ReporterFromPb(in *pb.ReporterData, identity *authnapi.Identity) *biz.Reporter {
+	return &biz.Reporter{
 		ReporterID:      identity.Principal,
 		ReporterType:    in.ReporterType.String(),
 		ReporterVersion: in.ReporterVersion,
@@ -42,7 +42,7 @@ func ReporterFromPb(in *pb.ReporterData, identity *authnapi.Identity) *models.Re
 	}
 }
 
-func MetadataFromModel(in *models.Metadata) *pb.Metadata {
+func MetadataFromModel(in *biz.Metadata) *pb.Metadata {
 	var tags []*pb.ResourceTag
 	for _, t := range in.Tags {
 		tags = append(tags, &pb.ResourceTag{Key: t.Key, Value: t.Value})
@@ -60,7 +60,7 @@ func MetadataFromModel(in *models.Metadata) *pb.Metadata {
 	}
 }
 
-func ReportersFromModel(in []*models.Reporter) []*pb.ReporterData {
+func ReportersFromModel(in []*biz.Reporter) []*pb.ReporterData {
 	var reporters []*pb.ReporterData
 	for _, r := range in {
 		reporters = append(reporters, &pb.ReporterData{

--- a/internal/service/hosts/hosts.go
+++ b/internal/service/hosts/hosts.go
@@ -13,10 +13,6 @@ import (
 	conv "github.com/project-kessel/inventory-api/internal/service/common"
 )
 
-const (
-	resource_type = "rhelhost"
-)
-
 // HostsService handles requests for Rhel hosts
 type HostsService struct {
 	pb.UnimplementedHostsServiceServer
@@ -37,8 +33,8 @@ func (c *HostsService) CreateRhelHost(ctx context.Context, r *pb.CreateRhelHostR
 	}
 
 	//TODO: refactor / abstract resource type strings
-	if !strings.EqualFold(r.Host.Metadata.ResourceType, resource_type) {
-		return nil, errors.BadRequest("BADREQUEST", fmt.Sprintf("incorrect resource type: expected %s", resource_type))
+	if !strings.EqualFold(r.Host.Metadata.ResourceType, biz.ResourceType) {
+		return nil, errors.BadRequest("BADREQUEST", fmt.Sprintf("incorrect resource type: expected %s", biz.ResourceType))
 	}
 
 	identity, err := middleware.GetIdentity(ctx)

--- a/internal/service/notificationsintegrations/notificationsintegrations.go
+++ b/internal/service/notificationsintegrations/notificationsintegrations.go
@@ -13,10 +13,6 @@ import (
 	conv "github.com/project-kessel/inventory-api/internal/service/common"
 )
 
-const (
-	resource_type = "notificationsintegration"
-)
-
 // NotificationsIntegrationsService handles requests for Notifications Integrations
 type NotificationsIntegrationsService struct {
 	pb.UnimplementedNotificationsIntegrationsServiceServer
@@ -37,8 +33,8 @@ func (c *NotificationsIntegrationsService) CreateNotificationsIntegration(ctx co
 	}
 
 	//TODO: refactor / abstract resource type strings
-	if !strings.EqualFold(r.Integration.Metadata.ResourceType, resource_type) {
-		return nil, errors.BadRequest("BADREQUEST", fmt.Sprintf("incorrect resource type: expected %s", resource_type))
+	if !strings.EqualFold(r.Integration.Metadata.ResourceType, biz.ResourceType) {
+		return nil, errors.BadRequest("BADREQUEST", fmt.Sprintf("incorrect resource type: expected %s", biz.ResourceType))
 	}
 
 	identity, err := middleware.GetIdentity(ctx)


### PR DESCRIPTION
Strings representing resource types are used in multiple places.  At least define the string for a resource type in one place.

I hyphenated types where it seemed sensible to me because hyphenation aligns with REST best practices, and we're going to have a URL path per resource type.  I don't think we currently follow the practice in our URLs, but we should.