### PR TITLE
adds db-cleaner deploy files for db operation needs

### DIFF
--- a/deploy/kessel-inventory-db-operations.yaml
+++ b/deploy/kessel-inventory-db-operations.yaml
@@ -1,0 +1,91 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: inventory
+objects:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdApp
+    metadata:
+      name: kessel-inventory
+    spec:
+      envName: ${ENV_NAME}
+      database:
+        name: kessel-inventory
+      optionalDependencies:
+        - kessel-relations
+      deployments:
+        - name: api
+          replicas: ${{REPLICAS}}
+          podSpec:
+            initContainers:
+            - name: db-operations
+              image: registry.redhat.io/rhel9/postgresql-15:1-54
+              command: ["/bin/sh", "-c"]
+              args:
+                - cd /tmp && curl -OL https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64 && mv jq-linux-amd64 jq && chmod +x jq;
+                  export PGHOST=$(cat /cdapp/cdappconfig.json | ./jq -r '.database.hostname');
+                  export PGPORT=$(cat /cdapp/cdappconfig.json | ./jq -r '.database.port');
+                  export PGUSER=$(cat /cdapp/cdappconfig.json | ./jq -r '.database.username');
+                  export PGDATABASE=$(cat /cdapp/cdappconfig.json | ./jq -r '.database.name');
+                  export PGPASSWORD=$(cat /cdapp/cdappconfig.json | ./jq -r '.database.password');
+                  for i in local_inventory_to_resources relationship_history relationships resource_history resources;
+                  do psql -c "DROP TABLE $i";
+                  done;
+              inheritEnv: true
+            - name: migration
+              image: ${INVENTORY_IMAGE}:${IMAGE_TAG}
+              command: ["inventory-api"]
+              args: ["migrate"]
+              inheritEnv: true
+            image: ${INVENTORY_IMAGE}:${IMAGE_TAG}
+            command: ["inventory-api"]
+            args: ["serve"]
+            livenessProbe:
+              httpGet:
+                path: /api/inventory/v1/livez
+                port: 8000
+            readinessProbe:
+              httpGet:
+                path: /api/inventory/v1/readyz
+                port: 8000
+            env:
+            - name: CLOWDER_ENABLED
+              value: "true"
+            - name: INVENTORY_API_CONFIG
+              value: "/inventory/inventory-api-config.yaml"
+            - name: PGDATA
+              value: /temp/data
+            volumeMounts:
+                - name: config-volume
+                  mountPath: "/inventory"
+            volumes:
+              - name: config-volume
+                secret:
+                  secretName: inventory-api-config
+          webServices:
+            public:
+              enabled: true
+              apiPath: inventory
+  - kind: PodDisruptionBudget
+    apiVersion: policy/v1
+    metadata:
+      name: kessel-inventory-api-pdb
+    spec:
+      minAvailable: 1
+      selector:
+        matchLabels:
+          app: kessel-inventory
+parameters:
+  - description: ClowdEnvironment name (ephemeral, stage, prod)
+    name: ENV_NAME
+    required: true
+  - description: App Image
+    name: INVENTORY_IMAGE
+    value: quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api
+  - description: Image Tag
+    name: IMAGE_TAG
+    required: true
+    value: latest
+  - description: Number of replicas
+    name: REPLICAS
+    value: "1"

--- a/deploy/kessel-inventory-ephem-db-operations.yaml
+++ b/deploy/kessel-inventory-ephem-db-operations.yaml
@@ -1,0 +1,115 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: inventory
+objects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: inventory-api-config
+    data:
+      inventory-api-config.yaml: |
+        authn:
+          psk:
+            pre-shared-key-file: /psks/psks.yaml
+        authz:
+          kessel:
+            insecure-client: true
+            enable-oidc-auth: false
+        log:
+          level: "info"
+
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: psks
+    data:
+      psks.yaml: |
+        "1234":
+          tenant: "Example"
+          principal: "user@example.com"
+          is_reporter: true
+          type: "REPORTER_TYPE_ACM"
+
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdApp
+    metadata:
+      name: kessel-inventory
+    spec:
+      envName: ${ENV_NAME}
+      database:
+        name: kessel-inventory
+      optionalDependencies:
+        - kessel-relations
+      deployments:
+        - name: api
+          replicas: ${{REPLICAS}}
+          podSpec:
+            initContainers:
+            - name: db-operations
+              image: registry.redhat.io/rhel9/postgresql-15:1-54
+              command: ["/bin/sh", "-c"]
+              args:
+                - cd /tmp && curl -OL https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64 && mv jq-linux-amd64 jq && chmod +x jq;
+                  export PGHOST=$(cat /cdapp/cdappconfig.json | ./jq -r '.database.hostname');
+                  export PGPORT=$(cat /cdapp/cdappconfig.json | ./jq -r '.database.port');
+                  export PGUSER=$(cat /cdapp/cdappconfig.json | ./jq -r '.database.username');
+                  export PGDATABASE=$(cat /cdapp/cdappconfig.json | ./jq -r '.database.name');
+                  export PGPASSWORD=$(cat /cdapp/cdappconfig.json | ./jq -r '.database.password');
+                  for i in local_inventory_to_resources relationship_history relationships resource_history resources;
+                  do psql -c "DROP TABLE $i";
+                  done;
+              inheritEnv: true
+            - name: migration
+              image: ${INVENTORY_IMAGE}:${IMAGE_TAG}
+              command: ["inventory-api"]
+              args: ["migrate"]
+              inheritEnv: true
+            image: ${INVENTORY_IMAGE}:${IMAGE_TAG}
+            command: ["inventory-api"]
+            args: ["serve"]
+            livenessProbe:
+              httpGet:
+                path: /api/inventory/v1/livez
+                port: 8000
+            readinessProbe:
+              httpGet:
+                path: /api/inventory/v1/readyz
+                port: 8000
+            env:
+            - name: CLOWDER_ENABLED
+              value: "true"
+            - name: INVENTORY_API_CONFIG
+              value: "/inventory/inventory-api-config.yaml"
+            - name: PGDATA
+              value: /temp/data
+            volumeMounts:
+                - name: config-volume
+                  mountPath: "/inventory"
+                - name: psks-volume
+                  mountPath: /psks
+            volumes:
+              - name: config-volume
+                configMap:
+                  name: inventory-api-config
+              - name: psks-volume
+                configMap:
+                  name: psks
+          webServices:
+            public:
+              enabled: true
+              apiPath: inventory
+parameters:
+  - description: ClowdEnvironment name (ephemeral, stage, prod)
+    name: ENV_NAME
+    required: true
+  - description: App Image
+    name: INVENTORY_IMAGE
+    value: quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api
+  - description: Image Tag
+    name: IMAGE_TAG
+    required: true
+    value: latest
+  - description: Number of replicas
+    name: REPLICAS
+    value: "1"


### PR DESCRIPTION
### PR Template:

## Describe your changes

* adds extra deployment files that can be leverage for one off aggressive DB operations when needed
* initial use case is to drop key tables to allow the migrate command to recreate them with new data types (See https://github.com/project-kessel/inventory-api/pull/220)
* These would need to be targeted by saas file before they run so no danger in adding them

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

