### PR TITLE
Add test coverage changes as comment on PRs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,6 +2,8 @@ name: CI Build and Test
 
 on:
   workflow_call:
+  push:
+    branches: ['main']
   pull_request:
     branches: ['main']
 
@@ -27,3 +29,28 @@ jobs:
         run: go build -tags release -v ./...
       - name: Test
         run: make test
+      - name: Store coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.out
+
+  code-coverage:
+    name: "test coverage change report"
+    continue-on-error: true
+    if: github.event_name == 'pull_request' # Do not run when workflow is triggered by push to main
+    runs-on: ubuntu-latest
+    needs: build-and-test # Depends on the artifact uploaded by the "build-and-test" job
+    permissions:
+      contents:      read
+      actions:       read  # to download code coverage results from "test" job
+      pull-requests: write # write permission needed to comment on PR
+    steps:
+      # this will fail if the target branch does not already have a coverage.out file uploaded as an artifact
+      - uses: fgrosse/go-coverage-report@v1.1.1
+        with:
+          coverage-artifact-name: "coverage-report"
+          coverage-file-name: "coverage.out"
+           # below options used to make coverage work across forks
+          trim: github.com/project-kessel/inventory-api
+          root-package: ""

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+# HTML test coverage report produce with `go tool cover`
+coverage.html
 
 # Dependency directories (remove the comment below to include it)
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,12 @@ test:
 	@$(GO) test ./... -count=1 -coverprofile=coverage.out -skip 'TestInventoryAPIGRPC_*|TestInventoryAPIHTTP_*|Test_ACMKafkaConsumer'
 	@echo "Overall test coverage:"
 	@$(GO) tool cover -func=coverage.out | grep total: | awk '{print $$3}'
-	@rm coverage.out
+
+.PHONY: test-coverage
+# run all tests and create html coverage report, this takes a couple extra seconds
+test-coverage: test
+	@$(GO) tool cover -html=coverage.out -o coverage.html
+	@echo "coverage report written to coverage.html"
 
 
 .PHONY: generate


### PR DESCRIPTION
## Describe your changes

- adds a github action which will comment on PRs with test coverage deltas. Example from my fork [here](https://github.com/sfowl/inventory-api/pull/4#issuecomment-2458821147). 
- relies on `coverage.out` files being uploaded as github artifacts for the branches being compared.  The new action will fail on this PR because the `main` branch does not yet have a `coverage.out` file. After merging a `coverage.out` will be uploaded for the `main` branch and pipelines for new PRs should succeed
- also adds `make test-coverage` command, which writes a `coverage.html` file. This is unused by the new github action, and is currently just for local usage



## Ticket reference (if applicable)

For [RHCLOUD-35837](https://issues.redhat.com/browse/RHCLOUD-35837)

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

