### PR TITLE
RHCLOUD-34874 Added tests for k8s_cluster_detail_nodes_inner

### DIFF
--- a/api/kessel/inventory/v1beta1/k8s_cluster_detail_nodes_inner.pb.validate_test.go
+++ b/api/kessel/inventory/v1beta1/k8s_cluster_detail_nodes_inner.pb.validate_test.go
@@ -1,0 +1,118 @@
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestK8SClusterDetailNodesInnerValidatesSuccessfullyWithValidData(t *testing.T) {
+	node := &K8SClusterDetailNodesInner{
+		Name:   "ip-10-0-0-1.ec2.internal",
+		Cpu:    "7500m",
+		Memory: "30973224Ki",
+		Labels: []*ResourceLabel{
+			{
+				Key:   "node.openshift.io/os_id",
+				Value: "rhcos",
+			},
+		},
+	}
+	err := node.ValidateAll()
+	assert.NoError(t, err)
+}
+
+func TestK8SClusterDetailNodesInnerValidationFailsWithEmptyName(t *testing.T) {
+	node := &K8SClusterDetailNodesInner{
+		Name:   "",
+		Cpu:    "7500m",
+		Memory: "30973224Ki",
+		Labels: []*ResourceLabel{
+			{
+				Key:   "node.openshift.io/os_id",
+				Value: "rhcos",
+			},
+		},
+	}
+	err := node.ValidateAll()
+	assert.ErrorContains(t, err, "invalid K8SClusterDetailNodesInner.Name: value length must be at least 1 runes")
+}
+
+func TestK8SClusterDetailNodesInnerValidationFailsWithEmptyCpu(t *testing.T) {
+	node := &K8SClusterDetailNodesInner{
+		Name:   "ip-10-0-0-1.ec2.internal",
+		Cpu:    "",
+		Memory: "30973224Ki",
+		Labels: []*ResourceLabel{
+			{
+				Key:   "node.openshift.io/os_id",
+				Value: "rhcos",
+			},
+		},
+	}
+	err := node.ValidateAll()
+	assert.ErrorContains(t, err, "invalid K8SClusterDetailNodesInner.Cpu: value length must be at least 1 runes")
+}
+
+func TestK8SClusterDetailNodesInnerValidationFailsWithEmptyMemory(t *testing.T) {
+	node := &K8SClusterDetailNodesInner{
+		Name:   "ip-10-0-0-1.ec2.internal",
+		Cpu:    "7500m",
+		Memory: "",
+		Labels: []*ResourceLabel{
+			{
+				Key:   "node.openshift.io/os_id",
+				Value: "rhcos",
+			},
+		},
+	}
+	err := node.ValidateAll()
+	assert.ErrorContains(t, err, "invalid K8SClusterDetailNodesInner.Memory: value length must be at least 1 runes")
+}
+
+func TestK8SClusterDetailNodesInnerValidationFailsWithNilLabel(t *testing.T) {
+	node := &K8SClusterDetailNodesInner{
+		Name:   "ip-10-0-0-1.ec2.internal",
+		Cpu:    "7500m",
+		Memory: "30973224Ki",
+		Labels: []*ResourceLabel{
+			nil,
+		},
+	}
+	err := node.ValidateAll()
+	assert.ErrorContains(t, err, "invalid K8SClusterDetailNodesInner.Labels[0]: value is required")
+}
+
+func TestK8SClusterDetailNodesInnerValidationFailsWithInvalidLabel(t *testing.T) {
+	node := &K8SClusterDetailNodesInner{
+		Name:   "ip-10-0-0-1.ec2.internal",
+		Cpu:    "7500m",
+		Memory: "30973224Ki",
+		Labels: []*ResourceLabel{
+			{
+				Key:   "",
+				Value: "rhcos",
+			},
+		},
+	}
+	err := node.ValidateAll()
+	assert.ErrorContains(t, err, "invalid K8SClusterDetailNodesInner.Labels[0]: embedded message failed validation")
+}
+
+var multipleErrorMessage = "invalid K8SClusterDetailNodesInner.Name: value length must be at least 1 runes; " +
+	"invalid K8SClusterDetailNodesInner.Cpu: value length must be at least 1 runes; " +
+	"invalid K8SClusterDetailNodesInner.Memory: value length must be at least 1 runes; " +
+	"invalid K8SClusterDetailNodesInner.Labels[0]: value is required"
+
+func TestK8SClusterDetailNodesInnerValidationWithMultipleErrors(t *testing.T) {
+	node := &K8SClusterDetailNodesInner{
+		Name:   "",
+		Cpu:    "",
+		Memory: "",
+		Labels: []*ResourceLabel{nil},
+	}
+
+	err := node.ValidateAll()
+	assert.ErrorContains(t, err, multipleErrorMessage)
+
+}


### PR DESCRIPTION
### PR Template:

## Describe your changes
- Added 7 test cases for k8s_cluster_node
     - All Valid data included within k8s_cluster_node
     - k8s_cluster_node empty Name
     - k8s_cluster_node empty CPU
     - k8s_cluster_node empty Memory
     - k8s_cluster_node with nil Label
     - k8s_cluster_node empty Label data
     - k8s_cluster_node with multiple missing/nil parameters

## Ticket reference (if applicable)
Fixes [RHCLOUD-34874](https://issues.redhat.com/browse/RHCLOUD-34874)

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

