### PR TITLE
RHCLOUD-36175 - Kind cluster setup for inventory

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,29 @@
+name: E2E Testing with Kind
+
+on:
+  workflow_call:
+  pull_request:
+    branches: ['main']
+
+jobs:
+  e2e-test:
+    name: E2E Test Inventory API
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Inventory Up - Kind Cluster
+        run: make inventory-up-kind
+
+      - name: Monitor Pods in Kind
+        run: |
+          timeout 90s kubectl get pods -w || exit 0
+
+      - name: View Test Pod Logs
+        run: |
+          TEST_POD=$(kubectl get pods --selector=job-name=e2e-inventory-http-tests -o jsonpath='{.items[0].metadata.name}')
+          kubectl logs $TEST_POD
+
+      - name: Inventory Down - Kind Cluster
+        run: make inventory-down-kind
+

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,10 @@ inventory-up-sso:
 inventory-up-kafka:
 	./scripts/start-inventory-kafka.sh
 
+.PHONY: inventory-up-kind
+inventory-up-kind:
+	./scripts/start-inventory-kind.sh
+
 .PHONY: get-token
 get-token:
 	./scripts/get-token.sh
@@ -151,6 +155,10 @@ inventory-down-sso:
 .PHONY: inventory-down-kafka
 inventory-down-kafka:
 	./scripts/stop-inventory-kafka.sh
+
+.PHONY: inventory-down-kind
+inventory-down-kind:
+	./scripts/stop-inventory-kind.sh
 
 .PHONY: run
 # run api locally

--- a/deploy/kessel-inventory.yaml
+++ b/deploy/kessel-inventory.yaml
@@ -18,11 +18,11 @@ objects:
           replicas: ${{REPLICAS}}
           podSpec:
             initContainers:
-              - name: migration
-                image: ${INVENTORY_IMAGE}:${IMAGE_TAG}
-                command: ["inventory-api"]
-                args: ["migrate"]
-                inheritEnv: true
+            - name: migration
+              image: ${INVENTORY_IMAGE}:${IMAGE_TAG}
+              command: ["inventory-api"]
+              args: ["migrate"]
+              inheritEnv: true
             image: ${INVENTORY_IMAGE}:${IMAGE_TAG}
             command: ["inventory-api"]
             args: ["serve"]
@@ -35,15 +35,15 @@ objects:
                 path: /api/inventory/v1/readyz
                 port: 8000
             env:
-              - name: CLOWDER_ENABLED
-                value: "true"
-              - name: INVENTORY_API_CONFIG
-                value: "/inventory/inventory-api-config.yaml"
-              - name: PGDATA
-                value: /temp/data
+            - name: CLOWDER_ENABLED
+              value: "true"
+            - name: INVENTORY_API_CONFIG
+              value: "/inventory/inventory-api-config.yaml"
+            - name: PGDATA
+              value: /temp/data
             volumeMounts:
-              - name: config-volume
-                mountPath: "/inventory"
+                - name: config-volume
+                  mountPath: "/inventory"
             volumes:
               - name: config-volume
                 secret:

--- a/deploy/kessel-inventory.yaml
+++ b/deploy/kessel-inventory.yaml
@@ -18,11 +18,11 @@ objects:
           replicas: ${{REPLICAS}}
           podSpec:
             initContainers:
-            - name: migration
-              image: ${INVENTORY_IMAGE}:${IMAGE_TAG}
-              command: ["inventory-api"]
-              args: ["migrate"]
-              inheritEnv: true
+              - name: migration
+                image: ${INVENTORY_IMAGE}:${IMAGE_TAG}
+                command: ["inventory-api"]
+                args: ["migrate"]
+                inheritEnv: true
             image: ${INVENTORY_IMAGE}:${IMAGE_TAG}
             command: ["inventory-api"]
             args: ["serve"]
@@ -35,15 +35,15 @@ objects:
                 path: /api/inventory/v1/readyz
                 port: 8000
             env:
-            - name: CLOWDER_ENABLED
-              value: "true"
-            - name: INVENTORY_API_CONFIG
-              value: "/inventory/inventory-api-config.yaml"
-            - name: PGDATA
-              value: /temp/data
+              - name: CLOWDER_ENABLED
+                value: "true"
+              - name: INVENTORY_API_CONFIG
+                value: "/inventory/inventory-api-config.yaml"
+              - name: PGDATA
+                value: /temp/data
             volumeMounts:
-                - name: config-volume
-                  mountPath: "/inventory"
+              - name: config-volume
+                mountPath: "/inventory"
             volumes:
               - name: config-volume
                 secret:

