### PR TITLE
Load configuration after cobra initialization

### DIFF
--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -1,0 +1,55 @@
+package common
+
+import (
+	"fmt"
+	"github.com/go-kratos/kratos/v2/log"
+	"github.com/go-kratos/kratos/v2/middleware/tracing"
+	"github.com/spf13/viper"
+	"os"
+	"strings"
+)
+
+type LoggerOptions struct {
+	ServiceName    string
+	ServiceVersion string
+}
+
+func GetLogLevel() string {
+	logLevel := viper.GetString("log.level")
+	fmt.Printf("Log Level is set to: %s\n", logLevel)
+	return logLevel
+}
+
+// InitLogger initializes the logger based on the provided log level
+func InitLogger(logLevel string, options LoggerOptions) (*log.Helper, log.Logger) {
+	// Convert logLevel string to log.Level type
+	var level log.Level
+	switch strings.ToLower(logLevel) {
+	case "debug":
+		level = log.LevelDebug
+	case "info":
+		level = log.LevelInfo
+	case "warn":
+		level = log.LevelWarn
+	case "error":
+		level = log.LevelError
+	case "fatal":
+		level = log.LevelFatal
+	default:
+		fmt.Printf("Invalid log level '%s' provided. Defaulting to 'info' level.\n", logLevel)
+		level = log.LevelInfo
+	}
+
+	rootLogger := log.With(log.NewStdLogger(os.Stdout),
+		"ts", log.DefaultTimestamp,
+		"caller", log.DefaultCaller,
+		"service.name", options.ServiceName,
+		"service.version", options.ServiceVersion,
+		"trace.id", tracing.TraceID(),
+		"span.id", tracing.SpanID(),
+	)
+	filteredLogger := log.NewFilter(rootLogger, log.FilterLevel(level))
+	helperLogger := log.NewHelper(filteredLogger)
+
+	return helperLogger, filteredLogger
+}

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -2,6 +2,7 @@ package migrate
 
 import (
 	"github.com/go-kratos/kratos/v2/log"
+	"github.com/project-kessel/inventory-api/cmd/common"
 	"github.com/spf13/cobra"
 
 	"github.com/project-kessel/inventory-api/internal/data"
@@ -9,11 +10,13 @@ import (
 	"github.com/project-kessel/inventory-api/internal/storage"
 )
 
-func NewCommand(options *storage.Options, logger log.Logger) *cobra.Command {
+func NewCommand(options *storage.Options, loggerOptions common.LoggerOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "migrate",
 		Short: "Create or migrate the database tables",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			_, logger := common.InitLogger(common.GetLogLevel(), loggerOptions)
+
 			if errs := options.Complete(); errs != nil {
 				return errors.NewAggregate(errs)
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,19 +2,16 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/go-kratos/kratos/v2/log"
+	"github.com/project-kessel/inventory-api/cmd/common"
+	"github.com/project-kessel/inventory-api/cmd/migrate"
+	"github.com/project-kessel/inventory-api/cmd/serve"
 	"github.com/project-kessel/inventory-api/internal/config"
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"os"
 	"path/filepath"
-	"strings"
-
-	"github.com/go-kratos/kratos/v2/log"
-	"github.com/go-kratos/kratos/v2/middleware/tracing"
-
-	"github.com/project-kessel/inventory-api/cmd/migrate"
-	"github.com/project-kessel/inventory-api/cmd/serve"
 )
 
 // go build -ldflags "-X cmd.Version=x.y.z"
@@ -45,10 +42,24 @@ func Execute() {
 	}
 }
 
+func Initialize() {
+	initConfig()
+
+	// for troubleshoot, when set to debug, configuration info is logged in more detail to stdout
+	logLevel := common.GetLogLevel()
+	logger, baseLogger = common.InitLogger(logLevel, common.LoggerOptions{
+		ServiceName:    Name,
+		ServiceVersion: Version,
+	})
+	if logLevel == "debug" {
+		config.LogConfigurationInfo(options)
+	}
+}
+
 // init adds all child commands to the root command and sets flags appropriately.
 func init() {
 	// initializers are run as part of Command.PreRun
-	cobra.OnInitialize(initConfig)
+	cobra.OnInitialize(Initialize)
 
 	configHelp := fmt.Sprintf("config file (default is $PWD/.%s.yaml)", Name)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", configHelp)
@@ -66,28 +77,22 @@ func init() {
 		panic(err)
 	}
 
-	// TODO: Find a cleaner approach than explicitly calling initConfig
-	// Here we are calling the initConfig to ensure that the log level can be pulled from the inventory configuration file
-	initConfig()
-	logLevel := getLogLevel()
-	logger, baseLogger = initLogger(logLevel)
-
 	if clowder.IsClowderEnabled() {
 		options.InjectClowdAppConfig()
 	}
 
-	// for troubleshoot, when set to debug, configuration info is logged in more detail to stdout
-	if logLevel == "debug" {
-		config.LogConfigurationInfo(options)
+	loggerOptions := common.LoggerOptions{
+		ServiceName:    Name,
+		ServiceVersion: Version,
 	}
 
-	migrateCmd := migrate.NewCommand(options.Storage, baseLogger)
+	migrateCmd := migrate.NewCommand(options.Storage, loggerOptions)
 	rootCmd.AddCommand(migrateCmd)
 	err = viper.BindPFlags(migrateCmd.Flags())
 	if err != nil {
 		panic(err)
 	}
-	serveCmd := serve.NewCommand(options.Server, options.Storage, options.Authn, options.Authz, options.Eventing, baseLogger)
+	serveCmd := serve.NewCommand(options.Server, options.Storage, options.Authn, options.Authz, options.Eventing, loggerOptions)
 	rootCmd.AddCommand(serveCmd)
 	err = viper.BindPFlags(serveCmd.Flags())
 	if err != nil {
@@ -135,45 +140,4 @@ func initConfig() {
 	if err := viper.Unmarshal(&options); err != nil {
 		panic(err)
 	}
-}
-
-func getLogLevel() string {
-
-	logLevel := viper.GetString("log.level")
-	fmt.Printf("Log Level is set to: %s\n", logLevel)
-	return logLevel
-}
-
-// initLogger initializes the logger based on the provided log level
-func initLogger(logLevel string) (*log.Helper, log.Logger) {
-	// Convert logLevel string to log.Level type
-	var level log.Level
-	switch strings.ToLower(logLevel) {
-	case "debug":
-		level = log.LevelDebug
-	case "info":
-		level = log.LevelInfo
-	case "warn":
-		level = log.LevelWarn
-	case "error":
-		level = log.LevelError
-	case "fatal":
-		level = log.LevelFatal
-	default:
-		fmt.Printf("Invalid log level '%s' provided. Defaulting to 'info' level.\n", logLevel)
-		level = log.LevelInfo
-	}
-
-	rootLogger := log.With(log.NewStdLogger(os.Stdout),
-		"ts", log.DefaultTimestamp,
-		"caller", log.DefaultCaller,
-		"service.name", Name,
-		"service.version", Version,
-		"trace.id", tracing.TraceID(),
-		"span.id", tracing.SpanID(),
-	)
-	filteredLogger := log.NewFilter(rootLogger, log.FilterLevel(level))
-	helperLogger := log.NewHelper(filteredLogger)
-
-	return helperLogger, filteredLogger
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,8 +22,6 @@ var (
 
 	logger *log.Helper
 
-	baseLogger log.Logger
-
 	rootCmd = &cobra.Command{
 		Use:     Name,
 		Version: Version,
@@ -47,7 +45,7 @@ func Initialize() {
 
 	// for troubleshoot, when set to debug, configuration info is logged in more detail to stdout
 	logLevel := common.GetLogLevel()
-	logger, baseLogger = common.InitLogger(logLevel, common.LoggerOptions{
+	logger, _ = common.InitLogger(logLevel, common.LoggerOptions{
 		ServiceName:    Name,
 		ServiceVersion: Version,
 	})

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -3,6 +3,7 @@ package serve
 import (
 	"context"
 	"fmt"
+	"github.com/project-kessel/inventory-api/cmd/common"
 	relationshipsctl "github.com/project-kessel/inventory-api/internal/biz/relationships"
 	resourcesctl "github.com/project-kessel/inventory-api/internal/biz/resources"
 	relationshipsrepo "github.com/project-kessel/inventory-api/internal/data/relationships"
@@ -45,12 +46,13 @@ func NewCommand(
 	authnOptions *authn.Options,
 	authzOptions *authz.Options,
 	eventingOptions *eventing.Options,
-	logger log.Logger,
+	loggerOptions common.LoggerOptions,
 ) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Start the inventory server",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			_, logger := common.InitLogger(common.GetLogLevel(), loggerOptions)
 			ctx := context.Background()
 
 			// configure storage


### PR DESCRIPTION
 - Moves logging logic a bit
 - Ensures command line --config is used correctly

### PR Template:

## Describe your changes

 Moved the logger logic a bit to ensure we are using the right values.
- If we were to set the config using the flag `--config`, the logger would end up using the default config file instead of the specified file (as this input is set after initialization)


## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

