### PR TITLE
Remove generic handling of extra postgres params

### DIFF
--- a/internal/storage/postgres/config.go
+++ b/internal/storage/postgres/config.go
@@ -59,10 +59,6 @@ func (c *Config) Complete() CompletedConfig {
 		dsnBuilder.WriteString(fmt.Sprintf("sslrootcert=%s ", c.SSLRootCert))
 	}
 
-	for k, v := range c.Extra {
-		dsnBuilder.WriteString(fmt.Sprintf("%s=%s ", k, v))
-	}
-
 	dsn := strings.TrimSpace(dsnBuilder.String())
 
 	return CompletedConfig{&completedConfig{DSN: dsn}}

--- a/internal/storage/postgres/options.go
+++ b/internal/storage/postgres/options.go
@@ -8,14 +8,13 @@ import (
 
 type Options struct {
 	// https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
-	Host        string            `mapstructure:"host"`
-	Port        string            `mapstructure:"port"`
-	DbName      string            `mapstructure:"dbname"`
-	User        string            `mapstructure:"user"`
-	Password    string            `mapstructure:"password"`
-	SSLMode     string            `mapstructure:"sslmode"`
-	SSLRootCert string            `mapstructure:"sslrootcert"`
-	Extra       map[string]string `mapstructure:"extra,remain"`
+	Host        string `mapstructure:"host"`
+	Port        string `mapstructure:"port"`
+	DbName      string `mapstructure:"dbname"`
+	User        string `mapstructure:"user"`
+	Password    string `mapstructure:"password"`
+	SSLMode     string `mapstructure:"sslmode"`
+	SSLRootCert string `mapstructure:"sslrootcert"`
 	// HostAddr                string `mapstructure:"hostaddr"`
 	// Passfile                string `mapstructure:"passfile"`
 	// RequireAuth             string `mapstructure:"require_auth"`
@@ -72,8 +71,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 	fs.StringVar(&o.Password, prefix+"password", o.Password, "Password to be used if the server demands password authentication.")
 	fs.StringVar(&o.SSLMode, prefix+"sslmode", o.SSLMode, "This option determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server. See https://www.postgresql.org/docs/16/libpq-connect.html#LIBPQ-CONNECT-SSLMODE")
 	fs.StringVar(&o.SSLRootCert, prefix+"sslrootcert", o.SSLRootCert, "This parameter specifies the name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities. The default is ~/.postgresql/root.crt. The special value system may be specified instead, in which case the system's trusted CA roots will be loaded. The exact locations of these root certificates differ by SSL implementation and platform. For OpenSSL in particular, the locations may be further modified by the SSL_CERT_DIR and SSL_CERT_FILE environment variables.")
-
-	fs.StringToStringVar(&o.Extra, prefix+"extra", o.Extra, "Additional options passed as comma separated name=value pairs. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS")
 }
 
 func (o *Options) Complete() error {


### PR DESCRIPTION
This fixes a config parsing bug where `pflag` and `mapstructure` don't align with `StringToString` handling.