### PR TITLE
Update README to use `make api_breaking` for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This repository implements a common inventory system with eventing.
 
 ```bash
 make init
-make api
+make api_breaking
 make build
 ./bin/inventory-api migrate --config .inventory-api.yaml
 ./bin/inventory-api serve --config .inventory-api.yaml


### PR DESCRIPTION
`make api` won't be useful until the API settles down and we register a stable version with buf.build