### PR TITLE
RHCLOUD-35503 updates defaults and adds config pkg

### DIFF
--- a/.inventory-api.yaml
+++ b/.inventory-api.yaml
@@ -1,9 +1,9 @@
 server:
-  public_url: http://localhost:8081
+  public_url: http://localhost:8000
   http:
-    address: localhost:8081
+    address: localhost:8000
   grpc:
-    address: localhost:9081
+    address: localhost:9000
 authn:
    allow-unauthenticated: true
 authz:

--- a/README.md
+++ b/README.md
@@ -188,5 +188,33 @@ authz:
     sa-client-secret: "<secret>"
     sso-token-endpoint: "http://localhost:8084/realms/redhat-external/protocol/openid-connect/token"
 ```
+
+## Running in Ephemeral Cluster with Relations API using Bonfire
+
+Deploy Relations API first with Bonfire following the steps available [HERE](https://cuddly-tribble-gq7r66v.pages.github.io/kessel/ephemeral/)
+
+Once its running, deploy Inventory using Bonfire:
+
+`bonfire deploy kessel -C inventory-api --no-get-dependencies`
+
+If you wish to test changes you've made that are unmerged, you can deploy them to ephemeral using a local config file
+Note: this requires building the image first and pushing to your local quay (see make docker-build-push)
+
+```yaml
+# example local config under $HOME/.config/bonfire/config
+apps:
+- name: kessel
+  components:
+    - name: inventory-api
+      host: local
+      repo: /path/to/inventory-api-repo
+      path: deploy/kessel-inventory.yaml
+      parameters:
+        INVENTORY_IMAGE: quay.io/your-repo/image-name
+        IMAGE_TAG: your-image-tag # latest is not recommended due to pull policy
+```
+
+Then run `bonfire deploy kessel -c $HOME/.config/bonfire/config.yaml --local-config-method override --no-get-dependencies`
+
 ## Debugging Inventory API using Vscode
 Follow the [DEBUG](./DEBUG.md) guide

--- a/cmd/.inventory-api.yaml
+++ b/cmd/.inventory-api.yaml
@@ -1,9 +1,9 @@
 server:
-  public_url: http://localhost:8081
+  public_url: http://localhost:8000
   http:
-    address: localhost:8081
+    address: localhost:8000
   grpc:
-    address: localhost:9081
+    address: localhost:9000
 authn:
    allow-unauthenticated: true
 authz:

--- a/deploy/kessel-inventory.yaml
+++ b/deploy/kessel-inventory.yaml
@@ -9,27 +9,15 @@ objects:
       name: inventory-api-config
     data:
       inventory-api-config.yaml: |
-        server:
-          http:
-            address: 0.0.0.0:8000
-          grpc:
-            address: 0.0.0.0:9000
         authn:
           psk:
             pre-shared-key-file: /psks/psks.yaml
         authz:
-          impl: kessel
           kessel:
             insecure-client: true
-            url: kessel-relations-api:9000
-            enable_oidc_auth: false
-        eventing:
-          eventer: stdout
-          kafka:
-        storage:
-          database: postgres
-          sqlite3:
-            dsn: inventory.db
+            enable-oidc-auth: false
+        log:
+          level: "info"
 
   - apiVersion: v1
     kind: ConfigMap
@@ -51,6 +39,8 @@ objects:
       envName: ${ENV_NAME}
       database:
         name: kessel-inventory
+      optionalDependencies:
+        - kessel-relations
       deployments:
         - name: api
           replicas: 1

--- a/internal/authz/kessel/options.go
+++ b/internal/authz/kessel/options.go
@@ -17,7 +17,10 @@ type Options struct {
 }
 
 func NewOptions() *Options {
-	return &Options{}
+	return &Options{
+		Insecure:       false,
+		EnableOidcAuth: true,
+	}
 }
 
 func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {

--- a/internal/authz/options.go
+++ b/internal/authz/options.go
@@ -15,8 +15,9 @@ type Options struct {
 }
 
 const (
-	AllowAll = "allow-all"
-	Kessel   = "kessel"
+	AllowAll     = "allow-all"
+	Kessel       = "kessel"
+	RelationsAPI = "kessel-relations"
 )
 
 func NewOptions() *Options {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"fmt"
+	"github.com/go-kratos/kratos/v2/log"
+	"github.com/project-kessel/inventory-api/internal/authn"
+	"github.com/project-kessel/inventory-api/internal/authz"
+	"github.com/project-kessel/inventory-api/internal/eventing"
+	"github.com/project-kessel/inventory-api/internal/server"
+	"github.com/project-kessel/inventory-api/internal/storage"
+	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
+	"strconv"
+)
+
+// OptionsConfig contains the settings for each configuration option
+type OptionsConfig struct {
+	Authn    *authn.Options
+	Authz    *authz.Options
+	Storage  *storage.Options
+	Eventing *eventing.Options
+	Server   *server.Options
+}
+
+// NewOptionsConfig returns a new OptionsConfig with default options set
+func NewOptionsConfig() *OptionsConfig {
+	return &OptionsConfig{
+		authn.NewOptions(),
+		authz.NewOptions(),
+		storage.NewOptions(),
+		eventing.NewOptions(),
+		server.NewOptions(),
+	}
+}
+
+// LogConfigurationInfo outputs connection details to logs when in debug for testing (no secret data is output)
+func LogConfigurationInfo(options *OptionsConfig) {
+	log.Debugf("Server Configuration: Public URL: %s, HTTP Listener: %s, GRPC Listener: %s",
+		options.Server.PublicUrl,
+		options.Server.HttpOptions.Addr,
+		options.Server.GrpcOptions.Addr)
+
+	if options.Authn.Oidc.AuthorizationServerURL != "" {
+		log.Debugf("Authn Configuration: URL: %s, ClientID: %s",
+			options.Authn.Oidc.AuthorizationServerURL,
+			options.Authn.Oidc.ClientId,
+		)
+	}
+
+	if options.Storage.Database == storage.Postgres {
+		log.Debugf("Storage Configuration: Host: %s, DB: %s, Port: %s",
+			options.Storage.Postgres.Host,
+			options.Storage.Postgres.DbName,
+			options.Storage.Postgres.Port,
+		)
+	}
+
+	if options.Authz.Authz == authz.Kessel {
+		log.Debugf("Authz Configuration: URL: %s, Insecure?: %t, OIDC?: %t",
+			options.Authz.Kessel.URL,
+			options.Authz.Kessel.Insecure,
+			options.Authz.Kessel.EnableOidcAuth,
+		)
+	}
+}
+
+// InjectClowdAppConfig updates service options based on values in the ClowdApp AppConfig
+func (o *OptionsConfig) InjectClowdAppConfig() {
+	// check for authz config
+	for _, endpoint := range clowder.LoadedConfig.Endpoints {
+		if endpoint.App == authz.RelationsAPI {
+			o.ConfigureAuthz(endpoint)
+		}
+	}
+	// check for db config
+	if clowder.LoadedConfig.Database != nil {
+		o.ConfigureStorage(clowder.LoadedConfig.Database)
+	}
+}
+
+// ConfigureAuthz updates Authz settings based on ClowdApp AppConfig
+func (o *OptionsConfig) ConfigureAuthz(endpoint clowder.DependencyEndpoint) {
+	o.Authz.Authz = authz.Kessel
+	o.Authz.Kessel.URL = fmt.Sprintf("%s:%d", endpoint.Hostname, 9000)
+}
+
+// ConfigureStorage updates Storage settings based on ClowdApp AppConfig
+func (o *OptionsConfig) ConfigureStorage(database *clowder.DatabaseConfig) {
+	o.Storage.Database = storage.Postgres
+	o.Storage.Postgres.Host = database.Hostname
+	o.Storage.Postgres.Port = strconv.Itoa(database.Port)
+	o.Storage.Postgres.User = database.Username
+	o.Storage.Postgres.Password = database.Password
+	o.Storage.Postgres.DbName = database.Name
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestConfigureStorage(t *testing.T) {
+	tests := []struct {
+		name      string
+		appconfig *clowder.AppConfig
+		options   *OptionsConfig
+	}{
+		{
+			name: "ensures DB info is set",
+			appconfig: &clowder.AppConfig{
+				Database: &clowder.DatabaseConfig{
+					Hostname: "postgres",
+					Name:     "postgres",
+					Port:     5432,
+					Username: "db-user",
+					Password: "db-password",
+				},
+			},
+			options: NewOptionsConfig(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.options.ConfigureStorage(test.appconfig.Database)
+			assert.Equal(t, "postgres", test.options.Storage.Database)
+			assert.Equal(t, "postgres", test.options.Storage.Postgres.Host)
+			assert.Equal(t, "postgres", test.options.Storage.Postgres.DbName)
+			assert.Equal(t, "5432", test.options.Storage.Postgres.Port)
+			assert.Equal(t, "db-user", test.options.Storage.Postgres.User)
+			assert.Equal(t, "db-password", test.options.Storage.Postgres.Password)
+		})
+	}
+}
+
+func TestConfigureAuthz(t *testing.T) {
+	tests := []struct {
+		name      string
+		appconfig *clowder.AppConfig
+		options   *OptionsConfig
+	}{
+		{
+			name: "ensures Authz info is set",
+			appconfig: &clowder.AppConfig{
+				Endpoints: []clowder.DependencyEndpoint{
+					clowder.DependencyEndpoint{
+						Hostname: "kessel-relations",
+					},
+				},
+			},
+			options: NewOptionsConfig(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.options.ConfigureAuthz(test.appconfig.Endpoints[0])
+			assert.Equal(t, "kessel", test.options.Authz.Authz)
+			assert.Equal(t, "kessel-relations:9000", test.options.Authz.Kessel.URL)
+		})
+	}
+}

--- a/internal/server/grpc/options.go
+++ b/internal/server/grpc/options.go
@@ -20,7 +20,7 @@ type Options struct {
 
 func NewOptions() *Options {
 	return &Options{
-		Addr:    "localhost:9080",
+		Addr:    "0.0.0.0:9000",
 		Timeout: 300,
 		CertOpt: 3, // https://pkg.go.dev/crypto/tls#ClientAuthType
 	}

--- a/internal/server/http/http_test.go
+++ b/internal/server/http/http_test.go
@@ -11,7 +11,7 @@ func TestNewOptions(t *testing.T) {
 		opts := NewOptions()
 
 		expectedOpts := &Options{
-			Addr:    "localhost:8080",
+			Addr:    "0.0.0.0:8000",
 			Timeout: 300,
 			CertOpt: 3,
 		}

--- a/internal/server/http/options.go
+++ b/internal/server/http/options.go
@@ -20,7 +20,7 @@ type Options struct {
 
 func NewOptions() *Options {
 	return &Options{
-		Addr:    "localhost:8080",
+		Addr:    "0.0.0.0:8000",
 		Timeout: 300,
 		CertOpt: 3, // https://pkg.go.dev/crypto/tls#ClientAuthType
 	}

--- a/internal/server/options.go
+++ b/internal/server/options.go
@@ -22,8 +22,8 @@ func NewOptions() *Options {
 	id, _ := os.Hostname()
 	return &Options{
 		Id:        id,
-		Name:      "kessel-asset-inventory",
-		PublicUrl: "http://localhost:8081",
+		Name:      "kessel-inventory-api",
+		PublicUrl: "http://localhost:8000",
 
 		GrpcOptions: grpc.NewOptions(),
 		HttpOptions: http.NewOptions(),

--- a/internal/storage/options.go
+++ b/internal/storage/options.go
@@ -14,6 +14,11 @@ type Options struct {
 	Database string            `mapstructure:"database"`
 }
 
+const (
+	Postgres = "postgres"
+	Sqlite3  = "sqlite3"
+)
+
 func NewOptions() *Options {
 	return &Options{
 		Postgres: postgres.NewOptions(),

--- a/inventory-api-compose.yaml
+++ b/inventory-api-compose.yaml
@@ -11,7 +11,7 @@ authz:
   kessel:
     insecure-client: true
     url: relations-api:9000
-    enable_oidc_auth: false
+    enable-oidc-auth: false
 eventing:
   eventer: stdout
   kafka:
@@ -26,7 +26,7 @@ storage:
     password: "yPsw5e6ab4bvAGe5H"
     dbname: "spicedb"
 log:
-  level: "info"
+  level: "debug"
   livez: true
   readyz: true
 


### PR DESCRIPTION
### PR Template:

## Describe your changes

* Adds config pkg that will:
  * update config options based on values in ClowdApp Appconfig (when enabled)
  * provides debug output of configuration settings for testing
* updates some of the defaults defined in `NewOptions` calls to production like settings, reducing the number of settings that need explicit defining in config files or startup commands
* updates deployment manifest
  * removes any settings from configmap that are default or are expected to be captured by Clowder
  * adds `optionalDependency` of relations-api to capture config data
* updates server address in some default config files
* fixes typo with `enable-oidc-auth` setting as it was invalid
* updates README for how to deploy via ephemeral

Note: I also tested local deployment methods (docker compose, make run) and these changes did not seem to impact any of it
This has also been tested in ephemeral

### Validation:
```shell
$ oc get pods | grep kessel
kessel-inventory-api-5d5b8f6c7-9tf4g                             2/2     Running   0             8m12s
kessel-inventory-db-85c7b796f9-nr5wh                             1/1     Running   0             8m12s
kessel-relations-api-686c994969-xzwhf                            2/2     Running   0             16m

