### PR TITLE
RHCLOUD-35835: improves error messages for base commands

### DIFF
--- a/internal/authn/authn.go
+++ b/internal/authn/authn.go
@@ -1,6 +1,7 @@
 package authn
 
 import (
+	"fmt"
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/project-kessel/inventory-api/internal/authn/api"
 	"github.com/project-kessel/inventory-api/internal/authn/clientcert"
@@ -31,7 +32,7 @@ func New(config CompletedConfig, logger *log.Helper) (api.Authenticator, error) 
 		if a, err := oidc.New(*config.Oidc); err == nil {
 			d.Add(a)
 		} else {
-			return nil, err
+			return nil, fmt.Errorf("failed to load OIDC info: %v", err)
 		}
 	}
 

--- a/internal/authn/oidc/oidc.go
+++ b/internal/authn/oidc/oidc.go
@@ -25,7 +25,7 @@ func New(c CompletedConfig) (*OAuth2Authenticator, error) {
 	ctx := coreosoidc.ClientContext(context.Background(), c.Client)
 	provider, err := coreosoidc.NewProvider(ctx, c.AuthorizationServerURL)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create provider: %v", err)
 	}
 
 	if c.PrincipalUserDomain == "" {

--- a/internal/data/migrate.go
+++ b/internal/data/migrate.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"fmt"
+
 	"github.com/project-kessel/inventory-api/internal/biz/model"
 	"gorm.io/gorm"
 
@@ -19,7 +21,7 @@ func Migrate(db *gorm.DB, logger *log.Helper) error {
 	}
 
 	if err := db.AutoMigrate(models...); err != nil {
-		return err
+		return fmt.Errorf("auto migration has failed: %v", err)
 	}
 
 	for _, m := range models {
@@ -27,12 +29,12 @@ func Migrate(db *gorm.DB, logger *log.Helper) error {
 			statement := &gorm.Statement{DB: db}
 			err := statement.Parse(m)
 			if err != nil {
-				return err
+				return fmt.Errorf("statement parsing has failed: %v", err)
 			}
 
 			err = gormDbIndexStatement.GormDbAfterMigration(db, statement.Schema)
 			if err != nil {
-				return err
+				return fmt.Errorf("migration failure: %v", err)
 			}
 		}
 	}

--- a/internal/eventing/factory.go
+++ b/internal/eventing/factory.go
@@ -17,7 +17,7 @@ func New(c CompletedConfig, source string, logger *log.Helper) (api.Manager, err
 	case "kafka":
 		km, err := kafka.New(c.Kafka, source, logger)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to create kafka manager: %w", err)
 		}
 		return km, nil
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-kratos/kratos/v2"
 	"github.com/go-kratos/kratos/v2/log"
@@ -33,22 +34,22 @@ func New(c CompletedConfig, authn middleware.Middleware, logger log.Logger) (*Se
 
 	meterProvider, err := NewMeterProvider(s)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init meter provider failed: %v", err)
 	}
 
 	meter, err := NewMeter(meterProvider)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init meter failed: %v", err)
 	}
 
 	httpServer, err := http.New(c.HttpConfig, authn, meter, logger)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init http server failed: %v", err)
 	}
 
 	grpcServer, err := grpc.New(c.GrpcConfig, authn, meter, logger)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init grpc server failed: %v", err)
 	}
 
 	s.HttpServer = httpServer


### PR DESCRIPTION
### PR Template:

## Describe your changes

Improves error messages returned during server/migrate commands to help improve logs

IIUC, all errors returned from a `x.NewCommand` call are properly logged by the root command [HERE](https://github.com/project-kessel/inventory-api/blob/93766cf49a686c580c302d48fed2916e1746de35/cmd/root.go#L38).  
This should at least improve some of the errors seen on start up and should help in narrowing down what failed when an error occurs

## Ticket reference (if applicable)
For RHCLOUD-35835

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

