### PR TITLE
Rename the ClowdApp to kessel-inventory-api

### DIFF
--- a/deploy/kessel-inventory.yaml
+++ b/deploy/kessel-inventory.yaml
@@ -103,14 +103,14 @@ objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
     metadata:
-      name: inventory
+      name: kessel-inventory
     spec:
       envName: ${ENV_NAME}
 #      testing:
 #        iqePlugin: inventory_api
       replicas: 1
       deployments:
-        - name: inventory
+        - name: api
           podSpec:
             image: ${INVENTORY_IMAGE}:${INVENTORY_IMAGE_TAG}
             livenessProbe:
@@ -140,12 +140,9 @@ objects:
               enabled: true
               apiPath: inventory
 parameters:
-  - description: Name of the ClowdApp
-    name: CLOWDAPP_NAME
-    value: inventory
-  - description : ClowdEnvironment name
+  - description: ClowdEnvironment name (ephemeral, stage, prod)
     name: ENV_NAME
-    value: insights-ephemeral
+    required: true
   - description: App Image
     name: INVENTORY_IMAGE
     value: quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory-main/inventory-api-main


### PR DESCRIPTION
### PR Template:

## Describe your changes

Related to https://github.com/project-kessel/relations-api/pull/159

- This PR renames pods in OpenShift from `inventory-inventory` to `kessel-inventory-api`.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