$ oc logs kessel-inventory-api-5d5b8f6c7-9tf4g
Defaulted container "kessel-inventory-api" out of: kessel-inventory-api, crcauth, migration-init (init)
INFO msg=Using config file: /inventory/inventory-api-config.yaml
Log Level is set to: debug
DEBUG msg=Server Configuration: Public URL: http://localhost:8000, HTTP Listener: 0.0.0.0:8000, GRPC Listener: 0.0.0.0:9000
DEBUG msg=Storage Configuration: Host: kessel-inventory-db.ephemeral-uezpid.svc, DB: kessel-inventory, Port: 5432
DEBUG msg=Authz Configuration: URL: kessel-relations-api.ephemeral-uezpid.svc:9000, Insecure?: true, OIDC?: false
INFO msg=Using config file: /inventory/inventory-api-config.yaml
INFO ts=2024-10-02T17:48:40Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= subsystem=storage msg=Using backing storage: postgres
INFO ts=2024-10-02T17:48:40Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= subsystem=authn msg=Will check for client certs
INFO ts=2024-10-02T17:48:40Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= subsystem=authn msg=Loading pre-shared-keys from /psks/psks.yaml
INFO ts=2024-10-02T17:48:40Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= subsystem=authz msg=Using authorizer: kessel
INFO ts=2024-10-02T17:48:40Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= subsystem=eventing msg=Using eventing: stdout
INFO ts=2024-10-02T17:48:40Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= service.id=kessel-inventory-api-5d5b8f6c7-9tf4g msg=[HTTP] server listening on: [::]:8000
INFO ts=2024-10-02T17:48:40Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= service.id=kessel-inventory-api-5d5b8f6c7-9tf4g msg=[gRPC] server listening on: [::]:9000
INFO ts=2024-10-02T17:48:41Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= service.id=kessel-inventory-api-5d5b8f6c7-9tf4g msg=Readyz logs disabled
INFO ts=2024-10-02T17:48:41Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= service.id=kessel-inventory-api-5d5b8f6c7-9tf4g msg=Livez logs disabled

$ curl 127.0.0.1:8000/api/inventory/v1/readyz && echo ""
{"status":"STORAGE postgres and RELATIONS-API", "code":200}
```

Some Notes:
* based on testing, the order of precedence is 
  Config File --> CLI flags/explicit option setting (what the ClowderInjection code does) --> Default options
* Settings defined in any of these fashions that are non-duplicative are merged together; any settings overlap, the precedence takes place

Example:
`authz.kessel.insecure-client` is set by default as false in default options
`authz.kessel.insecure-client` is set to true in the inventory configmap in deployment yaml
The insecure setting from the config overrides the default flag or any explicit option settings
This means anything we wish to override can be set at config file without code changes and it will take precedence

## Ticket reference (if applicable)
For RHCLOUD-35503

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

