### PR TITLE
Adds build flag to compose calls to prevent stale executions 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,19 @@ RUN ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 WORKDIR /workspace
 
-COPY . ./
+COPY go.mod go.sum ./
 
 ENV CGO_ENABLED 1
-RUN go mod vendor
-RUN make build
+RUN go mod download
+
+COPY api ./api
+COPY cmd ./cmd
+COPY internal ./internal
+COPY third_party ./third_party
+COPY main.go Makefile ./
+
+ARG VERSION
+RUN VERSION=${VERSION} make build
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
 

--- a/Makefile
+++ b/Makefile
@@ -105,11 +105,11 @@ pr-check:
 
 .PHONY: inventory-up
 inventory-up:
-	INVENTORY_VERSION=$(VERSION) ./scripts/start-inventory.sh
+	./scripts/start-inventory.sh
 
 .PHONY: inventory-up-sso
 inventory-up-sso:
-	INVENTORY_VERSION=$(VERSION)  ./scripts/start-inventory-kc.sh
+	./scripts/start-inventory-kc.sh
 
 .PHONY: get-token
 get-token:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ endif
 API_PROTO_FILES:=$(shell find api -name *.proto)
 
 TITLE:="Kessel Asset Inventory API"
+ifeq ($(VERSION),)
 VERSION:=$(shell git describe --tags --always)
+endif
 INVENTORY_SCHEMA_VERSION=0.11.0
 
 .PHONY: init
@@ -103,11 +105,11 @@ pr-check:
 
 .PHONY: inventory-up
 inventory-up:
-	./scripts/start-inventory.sh
+	INVENTORY_VERSION=$(VERSION) ./scripts/start-inventory.sh
 
 .PHONY: inventory-up-sso
 inventory-up-sso:
-	./scripts/start-inventory-kc.sh
+	INVENTORY_VERSION=$(VERSION)  ./scripts/start-inventory-kc.sh
 
 .PHONY: get-token
 get-token:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,8 @@ services:
 #      - "INVENTORY_API_STORAGE_POSTGRES_PASSWORD=${POSTGRES_PASSWORD}"
     build:
       dockerfile: Dockerfile
+      args:
+        VERSION: $INVENTORY_VERSION
     volumes:
       - ./inventory-api-compose.yaml:/inventory-api-compose.yaml:ro,z
       - ./config/psks.yaml:/psks.yaml:ro,z
@@ -22,6 +24,8 @@ services:
       INVENTORY_API_CONFIG: /inventory-api-compose.yaml
     build:
       dockerfile: Dockerfile
+      args:
+        VERSION: $INVENTORY_VERSION
     volumes:
       - ./inventory-api-compose.yaml:/inventory-api-compose.yaml:ro,z
     command: ["migrate"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     build:
       dockerfile: Dockerfile
       args:
-        VERSION: $INVENTORY_VERSION
+        VERSION: dev
     volumes:
       - ./inventory-api-compose.yaml:/inventory-api-compose.yaml:ro,z
       - ./config/psks.yaml:/psks.yaml:ro,z
@@ -25,7 +25,7 @@ services:
     build:
       dockerfile: Dockerfile
       args:
-        VERSION: $INVENTORY_VERSION
+        VERSION: dev
     volumes:
       - ./inventory-api-compose.yaml:/inventory-api-compose.yaml:ro,z
     command: ["migrate"]

--- a/scripts/start-inventory-kc.sh
+++ b/scripts/start-inventory-kc.sh
@@ -2,4 +2,4 @@
 set -e
 # Function to check if a command is available
 source ./scripts/check_docker_podman.sh
-${DOCKER} compose --env-file ./scripts/.env -f ./docker-compose-sso.yaml up -d
+${DOCKER} compose --env-file ./scripts/.env -f ./docker-compose-sso.yaml up -d --build

--- a/scripts/start-inventory.sh
+++ b/scripts/start-inventory.sh
@@ -2,4 +2,4 @@
 set -e
 # Function to check if a command is available
 source ./scripts/check_docker_podman.sh
-${DOCKER} compose --env-file ./scripts/.env -f ./docker-compose.yaml up -d
+${DOCKER} compose --env-file ./scripts/.env -f ./docker-compose.yaml up -d --build


### PR DESCRIPTION
### PR Template:

## Describe your changes

Every time we call `make inventory-up` (or the sso version), it will check if there has been any change in source code to decide if we need to re-build because of those changes, this should help to run any stale build.

- Adds  `build` flag to compose excecutions - this prevents from using old builds if there are changes in the code.
- Also made more granular the required files in order to build - this will prevent from non-required files to trigger a full dependency download / build - slowing us down.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