--- a/deploy/kind/e2e/e2e-batch.yaml
+++ b/deploy/kind/e2e/e2e-batch.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: e2e-inventory-http-tests
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: wait-for-inventory
+          image: curlimages/curl:latest
+          command:
+            - /bin/sh
+            - "-c"
+            - |
+              echo "Waiting for kessel-inventory-service to be ready..."
+              while ! curl -s http://kessel-inventory-service/api/inventory/v1/readyz; do
+                echo "Inventory service not ready yet. Sleeping for 5 seconds..."
+                sleep 5
+              done
+              echo "Inventory service is ready!"
+      containers:
+        - name: e2e-http-tests
+          image: localhost/inventory-e2e-tests:e2e-test
+          env:
+            - name: INV_HTTP_URL
+              value: "kessel-inventory-service:80"
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: "localhost:9092"
+          command: ["/usr/local/bin/e2e-inventory-tests", "-test.v"]
+      restartPolicy: Never
+  backoffLimit: 4

--- a/deploy/kind/inventory/invdatabase.yaml
+++ b/deploy/kind/inventory/invdatabase.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: invdatabase
+  labels:
+    app: invdatabase
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: invdatabase
+  template:
+    metadata:
+      labels:
+        app: invdatabase
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:latest
+          env:
+            - name: POSTGRES_DB
+              value: spicedb
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: inventory-api-config
+                  key: db_password
+          ports:
+            - containerPort: 5432
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: invdatabase
+  labels:
+    app: invdatabase
+spec:
+  ports:
+    - port: 5433
+      targetPort: 5432
+  selector:
+    app: invdatabase
+  type: ClusterIP

--- a/deploy/kind/inventory/kessel-inventory.yaml
+++ b/deploy/kind/inventory/kessel-inventory.yaml
@@ -1,0 +1,163 @@
+# Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kessel-inventory
+  labels:
+    app: kessel-inventory
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kessel-inventory
+  template:
+    metadata:
+      labels:
+        app: kessel-inventory
+    spec:
+      initContainers:
+        - name: migration
+          image: quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api:latest
+          command:
+            - /bin/sh
+            - "-c"
+            - |
+              echo "Waiting for PostgreSQL to be ready..."
+              sleep 20 
+              
+              inventory-api migrate
+          env:
+            - name: CLOWDER_ENABLED
+              value: "true"
+            - name: INVENTORY_API_CONFIG
+              value: "/inventory/inventory-api-config.yaml"
+            - name: PGDATA
+              value: /temp/data
+            - name: POSTGRES_HOST
+              value: "invdatabase"
+            - name: POSTGRES_PORT
+              value: "5433"
+            - name: POSTGRES_USER
+              value: "postgres"
+            - name: POSTGRES_DB
+              value: "spicedb"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: inventory-api-config
+                  key: db_password
+          volumeMounts:
+            - name: config-volume
+              mountPath: "/inventory"
+      containers:
+        - name: api
+          image: quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api:latest
+          command: ["inventory-api"]
+          args: ["serve"]
+          env:
+            - name: CLOWDER_ENABLED
+              value: "true"
+            - name: INVENTORY_API_CONFIG
+              value: "/inventory/inventory-api-config.yaml"
+            - name: PGDATA
+              value: /temp/data
+            - name: POSTGRES_HOST
+              value: "invdatabase"
+            - name: POSTGRES_PORT
+              value: "5433"
+            - name: POSTGRES_USER
+              value: "postgres"
+            - name: POSTGRES_DB
+              value: "spicedb"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: inventory-api-config
+                  key: db_password
+          livenessProbe:
+            httpGet:
+              path: /api/inventory/v1/livez
+              port: 8081
+          readinessProbe:
+            httpGet:
+              path: /api/inventory/v1/readyz
+              port: 8081
+          volumeMounts:
+            - name: psks-volume
+              mountPath: "/psks.yaml"
+              subPath: psks.yaml
+            - name: config-volume
+              mountPath: "/inventory"
+      volumes:
+        - name: config-volume
+          secret:
+            secretName: inventory-api-config
+        - name: psks-volume
+          configMap:
+            name: inventory-api-psks
+---
+# Services
+apiVersion: v1
+kind: Service
+metadata:
+  name: kessel-inventory-service
+  labels:
+    app: kessel-inventory
+spec:
+  selector:
+    app: kessel-inventory
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8081
+---
+# PodDisruptionBudget
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: kessel-inventory-api-pdb
+  labels:
+    app: kessel-inventory
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: kessel-inventory
+---
+# Secret
+apiVersion: v1
+kind: Secret
+metadata:
+  name: inventory-api-config
+type: Opaque
+stringData:
+  inventory-api-config.yaml: |
+    server:
+      http:
+        address: 0.0.0.0:8081
+      grpc:
+        address: 0.0.0.0:9081
+    authn:
+      psk:
+        pre-shared-key-file: /psks.yaml
+    authz:
+      impl: allow-all
+    eventing:
+      eventer: stdout
+      kafka:
+    storage:
+      database: postgres
+      sqlite3:
+        dsn: inventory.db
+      postgres:
+        host: "invdatabase"
+        port: "5433"
+        user: "postgres"
+        password: "yPsw5e6ab4bvAGe5H"
+        dbname: "spicedb"
+    log:
+      level: "debug"
+      livez: true
+      readyz: true
+  db_password: "yPsw5e6ab4bvAGe5H"
+

