### PR TITLE
updates authz plus makefile updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 GOHOSTOS:=$(shell go env GOHOSTOS)
 GOPATH:=$(shell go env GOPATH)
+IMAGE ?="quay.io/cloudservices/kessel-inventory"
+IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+GIT_COMMIT=$(git rev-parse --short HEAD)
 
 ifeq ($(DOCKER),)
 DOCKER:=$(shell command -v podman || command -v docker)
@@ -57,6 +60,10 @@ api_breaking:
 # build
 build:
 	mkdir -p bin/ && go build -ldflags "-X cmd.Version=$(VERSION)" -o ./bin/ ./...
+
+.PHONY: docker-build-push
+docker-build-push:
+	./build_deploy.sh
 
 .PHONY: clean
 # removes all binaries

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ make init
 ## Build
 `make build`
 
+## Build Container Images
+By default the quay repository is `quay.io/cloudservices/kessel-inventory`. If you wish to use another for testing, set IMAGE value first
+```shell
+export IMAGE=your-quay-repo # if desired
+make docker-build-push
+```
+
 ## Run inventory api locally
 ### Run migration
 `make migrate`

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,6 +1,8 @@
 set -exv
 
-IMAGE="quay.io/cloudservices/kessel-inventory"
+if [[ -z "$IMAGE" ]]; then
+    IMAGE="quay.io/cloudservices/kessel-inventory"
+fi
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 GIT_COMMIT=$(git rev-parse --short HEAD)
 

--- a/deploy/kessel-inventory.yaml
+++ b/deploy/kessel-inventory.yaml
@@ -18,7 +18,11 @@ objects:
           psk:
             pre-shared-key-file: /psks/psks.yaml
         authz:
-          impl: allow-all
+          impl: kessel
+          kessel:
+            insecure-client: true
+            url: kessel-relations-api:9000
+            enable_oidc_auth: false
         eventing:
           eventer: stdout
           kafka:
@@ -101,3 +105,4 @@ parameters:
   - description: Image Tag
     name: IMAGE_TAG
     required: true
+    value: latest


### PR DESCRIPTION
### PR Template:

## Describe your changes

* updates the authz section of server config to use relations api
* adds make target for building the container images, updates script to support overriding IMAGE_TAG
* adds default value for IMAGE_TAG for local testing if needed
* updates README for make target addition

Validation Testing:
I deployed invenotry and relations API to ephemeral and can see inventory is properly setup for kessel in authz and some basically functionality is working.

```shell
$ curl http://localhost:8000/api/inventory/v1/readyz && echo ""
{"status":"STORAGE postgres and RELATIONS-API","code":200}

$ curl http://localhost:8000/api/inventory/v1/livez && echo ""
{"status":"OK","code":200}

$ oc logs kessel-inventory-api-7cc88cc554-bhf8f | grep relations | tail -n 1
Defaulted container "kessel-inventory-api" out of: kessel-inventory-api, crcauth, migration-init (init)
INFO ts=2024-09-30T15:02:14Z caller=health/health.go:49 service.name=inventory-api service.version=0.1.0 trace.id= span.id= group=server service.id=kessel-inventory-api-7cc88cc554-bhf8f msg=Storage type postgres and relations-api OK
```

Attempted to create a k8s-cluster using the sample data file since in the past it has worked but it fails complaining about a missing workspace value. Defined the workspace as "rbac" and i get an error from relations, likely due to things not being fully implemented but it would seem its talking to relations API as part of the flow now, the error appears to be coming from relations api.

```shell
curl --location 'localhost:8000/api/inventory/v1beta1/resources/k8s-clusters' \
--header 'Authorization: Bearer 1234' \
--header 'Content-Type: text/plain' \
--data '@/home/anatale/go/src/github.com/tonytheleg/inventory-api/data/k8s-cluster.json'

{
    "code": 400,
    "reason": "ERROR_REASON_UNKNOWN_DEFINITION",
    "message": "error creating tuples: error writing relationships to SpiceDB: rpc error: code = FailedPrecondition desc = object definition `acm/k8scluster` not found",
    "metadata": {
        "definition_name": "acm/k8scluster"
    }
}
```

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

