### PR TITLE
Fix probes port

### DIFF
--- a/deploy/kessel-inventory.yaml
+++ b/deploy/kessel-inventory.yaml
@@ -116,11 +116,11 @@ objects:
             livenessProbe:
               httpGet:
                 path: /api/inventory/v1/livez
-                port: 8081
+                port: 8000
             readinessProbe:
               httpGet:
                 path: /api/inventory/v1/readyz
-                port: 8081
+                port: 8000
             env:
               - name: INVENTORY_API_CONFIG
                 value: "/inventory-api-compose.yaml"


### PR DESCRIPTION
### PR Template:

## Describe your changes

The container listens to port `8000` when it's deployed by Clowder. As a consequence, health checks are currently failing in stage because of the ports mismatch between the template and Clowder. This PR will fix that.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

