### PR TITLE
RHCLOUD-34760 | refactor: update resource name for "notifications/integration"

### DIFF
--- a/internal/biz/notificationsintegrations/notificationsintegrations.go
+++ b/internal/biz/notificationsintegrations/notificationsintegrations.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	ResourceType = "notifications-integration"
+	ResourceType = "notifications/integration"
 )
 
 // NotificationsIntegration is a NotificationsIntegration repo.


### PR DESCRIPTION
## Describe your changes
The SpiceDB schema for Notifications names the integrations as a combination of the "notifications" namespace and the "integration" resource name, resulting in the following full resource name: "notifications/integration". The goal is to represent that in the inventory API.

## Ticket reference (if applicable)
Fixes [[RHCLOUD-34760]](https://issues.redhat.com/browse/RHCLOUD-34760)

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

