### PR TITLE
Allows reporter to share the same id for different resources

### DIFF
--- a/internal/biz/common/common.go
+++ b/internal/biz/common/common.go
@@ -33,7 +33,7 @@ type Metadata struct {
 
 type Reporter struct {
 	// This is necessary to satisfy gorm so the collection in the Resource model works.
-	MetadataID int64 `json:"-"`
+	MetadataID int64 `gorm:"primaryKey" json:"-"`
 
 	// ReporterID should be populated from the Identity of the caller.  e.g. if this is an ACM reporter, *which* ACM
 	// instance is it?


### PR DESCRIPTION
This is something i found while looking on the storage part of inventory

 A reporter might send different types of resources - if they
 are using an incremental id or if 2 different resources
 share an id, the reported data for the resource will only be stored once.

 With this commit, it ensures that we store the reporter once
 for each resource, thus each one having it's own reporting data
 and console/api hrefs

### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

