### PR TITLE
RHCLOUD-35387 updates ports in server/health to align with clowdapp ports

### DIFF
--- a/deploy/kessel-inventory.yaml
+++ b/deploy/kessel-inventory.yaml
@@ -20,9 +20,9 @@ objects:
       inventory-api-config.yaml: |
         server:
           http:
-            address: 0.0.0.0:8081
+            address: 0.0.0.0:8000
           grpc:
-            address: 0.0.0.0:9081
+            address: 0.0.0.0:9000
         authn:
           psk:
             pre-shared-key-file: /psks/psks.yaml
@@ -141,11 +141,11 @@ objects:
             livenessProbe:
               httpGet:
                 path: /api/inventory/v1/livez
-                port: 8081
+                port: 8000
             readinessProbe:
               httpGet:
                 path: /api/inventory/v1/readyz
-                port: 8081
+                port: 8000
             env:
             - name: INVENTORY_API_CONFIG
               value: "/inventory/inventory-api-config.yaml"


### PR DESCRIPTION
### PR Template:

## Describe your changes

* updates the port configurations for inventory API to match the expected ports used for clowdapp web services
* this ensures the pod exposes the correct ports and makes the service reachable (currently it is not in stage)

Validation:
```shell
# from ephemeral
]$ oc port-forward svc/kessel-inventory-api 8000:8000
Forwarding from 127.0.0.1:8000 -> 8000
Forwarding from [::1]:8000 -> 8000
Handling connection for 8000
Handling connection for 8000

$ curl -s localhost:8000/api/inventory/v1/livez && echo ""
{"status":"OK","code":200}

$ curl -s localhost:8000/api/inventory/v1/readyz && echo ""
{"status":"Storage type postgres","code":200}
``` 

## Ticket reference (if applicable)
For RHCLOUD-35387

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

