### PR TITLE
RHCLOUD-34499 adds basic metrics to grpc and http servers

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -144,7 +144,10 @@ func NewCommand(
 			}
 
 			// construct servers
-			server := server.New(serverConfig, middleware.Authentication(authenticator), logger)
+			server, err := server.New(serverConfig, middleware.Authentication(authenticator), logger)
+			if err != nil {
+				return err
+			}
 
 			// wire together notificationsintegrations handling
 			notifs_repo := notifsrepo.New(db, authorizer, eventingManager)

--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,16 @@ require (
 	github.com/google/wire v0.6.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/project-kessel/relations-api v0.0.0-20240801131134-0f51350f3c3d
+	github.com/prometheus/client_golang v1.19.1
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
+	go.opentelemetry.io/otel v1.28.0
+	go.opentelemetry.io/otel/exporters/prometheus v0.50.0
+	go.opentelemetry.io/otel/metric v1.28.0
+	go.opentelemetry.io/otel/sdk v1.28.0
+	go.opentelemetry.io/otel/sdk/metric v1.28.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240604185151-ef581f913117
 	google.golang.org/grpc v1.66.0
 	google.golang.org/protobuf v1.34.2
@@ -30,9 +36,12 @@ require (
 
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/docker/docker v27.2.0+incompatible // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.2 // indirect
@@ -56,10 +65,15 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/prometheus/client_model v0.6.1 // indirect
+	github.com/prometheus/common v0.55.0 // indirect
+	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
@@ -68,8 +82,6 @@ require (
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	go.opentelemetry.io/otel v1.28.0 // indirect
-	go.opentelemetry.io/otel/metric v1.28.0 // indirect
 	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/docker/compose/v2 v2.27.0 h1:FKyClQdErCxUZULC2zo6Jn5ve+epFPe/Y0HaxjmU
 github.com/docker/compose/v2 v2.27.0/go.mod h1:uaqwmY6haO8wXWHk+LAsqqDapX6boH4izRKqj/E7+Bo=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v27.0.0+incompatible h1:JRugTYuelmWlW0M3jakcIadDx2HUoUO6+Tf2C5jVfwA=
-github.com/docker/docker v27.0.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v27.2.0+incompatible h1:Rk9nIVdfH3+Vz4cyI/uhbINhEZ/oLmc+CBXmH6fbNk4=
+github.com/docker/docker v27.2.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.0 h1:YQFtbBQb4VrpoPxhFuzEBPQ9E16qz5SpHLS+uswaCp8=
 github.com/docker/docker-credential-helpers v0.8.0/go.mod h1:UGFXcuoQ5TxPiB54nHOZ32AWRqQdECoh/Mg0AlEYb40=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=
@@ -310,6 +310,8 @@ github.com/moby/sys/symlink v0.2.0 h1:tk1rOM+Ljp0nFmfOIBtlV3rTDlWOwFRhjEeAhZB0nZ
 github.com/moby/sys/symlink v0.2.0/go.mod h1:7uZVF2dqJjG/NsClqul95CqKOBRQyYSNnJ6BMgR/gFs=
 github.com/moby/sys/user v0.1.0 h1:WmZ93f5Ux6het5iituh9x2zAG7NFY9Aqi49jjE1PaQg=
 github.com/moby/sys/user v0.1.0/go.mod h1:fKJhFOnsCN6xZ5gSfbM6zaHGgDJMrqt9/reuj4T7MmU=
+github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g=
+github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/server/http/http.go
+++ b/internal/server/http/http.go
@@ -3,23 +3,39 @@ package http
 import (
 	"github.com/bufbuild/protovalidate-go"
 	"github.com/go-kratos/kratos/v2/middleware"
+	"github.com/go-kratos/kratos/v2/middleware/metrics"
 	"github.com/go-kratos/kratos/v2/middleware/recovery"
 	"github.com/go-kratos/kratos/v2/middleware/selector"
 	"github.com/go-kratos/kratos/v2/transport/http"
 	m "github.com/project-kessel/inventory-api/internal/middleware"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/otel/metric"
 )
 
 // New create a new http server.
-func New(c CompletedConfig, authn middleware.Middleware) *http.Server {
+func New(c CompletedConfig, authn middleware.Middleware, meter metric.Meter) (*http.Server, error) {
+	requests, err := metrics.DefaultRequestsCounter(meter, metrics.DefaultServerRequestsCounterName)
+	if err != nil {
+		return nil, err
+	}
+	seconds, err := metrics.DefaultSecondsHistogram(meter, metrics.DefaultServerSecondsHistogramName)
+	if err != nil {
+		return nil, err
+	}
 	validator, err := protovalidate.New()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	// TODO: pass in health, authn middleware
 	var opts = []http.ServerOption{
 		http.Middleware(
 			recovery.Recovery(),
 			m.Validation(validator),
+			metrics.Server(
+				metrics.WithSeconds(seconds),
+				metrics.WithRequests(requests),
+			),
 			selector.Server(
 				authn,
 			).Match(NewWhiteListMatcher).Build(),
@@ -27,5 +43,11 @@ func New(c CompletedConfig, authn middleware.Middleware) *http.Server {
 	}
 	opts = append(opts, c.ServerOptions...)
 	srv := http.NewServer(opts...)
-	return srv
+	srv.HandlePrefix("/metrics", promhttp.HandlerFor(
+		prometheus.DefaultGatherer,
+		promhttp.HandlerOpts{
+			EnableOpenMetrics: true,
+		},
+	))
+	return srv, nil
 }

--- a/internal/server/otel.go
+++ b/internal/server/otel.go
@@ -1,0 +1,39 @@
+package server
+
+// Taken from Kratos examples: https://github.com/go-kratos/examples/blob/main/otel/internal/dep/otel.go
+
+import (
+	"github.com/go-kratos/kratos/v2/middleware/metrics"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+)
+
+func NewMeter(provider metric.MeterProvider) (metric.Meter, error) {
+	return provider.Meter("inventory-api"), nil
+}
+
+func NewMeterProvider(s *Server) (metric.MeterProvider, error) {
+	exporter, err := prometheus.New()
+	if err != nil {
+		return nil, err
+	}
+
+	provider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithResource(
+			resource.NewWithAttributes(
+				semconv.SchemaURL,
+				semconv.ServiceNameKey.String("inventory-api"),
+			),
+		),
+		sdkmetric.WithReader(exporter),
+		sdkmetric.WithView(
+			metrics.DefaultSecondsHistogramView(metrics.DefaultServerSecondsHistogramName),
+		),
+	)
+	otel.SetMeterProvider(provider)
+	return provider, nil
+}


### PR DESCRIPTION
### PR Template:

## Describe your changes
* adds some basic [default metrics](https://go-kratos.dev/en/docs/component/middleware/metrics) provided by Kratos that includes
  * server_requests_code_total: captures response codes and their total count for each method/endpoint called and API type (grpc or http) 
  * server_requests_seconds_bucket_seconds: histogram of request times for each method/endpoint and API type (grpc or http)
* follows a similar pattern as relations-api and Kratos as well 
* updates some of the definitions and function returns to allow for error handling with changes

Validation: (note, metrics will only show up after an endpoint is hit so below is just a few that i was able to trigger testing locally, all API endpoints provided by gRPC and HTTP would have a correlating metrics as well as any error or successful response types would too)
```shell
# output of curling the metrics endpoint with some data from hitting both grpc and http endpoints
$ curl localhost:8081/metrics
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 2.7646e-05
go_gc_duration_seconds{quantile="0.25"} 4.2602e-05
====TRUNCATED-STANDARD-CPU/MEM/PROCESS-METRICS===
# HELP server_requests_code_total 
# TYPE server_requests_code_total counter
server_requests_code_total{code="0",kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetLivez",otel_scope_name="inventory-api",otel_scope_version="",reason=""} 1
server_requests_code_total{code="0",kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetReadyz",otel_scope_name="inventory-api",otel_scope_version="",reason=""} 1
server_requests_code_total{code="0",kind="http",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",reason=""} 1
server_requests_code_total{code="401",kind="grpc",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",reason="UNAUTHORIZED"} 1
# HELP server_requests_seconds_bucket_seconds 
# TYPE server_requests_seconds_bucket_seconds histogram
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetLivez",otel_scope_name="inventory-api",otel_scope_version="",le="0.005"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetLivez",otel_scope_name="inventory-api",otel_scope_version="",le="0.01"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetLivez",otel_scope_name="inventory-api",otel_scope_version="",le="0.025"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetLivez",otel_scope_name="inventory-api",otel_scope_version="",le="0.05"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetLivez",otel_scope_name="inventory-api",otel_scope_version="",le="0.1"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetLivez",otel_scope_name="inventory-api",otel_scope_version="",le="0.25"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetLivez",otel_scope_name="inventory-api",otel_scope_version="",le="0.5"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetLivez",otel_scope_name="inventory-api",otel_scope_version="",le="1"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetLivez",otel_scope_name="inventory-api",otel_scope_version="",le="+Inf"} 1
server_requests_seconds_bucket_seconds_sum{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetLivez",otel_scope_name="inventory-api",otel_scope_version=""} 2.5246e-05
server_requests_seconds_bucket_seconds_count{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetLivez",otel_scope_name="inventory-api",otel_scope_version=""} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetReadyz",otel_scope_name="inventory-api",otel_scope_version="",le="0.005"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetReadyz",otel_scope_name="inventory-api",otel_scope_version="",le="0.01"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetReadyz",otel_scope_name="inventory-api",otel_scope_version="",le="0.025"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetReadyz",otel_scope_name="inventory-api",otel_scope_version="",le="0.05"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetReadyz",otel_scope_name="inventory-api",otel_scope_version="",le="0.1"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetReadyz",otel_scope_name="inventory-api",otel_scope_version="",le="0.25"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetReadyz",otel_scope_name="inventory-api",otel_scope_version="",le="0.5"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetReadyz",otel_scope_name="inventory-api",otel_scope_version="",le="1"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetReadyz",otel_scope_name="inventory-api",otel_scope_version="",le="+Inf"} 1
server_requests_seconds_bucket_seconds_sum{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetReadyz",otel_scope_name="inventory-api",otel_scope_version=""} 2.5513e-05
server_requests_seconds_bucket_seconds_count{kind="grpc",operation="/kessel.inventory.v1.KesselInventoryHealthService/GetReadyz",otel_scope_name="inventory-api",otel_scope_version=""} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="0.005"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="0.01"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="0.025"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="0.05"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="0.1"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="0.25"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="0.5"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="1"} 1
server_requests_seconds_bucket_seconds_bucket{kind="grpc",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="+Inf"} 1
server_requests_seconds_bucket_seconds_sum{kind="grpc",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version=""} 1.4839e-05
server_requests_seconds_bucket_seconds_count{kind="grpc",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version=""} 1
server_requests_seconds_bucket_seconds_bucket{kind="http",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="0.005"} 1
server_requests_seconds_bucket_seconds_bucket{kind="http",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="0.01"} 1
server_requests_seconds_bucket_seconds_bucket{kind="http",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="0.025"} 1
server_requests_seconds_bucket_seconds_bucket{kind="http",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="0.05"} 1
server_requests_seconds_bucket_seconds_bucket{kind="http",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="0.1"} 1
server_requests_seconds_bucket_seconds_bucket{kind="http",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="0.25"} 1
server_requests_seconds_bucket_seconds_bucket{kind="http",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="0.5"} 1
server_requests_seconds_bucket_seconds_bucket{kind="http",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="1"} 1
server_requests_seconds_bucket_seconds_bucket{kind="http",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version="",le="+Inf"} 1
server_requests_seconds_bucket_seconds_sum{kind="http",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version=""} 0.004805892
server_requests_seconds_bucket_seconds_count{kind="http",operation="/kessel.inventory.v1beta1.resources.KesselRhelHostService/CreateRhelHost",otel_scope_name="inventory-api",otel_scope_version=""} 1


## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

