### PR TITLE
Prevent duplicated rhel_host resources

### DIFF
--- a/internal/biz/common/resource.go
+++ b/internal/biz/common/resource.go
@@ -15,6 +15,9 @@ type Metadata struct {
 	// The type of the Resource.
 	ResourceType string
 
+	// Local Resource Id
+	LocalResourceId string
+
 	// Identity of the reporter that first reported this item.
 	FirstReportedBy string
 

--- a/internal/biz/common/resource.go
+++ b/internal/biz/common/resource.go
@@ -15,9 +15,6 @@ type Metadata struct {
 	// The type of the Resource.
 	ResourceType string
 
-	// Local Resource Id
-	LocalResourceId string
-
 	// Identity of the reporter that first reported this item.
 	FirstReportedBy string
 
@@ -71,4 +68,11 @@ type Label struct {
 
 	Key   string
 	Value string
+}
+
+// ResourceId Acts as a resource id from the standpoint of a reporter
+type ResourceId struct {
+	LocalResourceId string
+	ReporterType    string
+	ReporterId      string
 }

--- a/internal/biz/hosts/hosts.go
+++ b/internal/biz/hosts/hosts.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/project-kessel/inventory-api/internal/biz/common"
 	"gorm.io/gorm"
 
 	"github.com/go-kratos/kratos/v2/log"

--- a/internal/biz/hosts/hosts.go
+++ b/internal/biz/hosts/hosts.go
@@ -2,6 +2,10 @@ package hosts
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"github.com/project-kessel/inventory-api/internal/biz/common"
+	"gorm.io/gorm"
 
 	"github.com/go-kratos/kratos/v2/log"
 )
@@ -32,6 +36,13 @@ func New(repo HostRepo, logger log.Logger) *HostUsecase {
 
 // CreateHost creates a Host in the repository and returns the new Host.
 func (uc *HostUsecase) CreateHost(ctx context.Context, h *Host) (*Host, error) {
+	_, err := uc.repo.FindByID(ctx, h.Metadata.LocalResourceId)
+	if err == nil {
+		return nil, fmt.Errorf("resource with local_resource_id: `%v` already exists for resource type: `%v`", h.Metadata.LocalResourceId, h.Metadata.ResourceType)
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
 	if ret, err := uc.repo.Save(ctx, h); err != nil {
 		return nil, err
 	} else {

--- a/internal/data/hosts/hosts.go
+++ b/internal/data/hosts/hosts.go
@@ -62,14 +62,7 @@ func (r *hostsRepo) Update(context.Context, *biz.Host, string) (*biz.Host, error
 	return nil, nil
 }
 
-func (r *hostsRepo) Delete(ctx context.Context, resource string) error {
-	//identity, err := middleware.GetIdentity(ctx)
-	//if err != nil {
-	//	return err
-	//}
-	//
-	//r.Db.Session(&gorm.Session{FullSaveAssociations: true}).Where("metadata.resource")
-
+func (r *hostsRepo) Delete(context.Context, string) error {
 	return nil
 }
 
@@ -78,7 +71,6 @@ func (r *hostsRepo) FindByID(ctx context.Context, localResourceId string) (*biz.
 
 	err := r.Db.Session(&gorm.Session{}).Joins("Metadata").Take(&host, "metadata.local_resource_id = ?", localResourceId).Error
 	if err != nil {
-		log.Infof("err: %v", err)
 		return nil, err
 	}
 

--- a/internal/data/hosts/hosts.go
+++ b/internal/data/hosts/hosts.go
@@ -2,7 +2,6 @@ package hosts
 
 import (
 	"context"
-
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
@@ -35,7 +34,7 @@ func New(g *gorm.DB, a authzapi.Authorizer, e eventingapi.Manager, l *log.Helper
 func (r *hostsRepo) Save(ctx context.Context, model *biz.Host) (*biz.Host, error) {
 	identity, err := middleware.GetIdentity(ctx)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	if err := r.Db.Session(&gorm.Session{FullSaveAssociations: true}).Create(model).Error; err != nil {
@@ -63,12 +62,27 @@ func (r *hostsRepo) Update(context.Context, *biz.Host, string) (*biz.Host, error
 	return nil, nil
 }
 
-func (r *hostsRepo) Delete(context.Context, string) error {
+func (r *hostsRepo) Delete(ctx context.Context, resource string) error {
+	//identity, err := middleware.GetIdentity(ctx)
+	//if err != nil {
+	//	return err
+	//}
+	//
+	//r.Db.Session(&gorm.Session{FullSaveAssociations: true}).Where("metadata.resource")
+
 	return nil
 }
 
-func (r *hostsRepo) FindByID(context.Context, string) (*biz.Host, error) {
-	return nil, nil
+func (r *hostsRepo) FindByID(ctx context.Context, localResourceId string) (*biz.Host, error) {
+	host := biz.Host{}
+
+	err := r.Db.Session(&gorm.Session{}).Joins("Metadata").Take(&host, "metadata.local_resource_id = ?", localResourceId).Error
+	if err != nil {
+		log.Infof("err: %v", err)
+		return nil, err
+	}
+
+	return &host, nil
 }
 
 func (r *hostsRepo) ListAll(context.Context) ([]*biz.Host, error) {

--- a/internal/service/common/resource.go
+++ b/internal/service/common/resource.go
@@ -16,7 +16,7 @@ func MetadataFromPb(in *pb.Metadata, reporter *pb.ReporterData, identity *authna
 	}
 
 	return &biz.Metadata{
-		ID:              in.Id, // Todo: Is this a relation's ID?
+		ID:              in.Id,
 		ResourceType:    bizhosts.ResourceType,
 		Workspace:       in.Workspace,
 		CreatedAt:       timestamppb.Now().AsTime(),

--- a/internal/service/common/resource.go
+++ b/internal/service/common/resource.go
@@ -1,9 +1,7 @@
 package common
 
 import (
-	"fmt"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	"strings"
 
 	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1"
 	authnapi "github.com/project-kessel/inventory-api/internal/authn/api"

--- a/internal/service/common/resource.go
+++ b/internal/service/common/resource.go
@@ -1,15 +1,13 @@
 package common
 
 import (
-	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-
 	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1"
 	authnapi "github.com/project-kessel/inventory-api/internal/authn/api"
 	biz "github.com/project-kessel/inventory-api/internal/biz/common"
-	bizhosts "github.com/project-kessel/inventory-api/internal/biz/hosts"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func MetadataFromPb(in *pb.Metadata, reporter *pb.ReporterData, identity *authnapi.Identity) *biz.Metadata {
+func MetadataFromPb(in *pb.Metadata, reporter *pb.ReporterData, identity *authnapi.Identity, resourceType string) *biz.Metadata {
 	var labels []*biz.Label
 	for _, t := range in.Labels {
 		labels = append(labels, &biz.Label{Key: t.Key, Value: t.Value})
@@ -17,10 +15,10 @@ func MetadataFromPb(in *pb.Metadata, reporter *pb.ReporterData, identity *authna
 
 	return &biz.Metadata{
 		ID:              in.Id,
-		ResourceType:    bizhosts.ResourceType,
+		ResourceType:    resourceType,
 		Workspace:       in.Workspace,
-		CreatedAt:       timestamppb.Now().AsTime(),
-		UpdatedAt:       timestamppb.Now().AsTime(),
+		CreatedAt:       in.FirstReported.AsTime(),
+		UpdatedAt:       in.LastReported.AsTime(),
 		Labels:          labels,
 		FirstReportedBy: identity.Principal,
 		LastReportedBy:  identity.Principal,
@@ -38,8 +36,8 @@ func ReporterFromPb(in *pb.ReporterData, identity *authnapi.Identity) *biz.Repor
 		LocalResourceId: in.LocalResourceId,
 		ConsoleHref:     in.ConsoleHref,
 		ApiHref:         in.ApiHref,
-		CreatedAt:       timestamppb.Now().AsTime(),
-		UpdatedAt:       timestamppb.Now().AsTime(),
+		CreatedAt:       in.FirstReported.AsTime(),
+		UpdatedAt:       in.LastReported.AsTime(),
 	}
 }
 

--- a/internal/service/common/resource.go
+++ b/internal/service/common/resource.go
@@ -22,7 +22,6 @@ func MetadataFromPb(in *pb.Metadata, reporter *pb.ReporterData, identity *authna
 		Labels:          labels,
 		FirstReportedBy: identity.Principal,
 		LastReportedBy:  identity.Principal,
-		LocalResourceId: reporter.LocalResourceId,
 
 		Reporters: []*biz.Reporter{ReporterFromPb(reporter, identity)},
 	}

--- a/internal/service/common/resource.go
+++ b/internal/service/common/resource.go
@@ -1,11 +1,14 @@
 package common
 
 import (
+	"fmt"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	"strings"
 
 	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1"
 	authnapi "github.com/project-kessel/inventory-api/internal/authn/api"
 	biz "github.com/project-kessel/inventory-api/internal/biz/common"
+	bizhosts "github.com/project-kessel/inventory-api/internal/biz/hosts"
 )
 
 func MetadataFromPb(in *pb.Metadata, reporter *pb.ReporterData, identity *authnapi.Identity) *biz.Metadata {
@@ -15,14 +18,15 @@ func MetadataFromPb(in *pb.Metadata, reporter *pb.ReporterData, identity *authna
 	}
 
 	return &biz.Metadata{
-		ID:              in.Id,
-		ResourceType:    in.ResourceType,
+		ID:              in.Id, // Todo: Is this a relation's ID?
+		ResourceType:    bizhosts.ResourceType,
 		Workspace:       in.Workspace,
-		CreatedAt:       in.FirstReported.AsTime(),
-		UpdatedAt:       in.LastReported.AsTime(),
+		CreatedAt:       timestamppb.Now().AsTime(),
+		UpdatedAt:       timestamppb.Now().AsTime(),
 		Labels:          labels,
 		FirstReportedBy: identity.Principal,
 		LastReportedBy:  identity.Principal,
+		LocalResourceId: reporter.LocalResourceId,
 
 		Reporters: []*biz.Reporter{ReporterFromPb(reporter, identity)},
 	}
@@ -36,8 +40,8 @@ func ReporterFromPb(in *pb.ReporterData, identity *authnapi.Identity) *biz.Repor
 		LocalResourceId: in.LocalResourceId,
 		ConsoleHref:     in.ConsoleHref,
 		ApiHref:         in.ApiHref,
-		CreatedAt:       in.FirstReported.AsTime(),
-		UpdatedAt:       in.LastReported.AsTime(),
+		CreatedAt:       timestamppb.Now().AsTime(),
+		UpdatedAt:       timestamppb.Now().AsTime(),
 	}
 }
 

--- a/internal/service/common/resource_test.go
+++ b/internal/service/common/resource_test.go
@@ -47,6 +47,7 @@ func createBizMetadata(created time.Time, updated time.Time) biz.Metadata {
 		LastReportedBy:  "luke",
 		Workspace:       "droids",
 		Reporters:       nil,
+		LocalResourceId: "local-01",
 		Labels: []*biz.Label{
 			{
 				ID:         0,
@@ -98,6 +99,7 @@ func TestMetadataFromPb(t *testing.T) {
 			Href:       "",
 			IsGuest:    false,
 		},
+		"astromech",
 	)
 
 	expected := createBizMetadata(created, updated)

--- a/internal/service/common/resource_test.go
+++ b/internal/service/common/resource_test.go
@@ -47,7 +47,6 @@ func createBizMetadata(created time.Time, updated time.Time) biz.Metadata {
 		LastReportedBy:  "luke",
 		Workspace:       "droids",
 		Reporters:       nil,
-		LocalResourceId: "local-01",
 		Labels: []*biz.Label{
 			{
 				ID:         0,

--- a/internal/service/hosts/hosts.go
+++ b/internal/service/hosts/hosts.go
@@ -67,7 +67,7 @@ func hostFromCreateRequest(r *pb.CreateRhelHostRequest, identity *authnapi.Ident
 	}
 
 	return &biz.Host{
-		Metadata: *conv.MetadataFromPb(metadata, r.RhelHost.ReporterData, identity),
+		Metadata: *conv.MetadataFromPb(metadata, r.RhelHost.ReporterData, identity, biz.ResourceType),
 	}, nil
 }
 

--- a/internal/service/hosts/hosts_test.go
+++ b/internal/service/hosts/hosts_test.go
@@ -2,6 +2,7 @@ package hosts
 
 import (
 	"context"
+	"github.com/project-kessel/inventory-api/internal/biz/common"
 	"testing"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -30,7 +31,7 @@ func (m *HostRepoMock) Delete(ctx context.Context, hostId string) error {
 	return nil
 }
 
-func (m *HostRepoMock) FindByID(ctx context.Context, hostId string) (*hosts.Host, error) {
+func (m *HostRepoMock) FindByID(ctx context.Context, hostId common.ResourceId) (*hosts.Host, error) {
 	margs := m.Called(ctx, hostId)
 
 	err := margs.Error(1)

--- a/internal/service/notificationsintegrations/notificationsintegrations.go
+++ b/internal/service/notificationsintegrations/notificationsintegrations.go
@@ -67,7 +67,7 @@ func notificationsIntegrationFromCreateRequest(r *pb.CreateNotificationsIntegrat
 	}
 
 	return &biz.NotificationsIntegration{
-		Metadata: *conv.MetadataFromPb(metadata, r.Integration.ReporterData, identity),
+		Metadata: *conv.MetadataFromPb(metadata, r.Integration.ReporterData, identity, biz.ResourceType),
 	}, nil
 }
 


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Assuming we don't want to have duplicated resources that have the same `local_resource_id`. Duplicated resources across different resource types is allowed.

Copied the `LocalResourceId` to `Metadata` but wondering if it should be removed from the `ReporterData`

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

