### PR TITLE
RHCLOUD-34576 Loads both config and command line arguments

### DIFF
--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -34,7 +34,5 @@ func NewCommand(options *storage.Options, logger log.Logger) *cobra.Command {
 		},
 	}
 
-	options.AddFlags(cmd.Flags(), "storage")
-
 	return cmd
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -60,6 +60,6 @@ func TestRootCommand(t *testing.T) {
 func TestInvalidConfigFile(t *testing.T) {
 	rootCmd.SetArgs([]string{"migrate", "--config", "not-found"})
 	assert.Panics(t, func() {
-		rootCmd.Execute()
+		_ = rootCmd.Execute()
 	})
 }

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -205,7 +205,6 @@ func NewCommand(
 	}
 
 	serverOptions.AddFlags(cmd.Flags(), "server")
-	storageOptions.AddFlags(cmd.Flags(), "storage")
 	authnOptions.AddFlags(cmd.Flags(), "authn")
 	authzOptions.AddFlags(cmd.Flags(), "authz")
 	eventingOptions.AddFlags(cmd.Flags(), "eventing")


### PR DESCRIPTION
  The original fix was using the rootcmd prerun - but that is not
  executed when using a sub command. Config was not being loaded at all.

  The original bug still aplies, repeated flags are overriden.

  The flags are honored just before loading the config from viper. But once
  It is loaded the overriden repeated flags are set to the default values.

  Adding storage.* flags as PersistentFlags since is used in both commands.

### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

