### PR TITLE
Add make target for cross arch image build/push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ build:
 docker-build-push:
 	./build_deploy.sh
 
+.PHONY: build-push-minimal
+build-push-minimal:
+	./build_push_minimal.sh
+
 .PHONY: clean
 # removes all binaries
 clean:

--- a/README.md
+++ b/README.md
@@ -218,6 +218,14 @@ export IMAGE=your-quay-repo # if desired
 make docker-build-push
 ```
 
+### Build Container Images (macOS)
+This is an alternative to the above command for macOS users, but should work for any arch
+```shell
+export QUAY_REPO_INVENTORY=your-quay-repo # required
+podman login quay.io # required, this target assumes you are already logged in
+make build-push-minimal
+```
+
 ## Example Usage
 
 All these examples use the  REST API and assume we are running the default local version

--- a/build_push_minimal.sh
+++ b/build_push_minimal.sh
@@ -1,0 +1,16 @@
+# Publish inventory images to your personal quay.io repository
+# Compatible with MacOS and other archs for cross-compilation
+# Excludes redhat.registry.io as this is not needed for local/ephem development
+set -exv
+
+if [[ -z "$QUAY_REPO_INVENTORY" ]]; then
+    # required since this script is not used in the CI pipeline, publishing should
+    # only happen from a developer's local machine to their personal repo
+    echo "QUAY_REPO_INVENTORY must be set"
+    exit 1
+fi
+IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+
+source ./scripts/check_docker_podman.sh
+${DOCKER} build --platform linux/amd64 --build-arg TARGETARCH=amd64 -t "${QUAY_REPO_INVENTORY}:${IMAGE_TAG}" -f ./Dockerfile
+${DOCKER} push "${QUAY_REPO_INVENTORY}:${IMAGE_TAG}"


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Adds new make target and script for minimal image build-push operation
  - Intended for local/ephem dev use only without all of the prod-like necessities
  - Supports cross-arch builds (macOS)
  - No dependency on registry.redhat.io
- Updated README

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

