### PR TITLE
adds serve command to ClowApp def

### DIFF
--- a/deploy/kessel-inventory.yaml
+++ b/deploy/kessel-inventory.yaml
@@ -113,6 +113,7 @@ objects:
         - name: api
           podSpec:
             image: ${INVENTORY_IMAGE}:${INVENTORY_IMAGE_TAG}
+            command: ["serve"]
             livenessProbe:
               httpGet:
                 path: /api/inventory/v1/livez


### PR DESCRIPTION
### PR Template:

## Describe your changes

Currently inventory-api is failing to run in stage, i suspect its because its missing a command flag. Since the [dockerfile](https://github.com/project-kessel/inventory-api/blob/ca4950abc1367fee3c5cd60d76f96846a97e8ab5/Dockerfile#L36) has an entry point of the root `inventory-api` command, its not getting the required serve command. This chance adds the serve command to get it running

Currently logs in stage just dump out the help screen you get when running just the root command

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

