### PR TITLE
RHCLOUD-35379 updates image tag variable to leverage app interface better

### DIFF
--- a/deploy/kessel-inventory.yaml
+++ b/deploy/kessel-inventory.yaml
@@ -53,11 +53,11 @@ objects:
           podSpec:
             initContainers:
             - name: migration
-              image: ${INVENTORY_IMAGE}:${INVENTORY_IMAGE_TAG}
+              image: ${INVENTORY_IMAGE}:${IMAGE_TAG}
               command: ["inventory-api"]
               args: ["migrate"]
               inheritEnv: true
-            image: ${INVENTORY_IMAGE}:${INVENTORY_IMAGE_TAG}
+            image: ${INVENTORY_IMAGE}:${IMAGE_TAG}
             command: ["inventory-api"]
             args: ["serve"]
             livenessProbe:
@@ -99,5 +99,5 @@ parameters:
     name: INVENTORY_IMAGE
     value: quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api
   - description: Image Tag
-    name: INVENTORY_IMAGE_TAG
-    value: latest
+    name: IMAGE_TAG
+    required: true


### PR DESCRIPTION
### PR Template:

## Describe your changes

* App interface, when using openshift templates, makes the `IMAGE_TAG` variable available in all deployments for setting the image tag. This value is generated from the short hash of the git commit which matches our image tags in Quay. This will ensure the desired commit is always running versus using `latest` which has security issues and may also not be latest with regards to code changes

See [DOCS](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/continuous-delivery-in-app-interface.md#automatically-generated-parameters)

