### PR TITLE
RHCLOUD-35475 - Add e2e tests to cover all the exposed endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,11 @@ bin/
 .docker
 
 inventory.db
+
+inventory-api.tar
+inventory-e2e-tests.tar
+
+multicluster-global-hub/
+scripts/kubeconfig-global-hub
+
+

--- a/test/e2e/inventory_http_test.go
+++ b/test/e2e/inventory_http_test.go
@@ -221,6 +221,44 @@ func TestInventoryAPIHTTP_K8SCluster_CreateK8SCluster(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestInventoryAPIHTTP_K8SPolicy_CreateK8SPolicy(t *testing.T) {
+	t.Parallel()
+	c := v1beta1.NewConfig(
+		v1beta1.WithHTTPUrl(inventoryapi_http_url),
+		v1beta1.WithTLSInsecure(insecure),
+		v1beta1.WithHTTPTLSConfig(tlsConfig),
+	)
+	client, err := v1beta1.NewHttpClient(context.Background(), c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	request := resources.CreateK8SPolicyRequest{
+		K8SPolicy: &resources.K8SPolicy{
+			Metadata: &resources.Metadata{
+				ResourceType: "k8s-policy",
+				Workspace:    "default",
+			},
+			ResourceData: &resources.K8SPolicyDetail{
+				Disabled: true,
+				Severity: resources.K8SPolicyDetail_MEDIUM,
+			},
+			ReporterData: &resources.ReporterData{
+				ReporterInstanceId: "user@example.com",
+				ReporterType:       resources.ReporterData_ACM,
+				ConsoleHref:        "www.example.com",
+				ApiHref:            "www.example.com",
+				LocalResourceId:    "1",
+				ReporterVersion:    "0.1",
+			},
+		},
+	}
+	opts := getCallOptions()
+	_, err = client.PolicyServiceClient.CreateK8SPolicy(context.Background(), &request, opts...)
+	assert.NoError(t, err)
+
+}
+
 func getCallOptions() []http.CallOption {
 	var opts []http.CallOption
 	header := nethttp.Header{}

--- a/test/e2e/inventory_http_test.go
+++ b/test/e2e/inventory_http_test.go
@@ -120,6 +120,23 @@ func TestInventoryAPIHTTP_Readyz(t *testing.T) {
 	assert.Equal(t, expectedCode, resp.Code)
 }
 
+func TestInventoryAPIHTTP_Metrics(t *testing.T) {
+	resp, err := nethttp.Get("http://localhost:8081/metrics")
+	if err != nil {
+		t.Fatal("Failed to send request: ", err)
+	}
+	defer resp.Body.Close()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+
+	expectedStatusCode := 200
+	expectedStatusString := "200 OK"
+
+	assert.Equal(t, expectedStatusCode, resp.StatusCode)
+	assert.Equal(t, expectedStatusString, resp.Status)
+}
+
 func TestInventoryAPIHTTP_CreateRHELHost(t *testing.T) {
 	t.Parallel()
 	c := v1beta1.NewConfig(

--- a/test/e2e/inventory_http_test.go
+++ b/test/e2e/inventory_http_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/transport/http"
+	v1 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1"
 	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1/resources"
 	"github.com/project-kessel/inventory-client-go/v1beta1"
 	"github.com/stretchr/testify/assert"
@@ -71,6 +72,52 @@ func TestMain(m *testing.M) {
 
 	result := m.Run()
 	os.Exit(result)
+}
+
+func TestInventoryAPIHTTP_Livez(t *testing.T) {
+	t.Parallel()
+	httpClient, err := http.NewClient(
+		context.Background(),
+		http.WithEndpoint(inventoryapi_http_url),
+	)
+	if err != nil {
+		t.Fatal("Failed to create HTTP client: ", err)
+	}
+
+	healthClient := v1.NewKesselInventoryHealthServiceHTTPClient(httpClient)
+	resp, err := healthClient.GetLivez(context.Background(), &v1.GetLivezRequest{})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+
+	expectedStatus := "OK"
+	expectedCode := uint32(200)
+
+	assert.Equal(t, expectedStatus, resp.Status)
+	assert.Equal(t, expectedCode, resp.Code)
+}
+
+func TestInventoryAPIHTTP_Readyz(t *testing.T) {
+	t.Parallel()
+	httpClient, err := http.NewClient(
+		context.Background(),
+		http.WithEndpoint(inventoryapi_http_url),
+	)
+	if err != nil {
+		t.Fatal("Failed to create HTTP client: ", err)
+	}
+
+	healthClient := v1.NewKesselInventoryHealthServiceHTTPClient(httpClient)
+	resp, err := healthClient.GetReadyz(context.Background(), &v1.GetReadyzRequest{})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+
+	expectedStatus := "Storage type sqlite"
+	expectedCode := uint32(200)
+
+	assert.Equal(t, expectedStatus, resp.Status)
+	assert.Equal(t, expectedCode, resp.Code)
 }
 
 func TestInventoryAPIHTTP_CreateRHELHost(t *testing.T) {


### PR DESCRIPTION
### PR Template:

## Describe your changes
- Add Remaining Test cases to e2e tests
	- [x] livez
	- [x] readyz
	- [x] metrics
	- [x] K8S-Policy

## Ticket reference (if applicable)
Fixes [#RHCLOUD-35475](https://issues.redhat.com/browse/RHCLOUD-35475)

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

