### PR TITLE
Ensure the configuration file is read and unmarshaled

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,19 +42,6 @@ var (
 		Use:     Name,
 		Version: Version,
 		Short:   "A simple common inventory system",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := viper.ReadInConfig(); err != nil {
-				return err
-			} else {
-				msg := fmt.Sprintf("Using config file: %s", viper.ConfigFileUsed())
-				logger.Debug(msg)
-			}
-
-			// put the values into the options struct.
-			err := viper.Unmarshal(&options)
-
-			return err
-		},
 	}
 
 	options = struct {
@@ -118,9 +105,6 @@ func initConfig() {
 			}
 			// Set the config file path
 			viper.SetConfigFile(absPath)
-			if err := viper.ReadInConfig(); err != nil {
-				log.Fatalf("Error reading INVENTORY_API_CONFIG file, %s", err)
-			}
 		} else {
 			home, err := os.UserHomeDir()
 			cobra.CheckErr(err)
@@ -135,4 +119,11 @@ func initConfig() {
 
 	viper.SetEnvPrefix(Name)
 	viper.AutomaticEnv()
+
+	if err := viper.ReadInConfig(); err != nil {
+		log.Fatalf("Failed to read config file: %v", err)
+	}
+	if err := viper.Unmarshal(&options); err != nil {
+		log.Fatalf("Failed to unmarshal config to options: %v", err)
+	}
 }


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Remove `PreRunE` from rootCmd since it won't be execute for `serve` and `migrate` subcommand
- Ensure the configuration file is read and unmarshaled

## How to reproduce

`./bin/inventory-api migrate --config /tmp/inventory-api.yaml`
INFO ts=2024-08-16T14:46:01+08:00 caller=storage/storage.go:24 service.name=inventory-api service.version=0.1.0 trace.id= span.id= group=storage group=storage msg=Using backing storage: ***sqlite3***

`cat /tmp/inventory-api.yaml`
```server:
  http:
    address: 0.0.0.0:8081
  grpc:
    address: 0.0.0.0:9081
authn:
  allow-unauthenticated: true
authz:
  impl: allow-all
eventing:
  eventer: stdout
  kafka:
storage:
  database: postgres
  postgres:
    host: "multicluster-global-hub-postgres.multicluster-global-hub.svc"
    port: "5432"
    user: "postgres"
    password: "xxx"
    dbname: "inventory"
```

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

