### PR TITLE
RHCLOUD-34782 Added tests for k8s_cluster.pb.validate.go

### DIFF
--- a/api/kessel/inventory/v1beta1/k8s_cluster.pb.validate_test.go
+++ b/api/kessel/inventory/v1beta1/k8s_cluster.pb.validate_test.go
@@ -1,0 +1,86 @@
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestK8_clusterValidatesSuccessfullyWithValidData(t *testing.T) {
+	k8cluster := K8SCluster{
+		ReporterData: &ReporterData{
+			ReporterType:    2,
+			LocalResourceId: "some-id",
+		},
+		ResourceData: &K8SClusterDetail{
+			ExternalClusterId: "some-cluster-id",
+			ClusterStatus:     2,
+			KubeVendor:        5,
+			KubeVersion:       "v1.30.1",
+			VendorVersion:     "4.16",
+			CloudPlatform:     6,
+			Nodes: []*K8SClusterDetailNodesInner{
+				{
+					Name:   "ip-10-0-0-1.ec2.internal",
+					Cpu:    "7500m",
+					Memory: "30973224Ki",
+					Labels: []*ResourceLabel{
+						{
+							Key:   "node.openshift.io/os_id",
+							Value: "rhcos",
+						},
+					},
+				},
+			},
+		},
+	}
+	err := k8cluster.ValidateAll()
+	assert.NoError(t, err)
+}
+
+func TestK8ClusterValidationFailsWithMissingReporterData(t *testing.T) {
+	k8cluster := K8SCluster{
+		ResourceData: &K8SClusterDetail{
+			ExternalClusterId: "some-cluster-id",
+			ClusterStatus:     2,
+			KubeVendor:        5,
+			KubeVersion:       "v1.30.1",
+			VendorVersion:     "4.16",
+			CloudPlatform:     6,
+			Nodes: []*K8SClusterDetailNodesInner{
+				{
+					Name:   "ip-10-0-0-1.ec2.internal",
+					Cpu:    "7500m",
+					Memory: "30973224Ki",
+					Labels: []*ResourceLabel{
+						{
+							Key:   "node.openshift.io/os_id",
+							Value: "rhcos",
+						},
+					},
+				},
+			},
+		},
+	}
+	err := k8cluster.ValidateAll()
+	assert.ErrorContains(t, err, "K8SCluster.ReporterData")
+}
+func TestK8ClusterValidationFailsWithMissingResourceData(t *testing.T) {
+	k8cluster := K8SCluster{
+		ReporterData: &ReporterData{
+			ReporterType:    2,
+			LocalResourceId: "some-id",
+		},
+	}
+	err := k8cluster.ValidateAll()
+	assert.ErrorContains(t, err, "K8SCluster.ResourceData")
+}
+
+func TestK8ClusterValidationFailsWithMissingAllData(t *testing.T) {
+	k8cluster := K8SCluster{}
+
+	err := k8cluster.ValidateAll()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "K8SCluster.ReporterData")
+	assert.Contains(t, err.Error(), "K8SCluster.ResourceData")
+}


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Added four test cases for k8s_cluster
    - All Valid data included within k8s_cluster
    - k8s_cluster missing ReporterData
    - k8s_cluster missing RescourceData
    - k8s_cluster missing RepoterData and ResourceData

## Ticket reference (if applicable)
Fixes [RHCLOUD-34782](https://issues.redhat.com/browse/RHCLOUD-34782)

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

