### PR TITLE
adds logging to middleware

### DIFF
--- a/internal/server/grpc/grpc.go
+++ b/internal/server/grpc/grpc.go
@@ -3,17 +3,19 @@ package grpc
 import (
 	"github.com/bufbuild/protovalidate-go"
 	"github.com/go-kratos/kratos/v2/middleware"
+	"github.com/go-kratos/kratos/v2/middleware/logging"
 	"github.com/go-kratos/kratos/v2/middleware/recovery"
 	"github.com/go-kratos/kratos/v2/middleware/selector"
 	kgrpc "github.com/go-kratos/kratos/v2/transport/grpc"
 	m "github.com/project-kessel/inventory-api/internal/middleware"
 
+	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/middleware/metrics"
 	"go.opentelemetry.io/otel/metric"
 )
 
 // New creates a new a gRPC server.
-func New(c CompletedConfig, authn middleware.Middleware, meter metric.Meter) (*kgrpc.Server, error) {
+func New(c CompletedConfig, authn middleware.Middleware, meter metric.Meter, logger log.Logger) (*kgrpc.Server, error) {
 	requests, err := metrics.DefaultRequestsCounter(meter, metrics.DefaultServerRequestsCounterName)
 	if err != nil {
 		return nil, err
@@ -30,6 +32,7 @@ func New(c CompletedConfig, authn middleware.Middleware, meter metric.Meter) (*k
 	var opts = []kgrpc.ServerOption{
 		kgrpc.Middleware(
 			recovery.Recovery(),
+			logging.Server(logger),
 			m.Validation(validator),
 			metrics.Server(
 				metrics.WithRequests(requests),

--- a/internal/server/http/http.go
+++ b/internal/server/http/http.go
@@ -2,7 +2,9 @@ package http
 
 import (
 	"github.com/bufbuild/protovalidate-go"
+	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/middleware"
+	"github.com/go-kratos/kratos/v2/middleware/logging"
 	"github.com/go-kratos/kratos/v2/middleware/metrics"
 	"github.com/go-kratos/kratos/v2/middleware/recovery"
 	"github.com/go-kratos/kratos/v2/middleware/selector"
@@ -14,7 +16,7 @@ import (
 )
 
 // New create a new http server.
-func New(c CompletedConfig, authn middleware.Middleware, meter metric.Meter) (*http.Server, error) {
+func New(c CompletedConfig, authn middleware.Middleware, meter metric.Meter, logger log.Logger) (*http.Server, error) {
 	requests, err := metrics.DefaultRequestsCounter(meter, metrics.DefaultServerRequestsCounterName)
 	if err != nil {
 		return nil, err
@@ -31,6 +33,7 @@ func New(c CompletedConfig, authn middleware.Middleware, meter metric.Meter) (*h
 	var opts = []http.ServerOption{
 		http.Middleware(
 			recovery.Recovery(),
+			logging.Server(logger),
 			m.Validation(validator),
 			metrics.Server(
 				metrics.WithSeconds(seconds),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -41,12 +41,12 @@ func New(c CompletedConfig, authn middleware.Middleware, logger log.Logger) (*Se
 		return nil, err
 	}
 
-	httpServer, err := http.New(c.HttpConfig, authn, meter)
+	httpServer, err := http.New(c.HttpConfig, authn, meter, logger)
 	if err != nil {
 		return nil, err
 	}
 
-	grpcServer, err := grpc.New(c.GrpcConfig, authn, meter)
+	grpcServer, err := grpc.New(c.GrpcConfig, authn, meter, logger)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### PR Template:

## Describe your changes

While working through and testing issues with authn, i noticed that logs do not print anything about request or failed requests which would be beneficial for troubleshooting issues where requests are failing and the call is not originating from ourselves

These changes pass the logger created with the server to middleware for logging this info. We should look to start passing this logger around too with other logic for debugging

More details: https://go-kratos.dev/en/docs/component/middleware/logging

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