--- a/deploy/kind/inventory/kessel-inventory.yaml
+++ b/deploy/kind/inventory/kessel-inventory.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: migration
-          image: quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api:latest
+          image: localhost/inventory-api:e2e-test
           command:
             - /bin/sh
             - "-c"
@@ -51,7 +51,7 @@ spec:
               mountPath: "/inventory"
       containers:
         - name: api
-          image: quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api:latest
+          image: localhost/inventory-api:e2e-test
           command: ["inventory-api"]
           args: ["serve"]
           env:

--- a/deploy/kind/inventory/strimzi.yaml
+++ b/deploy/kind/inventory/strimzi.yaml
@@ -1,0 +1,35 @@
+# Taken from: https://github.com/strimzi/strimzi-kafka-operator/blob/main/examples/kafka/kafka-ephemeral.yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    version: 3.8.0
+    replicas: 1
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      inter.broker.protocol.version: "3.8"
+    storage:
+      type: ephemeral
+  zookeeper:
+    replicas: 1
+    storage:
+      type: ephemeral
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+

--- a/scripts/start-inventory-kind.sh
+++ b/scripts/start-inventory-kind.sh
@@ -5,15 +5,6 @@ source ./scripts/check_docker_podman.sh
 
 kind create cluster --name inventory-cluster
 
-kubectl create secret docker-registry redhat-registry-secret \
-  --docker-server=$DOCKER_SERVER \
-  --docker-username=$QUAY_USERNAME \
-  --docker-password=$QUAY_PASSWORD \
-  --docker-email=$QUAY_EMAIL
-
-kubectl create serviceaccount default
-kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "redhat-registry-secret"}]}'
-
 # build/tag image
 ${DOCKER} build -t localhost/inventory-api:latest -f Dockerfile .
 ${DOCKER} build -t localhost/inventory-e2e-tests:latest -f Dockerfile-e2e .

--- a/scripts/start-inventory-kind.sh
+++ b/scripts/start-inventory-kind.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+source ./scripts/check_docker_podman.sh
+
+kind create cluster --name inventory-cluster
+
+kubectl create secret docker-registry redhat-registry-secret \
+  --docker-server=$DOCKER_SERVER \
+  --docker-username=$QUAY_USERNAME \
+  --docker-password=$QUAY_PASSWORD \
+  --docker-email=$QUAY_EMAIL
+
+kubectl create serviceaccount default
+kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "redhat-registry-secret"}]}'
+
+# build/tag image
+${DOCKER} build -t localhost/inventory-api:latest -f Dockerfile .
+${DOCKER} build -t localhost/inventory-e2e-tests:latest -f Dockerfile-e2e .
+
+${DOCKER} tag localhost/inventory-api:latest localhost/inventory-api:e2e-test
+${DOCKER} tag localhost/inventory-e2e-tests:latest localhost/inventory-e2e-tests:e2e-test
+
+rm -rf inventory-api.tar
+rm -rf inventory-e2e-tests.tar
+
+${DOCKER} save -o inventory-api.tar localhost/inventory-api:e2e-test
+${DOCKER} save -o inventory-e2e-tests.tar localhost/inventory-e2e-tests:e2e-test
+
+kind load image-archive inventory-api.tar --name inventory-cluster
+kind load image-archive inventory-e2e-tests.tar --name inventory-cluster
+
+kubectl create configmap inventory-api-psks --from-file=config/psks.yaml
+
+kubectl apply -f https://strimzi.io/install/latest\?namespace\=default
+kubectl apply -f deploy/kind/inventory/kessel-inventory.yaml
+kubectl apply -f deploy/kind/inventory/invdatabase.yaml
+kubectl apply -f deploy/kind/e2e/e2e-batch.yaml
+kubectl apply -f deploy/kind/inventory/strimzi.yaml

--- a/scripts/stop-inventory-kind.sh
+++ b/scripts/stop-inventory-kind.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -oe errexit
+
+if ! command -v kind &> /dev/null
+then
+    echo "kind could not be found"
+    exit
+fi
+
+echo "Deleting kind inventory-cluster"
+kind delete clusters inventory-cluster

