### PR TITLE
RHCLOUD-34499 adds counter for kafka events to producer

### DIFF
--- a/internal/eventing/factory.go
+++ b/internal/eventing/factory.go
@@ -15,7 +15,11 @@ func New(c CompletedConfig, source string, logger *log.Helper) (api.Manager, err
 	case "stdout":
 		return stdout.New(logger)
 	case "kafka":
-		return kafka.New(c.Kafka, source, logger)
+		km, err := kafka.New(c.Kafka, source, logger)
+		if err != nil {
+			return nil, err
+		}
+		return km, nil
 	}
 
 	return nil, fmt.Errorf("unrecognized eventer type: %s", c.Eventer)


### PR DESCRIPTION
### PR Template:

## Describe your changes

* adds a new counter for capturing kafka event counts, partitioned by the event type but includes resource type
* updates the producer struct to include the counter so that on successful event production it can increment
* leverages the globally created meter in otel.go
* updates some of the logic for error handling since there is not an error to check for setting up the producer

The metric seems to be working testing with just creating a k8s cluster, ~but any attempts to delete or update don't seem to do much. It could be a fault in my logic or the delete/update methods not quite working yet or how im using them.~ since delete/update calls are not implemented yet for all endpoints I am unable to test them. 

Creating a cluster using the steps in the README does produce a metric value for the kafka event locally. Have not tested with rhel-hosts are other endpoints yet.

```
$ curl -s localhost:8081/metrics | grep kafka
# HELP kafka_event_total 
# TYPE kafka_event_total counter
kafka_event_total{event_type="add",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version="",resource_type="k8s-cluster"} 2
```

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

