### PR TITLE
Add MessageKey for Kafka

### DIFF
--- a/internal/eventing/kafka/manager.go
+++ b/internal/eventing/kafka/manager.go
@@ -136,7 +136,7 @@ func (p *kafkaProducer) Produce(ctx context.Context, event *api.Event) error {
 		return err
 	}
 
-	ret := p.Manager.Client.Send(cecontext.WithTopic(ctx, p.Topic), e)
+	ret := p.Manager.Client.Send(confluent.WithMessageKey(cecontext.WithTopic(ctx, p.Topic), p.Manager.Source), e)
 	if cloudevents.IsUndelivered(ret) {
 		p.Logger.Infof("Failed to send %v", ret)
 	} else {


### PR DESCRIPTION
### PR Template:

## Describe your changes

Add WithMessageKey to allow to set the key used when sending the producer message. otherwise, the following error throws `ERROR ts=2024-09-11T03:26:13Z caller=kafka/manager.go:57 service.name=inventory-api service.version=0.1.0 trace.id= span.id= group=server subsystem=eventing msg=Delivery failed: Broker: Broker failed to validate record`

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