--- a/test/e2e/inventory_http_test.go
+++ b/test/e2e/inventory_http_test.go
@@ -113,7 +113,7 @@ func TestInventoryAPIHTTP_Readyz(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 
-	expectedStatus := "Storage type sqlite"
+	expectedStatus := "Storage type postgres"
 	expectedCode := uint32(200)
 
 	assert.Equal(t, expectedStatus, resp.Status)
@@ -121,7 +121,7 @@ func TestInventoryAPIHTTP_Readyz(t *testing.T) {
 }
 
 func TestInventoryAPIHTTP_Metrics(t *testing.T) {
-	resp, err := nethttp.Get("http://localhost:8081/metrics")
+	resp, err := nethttp.Get("http://" + inventoryapi_http_url + "/metrics")
 	if err != nil {
 		t.Fatal("Failed to send request: ", err)
 	}


### PR DESCRIPTION
### PR Template:

## Describe your changes


- Added setup for running containers using Kind along with github workflow:
    - inventory-api - **Running**
    - invdatabase - **Running**
    - inventory-e2e-tests - **Running and Passing**
    - my-cluster-zookeeper-0 **Running**
    - strimzi-cluster-operator **Running**


- Added make targets for:
    - `make inventory-up-kind`
    - `make inventory-down-kind`

Output:
```sh
❯ kubectl get pods
NAME                                        READY   STATUS      RESTARTS   AGE
e2e-inventory-http-tests-r4wm2              0/1     Completed   0          62s
invdatabase-75f6cc55bc-l24b6                1/1     Running     0          62s
kessel-inventory-9bb5546d4-8tvv6            1/1     Running     0          62s
my-cluster-zookeeper-0                      0/1     Running     0          37s
strimzi-cluster-operator-6f9fbb4c75-knkpx   1/1     Running     0          63s
❯ kubectl logs e2e-inventory-http-tests-r4wm2
INFO msg=TLS environment variables not set
=== RUN   TestInventoryAPIHTTP_Livez
=== PAUSE TestInventoryAPIHTTP_Livez
=== RUN   TestInventoryAPIHTTP_Readyz
=== PAUSE TestInventoryAPIHTTP_Readyz
=== RUN   TestInventoryAPIHTTP_Metrics
--- PASS: TestInventoryAPIHTTP_Metrics (0.00s)
=== RUN   TestInventoryAPIHTTP_CreateRHELHost
=== PAUSE TestInventoryAPIHTTP_CreateRHELHost
=== RUN   TestInventoryAPIHTTP_K8SCluster_CreateK8SCluster
=== PAUSE TestInventoryAPIHTTP_K8SCluster_CreateK8SCluster
=== RUN   TestInventoryAPIHTTP_K8SPolicy_CreateK8SPolicy
=== PAUSE TestInventoryAPIHTTP_K8SPolicy_CreateK8SPolicy
=== RUN   Test_ACMKafkaConsumer
=== PAUSE Test_ACMKafkaConsumer
=== CONT  TestInventoryAPIHTTP_Livez
=== CONT  TestInventoryAPIHTTP_K8SCluster_CreateK8SCluster
=== CONT  Test_ACMKafkaConsumer
=== CONT  TestInventoryAPIHTTP_CreateRHELHost
=== CONT  TestInventoryAPIHTTP_Readyz
=== CONT  TestInventoryAPIHTTP_K8SPolicy_CreateK8SPolicy
--- PASS: TestInventoryAPIHTTP_Livez (0.00s)
--- PASS: TestInventoryAPIHTTP_Readyz (0.00s)
%3|1731421415.806|FAIL|rdkafka#consumer-1| [thrd:localhost:9092/bootstrap]: localhost:9092/bootstrap: Connect to ipv4#127.0.0.1:9092 failed: Connection refused (after 0ms in state CONNECT)
% Error: Local: Broker transport failure: localhost:9092/bootstrap: Connect to ipv4#127.0.0.1:9092 failed: Connection refused (after 0ms in state CONNECT)
% Error: Local: All broker connections are down: 1/1 brokers are down
--- PASS: Test_ACMKafkaConsumer (0.00s)
--- PASS: TestInventoryAPIHTTP_CreateRHELHost (0.02s)
--- PASS: TestInventoryAPIHTTP_K8SPolicy_CreateK8SPolicy (0.02s)
--- PASS: TestInventoryAPIHTTP_K8SCluster_CreateK8SCluster (0.02s)
PASS
```
## Ticket reference (if applicable)
Fixes [RHCLOUD-36175](https://issues.redhat.com/browse/RHCLOUD-36175)

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

