### PR TITLE
Generate openapi component properties in snake_case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ init:
 api:
 	@echo "Generating api protos"
 	@$(DOCKER) build -t custom-protoc ./api
-	@$(DOCKER) run -t --rm -v $(PWD)/api:/api -v $(PWD)/openapi.yaml:/openapi.yaml -v $(PWD)/third_party:/third_party \
+	@$(DOCKER) run -t --rm -v $(PWD)/api:/api:rw,z -v $(PWD)/openapi.yaml:/openapi.yaml:rw,z -v $(PWD)/third_party:/third_party:ro,z \
 	-w=/api/ custom-protoc sh -c "buf generate && \
 		buf lint && \
 		buf breaking --against 'buf.build/project-kessel/inventory-api' "
@@ -36,7 +36,7 @@ api:
 api_breaking:
 	@echo "Generating api protos, allowing breaking changes"
 	@$(DOCKER) build -t custom-protoc ./api
-	@$(DOCKER) run -t --rm -v $(PWD)/api:/api -v $(PWD)/openapi.yaml:/openapi.yaml -v $(PWD)/third_party:/third_party \
+	@$(DOCKER) run -t --rm -v $(PWD)/api:/api:rw,z -v $(PWD)/openapi.yaml:/openapi.yaml:rw,z -v $(PWD)/third_party:/third_party:ro,z \
 	-w=/api/ custom-protoc sh -c "buf generate && \
 		buf lint"
 

--- a/api/buf.gen.yaml
+++ b/api/buf.gen.yaml
@@ -14,6 +14,7 @@ plugins:
     opt:
       - fq_schema_naming=true
       - default_response=false
+      - naming=proto
   - local: protoc-gen-validate
     opt:
       - paths=source_relative


### PR DESCRIPTION
* Configure the openapi plugin to generate openapi component properties in snake_case instead of camelCase.
* Tweak `Makefile` so certain container volumes are writable.