### PR TITLE
Allow to specify DOCKER variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 GOHOSTOS:=$(shell go env GOHOSTOS)
 GOPATH:=$(shell go env GOPATH)
+ifeq ($(DOCKER),)
 DOCKER:=$(shell type -P podman || type -P docker)
+endif
 
 API_PROTO_FILES:=$(shell find api -name *.proto)
 


### PR DESCRIPTION
### PR Template:

## Describe your changes

Allows to specify DOCKER variable to bypass any issue with the automatic approach to discover podman vs docker

It can be used by exporting the `DOCKER` variable, setting it before the make call

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

