### PR TITLE
RHCLOUD-34576 Moving config reading to PreRun function

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,6 +42,19 @@ var (
 		Use:     Name,
 		Version: Version,
 		Short:   "A simple common inventory system",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := viper.ReadInConfig(); err != nil {
+				return err
+			} else {
+				msg := fmt.Sprintf("Using config file: %s", viper.ConfigFileUsed())
+				logger.Debug(msg)
+			}
+
+			// put the values into the options struct.
+			err := viper.Unmarshal(&options)
+
+			return err
+		},
 	}
 
 	options = struct {
@@ -122,17 +135,4 @@ func initConfig() {
 
 	viper.SetEnvPrefix(Name)
 	viper.AutomaticEnv()
-
-	if err := viper.ReadInConfig(); err != nil {
-		panic(err)
-	} else {
-		msg := fmt.Sprintf("Using config file: %s", viper.ConfigFileUsed())
-		logger.Debug(msg)
-	}
-
-	// put the values into the options struct.
-	err := viper.Unmarshal(&options)
-	if err != nil {
-		panic(err)
-	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+type MockedCommandRun struct {
+	mock.Mock
+}
+
+func (m *MockedCommandRun) RunE(cmd *cobra.Command, args []string) error {
+	margs := m.Called(cmd, args)
+	return margs.Error(0)
+}
+
+func setupMockRunE() map[string]*MockedCommandRun {
+	mocks := make(map[string]*MockedCommandRun)
+
+	for _, cmd := range rootCmd.Commands() {
+		mockedCommandRunE := new(MockedCommandRun)
+		mockedCommandRunE.On("RunE", mock.Anything, mock.Anything).Return(nil)
+		mocks[cmd.Name()] = mockedCommandRunE
+		cmd.RunE = mockedCommandRunE.RunE
+	}
+
+	return mocks
+}
+
+func assertCommandCalled(t *testing.T, command string, mocked map[string]*MockedCommandRun) {
+	targetRunE := "RunE"
+
+	for name, cmd := range mocked {
+		if name == command {
+			cmd.AssertCalled(t, targetRunE, mock.Anything, mock.Anything)
+		} else {
+			cmd.AssertNotCalled(t, targetRunE)
+		}
+	}
+}
+
+func TestRootCommand(t *testing.T) {
+	commands := []string{"migrate", "serve"}
+	for _, command := range commands {
+		t.Run(command+" by setting storage.database to postgres", func(t *testing.T) {
+			rootCmd.SetArgs([]string{command, "--storage.database=postgres"})
+
+			mocked := setupMockRunE()
+			assert.Nil(t, rootCmd.Execute())
+
+			assertCommandCalled(t, command, mocked)
+			assert.Equal(t, "postgres", viper.GetString("storage.database"))
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.opentelemetry.io/otel v1.28.0 // indirect
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -351,6 +351,7 @@ github.com/spf13/viper v1.19.0/go.mod h1:GQUN9bilAbhU/jgc1bKs99f/suXKeUMct8Adx5+
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Was initially checking https://github.com/spf13/viper/issues/233
   but none of the suggestions there seemed to work.
   In our case it looked like viper or cobra wasn't loading the value at all.
 - Moved some code to the PreRun and that seems to work. Some users suggest
   that the code shouldn't be in the init and use the PreRun instead.


Adding some tests to verify it works

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

