### PR TITLE
Adding `CreatedAt` and UpdatedAt` to MetadataFromPB and ReporterFromPB functions

### DIFF
--- a/internal/service/common/resource.go
+++ b/internal/service/common/resource.go
@@ -18,6 +18,8 @@ func MetadataFromPb(in *pb.Metadata, reporter *pb.ReporterData, identity *authna
 		ID:              in.Id,
 		ResourceType:    in.ResourceType,
 		Workspace:       in.Workspace,
+		CreatedAt:       in.FirstReported.AsTime(),
+		UpdatedAt:       in.LastReported.AsTime(),
 		Labels:          labels,
 		FirstReportedBy: identity.Principal,
 		LastReportedBy:  identity.Principal,
@@ -34,6 +36,8 @@ func ReporterFromPb(in *pb.ReporterData, identity *authnapi.Identity) *biz.Repor
 		LocalResourceId: in.LocalResourceId,
 		ConsoleHref:     in.ConsoleHref,
 		ApiHref:         in.ApiHref,
+		CreatedAt:       in.FirstReported.AsTime(),
+		UpdatedAt:       in.LastReported.AsTime(),
 	}
 }
 

--- a/internal/service/common/resource_test.go
+++ b/internal/service/common/resource_test.go
@@ -118,6 +118,43 @@ func TestMetadataFromPb(t *testing.T) {
 	assert.Equal(t, actual, &expected)
 }
 
+func TestReporterFromPb(t *testing.T) {
+	firstReported := time.Time{}.Add(100)
+	lastReported := firstReported.Add(500)
+
+	actual := ReporterFromPb(&pb.ReporterData{
+		ReporterType:       pb.ReporterData_REPORTER_TYPE_ACM,
+		ReporterInstanceId: "id-01",
+		FirstReported:      timestamppb.New(firstReported),
+		LastReported:       timestamppb.New(lastReported),
+		ConsoleHref:        "console-href",
+		ApiHref:            "api-href",
+		LocalResourceId:    "local-res-01",
+		ReporterVersion:    "version-123",
+	}, &authnapi.Identity{
+		Tenant:     "",
+		Principal:  "principal-01",
+		Groups:     nil,
+		IsReporter: false,
+		Type:       "",
+		Href:       "",
+		IsGuest:    false,
+	})
+	expected := biz.Reporter{
+		MetadataID:      0,
+		ReporterID:      "principal-01",
+		ReporterType:    pb.ReporterData_REPORTER_TYPE_ACM.String(),
+		CreatedAt:       firstReported,
+		UpdatedAt:       lastReported,
+		LocalResourceId: "local-res-01",
+		ReporterVersion: "version-123",
+		ConsoleHref:     "console-href",
+		ApiHref:         "api-href",
+	}
+
+	assert.Equal(t, actual, &expected)
+}
+
 func TestMetadataFromModel(t *testing.T) {
 	created := time.Time{}.Add(100)
 	updated := created.Add(500)
@@ -127,4 +164,62 @@ func TestMetadataFromModel(t *testing.T) {
 	expected := createPbMetadata(created, updated)
 
 	assert.Equal(t, actual, &expected)
+}
+
+func TestReportersFromModel(t *testing.T) {
+	created1 := time.Time{}.Add(100)
+	updated1 := created1.Add(500)
+
+	created2 := time.Time{}.Add(200)
+	updated2 := created2.Add(333)
+
+	actual := ReportersFromModel([]*biz.Reporter{
+		{
+			MetadataID:      100,
+			ReporterID:      "reporter-01",
+			ReporterType:    pb.ReporterData_REPORTER_TYPE_ACM.String(),
+			CreatedAt:       created1,
+			UpdatedAt:       updated1,
+			LocalResourceId: "local-resource-1",
+			ReporterVersion: "reporter-version-1",
+			ConsoleHref:     "console-href-1",
+			ApiHref:         "api-href-1",
+		},
+		{
+			MetadataID:      233,
+			ReporterID:      "reporter-02",
+			ReporterType:    pb.ReporterData_REPORTER_TYPE_OCM.String(),
+			CreatedAt:       created2,
+			UpdatedAt:       updated2,
+			LocalResourceId: "local-resource-2",
+			ReporterVersion: "reporter-version-2",
+			ConsoleHref:     "console-href-2",
+			ApiHref:         "api-href-2",
+		},
+	})
+
+	expected := []*pb.ReporterData{
+		{
+			ReporterType:       pb.ReporterData_REPORTER_TYPE_ACM,
+			ReporterInstanceId: "reporter-01",
+			FirstReported:      timestamppb.New(created1),
+			LastReported:       timestamppb.New(updated1),
+			ConsoleHref:        "console-href-1",
+			ApiHref:            "api-href-1",
+			LocalResourceId:    "local-resource-1",
+			ReporterVersion:    "reporter-version-1",
+		},
+		{
+			ReporterType:       pb.ReporterData_REPORTER_TYPE_OCM,
+			ReporterInstanceId: "reporter-02",
+			FirstReported:      timestamppb.New(created2),
+			LastReported:       timestamppb.New(updated2),
+			ConsoleHref:        "console-href-2",
+			ApiHref:            "api-href-2",
+			LocalResourceId:    "local-resource-2",
+			ReporterVersion:    "reporter-version-2",
+		},
+	}
+
+	assert.Equal(t, expected, actual)
 }

--- a/internal/service/common/resource_test.go
+++ b/internal/service/common/resource_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1"
+	authnapi "github.com/project-kessel/inventory-api/internal/authn/api"
 	biz "github.com/project-kessel/inventory-api/internal/biz/common"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -9,11 +10,34 @@ import (
 	"time"
 )
 
-func TestMetadataFromModel(t *testing.T) {
-	created := time.Time{}
-	updated := created.Add(500)
+func createPbMetadata(created time.Time, updated time.Time) pb.Metadata {
+	return pb.Metadata{
+		Id:              100,
+		ResourceType:    "astromech",
+		FirstReported:   timestamppb.New(created),
+		LastReported:    timestamppb.New(updated),
+		FirstReportedBy: "anakin",
+		LastReportedBy:  "luke",
+		Workspace:       "droids",
+		Labels: []*pb.ResourceLabel{
+			{
+				Key:   "color",
+				Value: "white",
+			},
+			{
+				Key:   "color",
+				Value: "blue",
+			},
+			{
+				Key:   "affiliation",
+				Value: "resistance",
+			},
+		},
+	}
+}
 
-	data := MetadataFromModel(&biz.Metadata{
+func createBizMetadata(created time.Time, updated time.Time) biz.Metadata {
+	return biz.Metadata{
 		ID:              100,
 		CreatedAt:       created,
 		UpdatedAt:       updated,
@@ -42,31 +66,65 @@ func TestMetadataFromModel(t *testing.T) {
 				Value:      "resistance",
 			},
 		},
-	})
+	}
+}
 
-	target := &pb.Metadata{
-		Id:              100,
-		ResourceType:    "astromech",
-		FirstReported:   timestamppb.New(created),
-		LastReported:    timestamppb.New(updated),
-		FirstReportedBy: "anakin",
-		LastReportedBy:  "luke",
-		Workspace:       "droids",
-		Labels: []*pb.ResourceLabel{
-			{
-				Key:   "color",
-				Value: "white",
-			},
-			{
-				Key:   "color",
-				Value: "blue",
-			},
-			{
-				Key:   "affiliation",
-				Value: "resistance",
-			},
+// MetadataFromPb is used when creating a new entry
+func TestMetadataFromPb(t *testing.T) {
+	created := time.Time{}.Add(100)
+	updated := created.Add(800)
+
+	pbMetadata := createPbMetadata(created, updated)
+
+	actual := MetadataFromPb(
+		&pbMetadata,
+		&pb.ReporterData{
+			ReporterType:       pb.ReporterData_REPORTER_TYPE_HBI,
+			ReporterInstanceId: "instance-001",
+			FirstReported:      timestamppb.New(created),
+			LastReported:       timestamppb.New(updated),
+			ConsoleHref:        "console-href",
+			ApiHref:            "api-href",
+			LocalResourceId:    "local-01",
+			ReporterVersion:    "version-123",
+		},
+		&authnapi.Identity{
+			Tenant:     "",
+			Principal:  "anakin",
+			Groups:     nil,
+			IsReporter: false,
+			Type:       "",
+			Href:       "",
+			IsGuest:    false,
+		},
+	)
+
+	expected := createBizMetadata(created, updated)
+	expected.LastReportedBy = "anakin"
+	expected.Reporters = []*biz.Reporter{
+		{
+			MetadataID:      0,
+			ReporterID:      "anakin",
+			ReporterType:    pb.ReporterData_REPORTER_TYPE_HBI.String(),
+			CreatedAt:       created,
+			UpdatedAt:       updated,
+			LocalResourceId: "local-01",
+			ReporterVersion: "version-123",
+			ConsoleHref:     "console-href",
+			ApiHref:         "api-href",
 		},
 	}
 
-	assert.Equal(t, data, target)
+	assert.Equal(t, actual, &expected)
+}
+
+func TestMetadataFromModel(t *testing.T) {
+	created := time.Time{}.Add(100)
+	updated := created.Add(500)
+
+	bizData := createBizMetadata(created, updated)
+	actual := MetadataFromModel(&bizData)
+	expected := createPbMetadata(created, updated)
+
+	assert.Equal(t, actual, &expected)
 }


### PR DESCRIPTION
### PR Template:

## Describe your changes

The PB data already had the Created/Updated but it wasn't being used. I'm adding those values and adding a small test for these.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

