### PR TITLE
RHCLOUD-36114: Add configuration to optionally disable persistence

### DIFF
--- a/.inventory-api.yaml
+++ b/.inventory-api.yaml
@@ -17,6 +17,7 @@ eventing:
   eventer: stdout
   kafka:
 storage:
+  disable-persistence: false
   database: sqlite3
   sqlite3:
     dsn: inventory.db

--- a/cmd/.inventory-api.yaml
+++ b/cmd/.inventory-api.yaml
@@ -12,6 +12,7 @@ eventing:
   eventer: stdout
   kafka:
 storage:
+  disable-persistence: false
   database: sqlite3
   sqlite3:
     dsn: inventory.db

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -16,6 +16,12 @@ func NewCommand(options *storage.Options, loggerOptions common.LoggerOptions) *c
 		Short: "Create or migrate the database tables",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_, logger := common.InitLogger(common.GetLogLevel(), loggerOptions)
+			logHelper := log.NewHelper(log.With(logger, "group", "storage"))
+
+			if options.DisablePersistence {
+				logHelper.Info("Persistence disabled, skipping database migration...")
+				return nil
+			}
 
 			if errs := options.Complete(); errs != nil {
 				return errors.NewAggregate(errs)
@@ -27,7 +33,6 @@ func NewCommand(options *storage.Options, loggerOptions common.LoggerOptions) *c
 
 			config := storage.NewConfig(options).Complete()
 
-			logHelper := log.NewHelper(log.With(logger, "group", "storage"))
 			db, err := storage.New(config, logHelper)
 			if err != nil {
 				return err

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -3,6 +3,10 @@ package serve
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/project-kessel/inventory-api/cmd/common"
 	relationshipsctl "github.com/project-kessel/inventory-api/internal/biz/relationships"
 	resourcesctl "github.com/project-kessel/inventory-api/internal/biz/resources"
@@ -13,9 +17,6 @@ import (
 	k8sclusterssvc "github.com/project-kessel/inventory-api/internal/service/resources/k8sclusters"
 	k8spoliciessvc "github.com/project-kessel/inventory-api/internal/service/resources/k8spolicies"
 	notifssvc "github.com/project-kessel/inventory-api/internal/service/resources/notificationsintegrations"
-	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/spf13/cobra"
 	"gorm.io/gorm"
@@ -146,41 +147,41 @@ func NewCommand(
 
 			// wire together notificationsintegrations handling
 			notifs_repo := resourcerepo.New(db)
-			notifs_controller := resourcesctl.New(notifs_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"))
+			notifs_controller := resourcesctl.New(notifs_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), storageConfig.Options.DisablePersistence)
 			notifs_service := notifssvc.New(notifs_controller)
 			pb.RegisterKesselNotificationsIntegrationServiceServer(server.GrpcServer, notifs_service)
 			pb.RegisterKesselNotificationsIntegrationServiceHTTPServer(server.HttpServer, notifs_service)
 
 			// wire together hosts handling
 			hosts_repo := resourcerepo.New(db)
-			hosts_controller := resourcesctl.New(hosts_repo, authorizer, eventingManager, "hbi", log.With(logger, "subsystem", "hosts_controller"))
+			hosts_controller := resourcesctl.New(hosts_repo, authorizer, eventingManager, "hbi", log.With(logger, "subsystem", "hosts_controller"), storageConfig.Options.DisablePersistence)
 			hosts_service := hostssvc.New(hosts_controller)
 			pb.RegisterKesselRhelHostServiceServer(server.GrpcServer, hosts_service)
 			pb.RegisterKesselRhelHostServiceHTTPServer(server.HttpServer, hosts_service)
 
 			// wire together k8sclusters handling
 			k8sclusters_repo := resourcerepo.New(db)
-			k8sclusters_controller := resourcesctl.New(k8sclusters_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8sclusters_controller"))
+			k8sclusters_controller := resourcesctl.New(k8sclusters_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8sclusters_controller"), storageConfig.Options.DisablePersistence)
 			k8sclusters_service := k8sclusterssvc.New(k8sclusters_controller)
 			pb.RegisterKesselK8SClusterServiceServer(server.GrpcServer, k8sclusters_service)
 			pb.RegisterKesselK8SClusterServiceHTTPServer(server.HttpServer, k8sclusters_service)
 
 			// wire together k8spolicies handling
 			k8spolicies_repo := resourcerepo.New(db)
-			k8spolicies_controller := resourcesctl.New(k8spolicies_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8spolicies_controller"))
+			k8spolicies_controller := resourcesctl.New(k8spolicies_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8spolicies_controller"), storageConfig.Options.DisablePersistence)
 			k8spolicies_service := k8spoliciessvc.New(k8spolicies_controller)
 			pb.RegisterKesselK8SPolicyServiceServer(server.GrpcServer, k8spolicies_service)
 			pb.RegisterKesselK8SPolicyServiceHTTPServer(server.HttpServer, k8spolicies_service)
 
 			// wire together relationships handling
 			relationships_repo := relationshipsrepo.New(db)
-			relationships_controller := relationshipsctl.New(relationships_repo, eventingManager, log.With(logger, "subsystem", "relationships_controller"))
+			relationships_controller := relationshipsctl.New(relationships_repo, eventingManager, log.With(logger, "subsystem", "relationships_controller"), storageConfig.Options.DisablePersistence)
 			relationships_service := relationshipssvc.New(relationships_controller)
 			rel.RegisterKesselK8SPolicyIsPropagatedToK8SClusterServiceServer(server.GrpcServer, relationships_service)
 			rel.RegisterKesselK8SPolicyIsPropagatedToK8SClusterServiceHTTPServer(server.HttpServer, relationships_service)
 
 			health_repo := healthrepo.New(db, authorizer, authzConfig)
-			health_controller := healthctl.New(health_repo, log.With(logger, "subsystem", "health_controller"))
+			health_controller := healthctl.New(health_repo, log.With(logger, "subsystem", "health_controller"), storageConfig.Options.DisablePersistence)
 			health_service := healthssvc.New(health_controller)
 			hb.RegisterKesselInventoryHealthServiceServer(server.GrpcServer, health_service)
 			hb.RegisterKesselInventoryHealthServiceHTTPServer(server.HttpServer, health_service)

--- a/internal/biz/health/health.go
+++ b/internal/biz/health/health.go
@@ -2,25 +2,31 @@ package biz
 
 import (
 	"context"
+
 	"github.com/go-kratos/kratos/v2/log"
 	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1"
 )
 
 type HealthRepo interface {
 	IsBackendAvailable(ctx context.Context) (*pb.GetReadyzResponse, error)
+	IsRelationsAvailable(ctx context.Context) (*pb.GetReadyzResponse, error)
 }
 
 // HealthUsecase is a Health usecase.
 type HealthUsecase struct {
-	repo HealthRepo
-	log  *log.Helper
+	repo               HealthRepo
+	log                *log.Helper
+	disablePersistence bool
 }
 
 // New creates a new a Health usecase.
-func New(repo HealthRepo, logger log.Logger) *HealthUsecase {
-	return &HealthUsecase{repo: repo, log: log.NewHelper(logger)}
+func New(repo HealthRepo, logger log.Logger, disablePersistence bool) *HealthUsecase {
+	return &HealthUsecase{repo: repo, log: log.NewHelper(logger), disablePersistence: disablePersistence}
 }
 
 func (rc *HealthUsecase) IsBackendAvailable(ctx context.Context) (*pb.GetReadyzResponse, error) {
+	if rc.disablePersistence {
+		return rc.repo.IsRelationsAvailable(ctx)
+	}
 	return rc.repo.IsBackendAvailable(ctx)
 }

--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -11,6 +11,7 @@ import (
 	"github.com/project-kessel/inventory-api/internal/biz"
 	"github.com/project-kessel/inventory-api/internal/biz/model"
 	eventingapi "github.com/project-kessel/inventory-api/internal/eventing/api"
+	"github.com/project-kessel/inventory-api/internal/server"
 	"gorm.io/gorm"
 )
 
@@ -30,120 +31,152 @@ var (
 )
 
 type Usecase struct {
-	repository ResourceRepository
-	Authz      authzapi.Authorizer
-	Eventer    eventingapi.Manager
-	Namespace  string
-	log        *log.Helper
+	repository         ResourceRepository
+	Authz              authzapi.Authorizer
+	Eventer            eventingapi.Manager
+	Namespace          string
+	log                *log.Helper
+	Server             server.Server
+	DisablePersistence bool
 }
 
-func New(repository ResourceRepository, authz authzapi.Authorizer, eventer eventingapi.Manager, namespace string, logger log.Logger) *Usecase {
+func New(repository ResourceRepository, authz authzapi.Authorizer, eventer eventingapi.Manager, namespace string, logger log.Logger, disablePersistence bool) *Usecase {
 	return &Usecase{
-		repository: repository,
-		Authz:      authz,
-		Eventer:    eventer,
-		Namespace:  namespace,
-		log:        log.NewHelper(logger),
+		repository:         repository,
+		Authz:              authz,
+		Eventer:            eventer,
+		Namespace:          namespace,
+		log:                log.NewHelper(logger),
+		DisablePersistence: disablePersistence,
 	}
 }
 
 func (uc *Usecase) Create(ctx context.Context, m *model.Resource) (*model.Resource, error) {
-	// check if the resource already exists
-	resource, err := uc.repository.FindByReporterResourceId(ctx, model.ReporterResourceIdFromResource(m))
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, ErrDatabaseError
-	}
-	if resource != nil {
-		return nil, ErrResourceAlreadyExists
-	}
+	ret := m // Default to returning the input model in case persistence is disabled
 
-	if ret, err := uc.repository.Save(ctx, m); err != nil {
-		return nil, err
+	if !uc.DisablePersistence {
+		// check if the resource already exists
+		resource, err := uc.repository.FindByReporterResourceId(ctx, model.ReporterResourceIdFromResource(m))
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrDatabaseError
+		}
+		if resource != nil {
+			return nil, ErrResourceAlreadyExists
+		}
+
+		ret, err = uc.repository.Save(ctx, m)
+		if err != nil {
+			return nil, err
+		}
 	} else {
-		if uc.Eventer != nil {
-			err := biz.DefaultResourceSendEvent(ctx, m, uc.Eventer, *m.CreatedAt, eventingapi.OperationTypeCreated)
-
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		if uc.Authz != nil {
-			err := biz.DefaultSetWorkspace(ctx, uc.Namespace, m, uc.Authz)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		uc.log.WithContext(ctx).Infof("Created Resource: %v(%v)", m.ID, m.ResourceType)
-		return ret, nil
+		// mock the created at time for eventing
+		// TODO: remove this when persistence is always enabled
+		now := time.Now()
+		m.CreatedAt = &now
 	}
+
+	if uc.Eventer != nil {
+		err := biz.DefaultResourceSendEvent(ctx, m, uc.Eventer, *m.CreatedAt, eventingapi.OperationTypeCreated)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if uc.Authz != nil {
+		err := biz.DefaultSetWorkspace(ctx, uc.Namespace, m, uc.Authz)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	uc.log.WithContext(ctx).Infof("Created Resource: %v(%v)", m.ID, m.ResourceType)
+	return ret, nil
 }
 
 // Update updates a model in the database, updates related tuples in the relations-api, and issues an update event.
 func (uc *Usecase) Update(ctx context.Context, m *model.Resource, id model.ReporterResourceId) (*model.Resource, error) {
-	// check if the resource exists
-	existingResource, err := uc.repository.FindByReporterResourceId(ctx, model.ReporterResourceIdFromResource(m))
+	ret := m // Default to returning the input model in case persistence is disabled
 
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return uc.Create(ctx, m)
-		} else {
+	if !uc.DisablePersistence {
+		// check if the resource exists
+		existingResource, err := uc.repository.FindByReporterResourceId(ctx, model.ReporterResourceIdFromResource(m))
+
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return uc.Create(ctx, m)
+			}
+
 			return nil, ErrDatabaseError
 		}
-	}
 
-	if ret, err := uc.repository.Update(ctx, m, existingResource.ID); err != nil {
-		return nil, err
+		ret, err = uc.repository.Update(ctx, m, existingResource.ID)
+		if err != nil {
+			return nil, err
+		}
 	} else {
-		if uc.Eventer != nil {
-			err := biz.DefaultResourceSendEvent(ctx, m, uc.Eventer, *m.UpdatedAt, eventingapi.OperationTypeUpdated)
-
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		if uc.Authz != nil {
-			// Todo: Update workspace if there is any change
-			err := biz.DefaultSetWorkspace(ctx, uc.Namespace, m, uc.Authz)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		uc.log.WithContext(ctx).Infof("Updated Resource: %v(%v)", m.ID, m.ResourceType)
-		return ret, nil
+		// mock the updated at time for eventing
+		// TODO: remove this when persistence is always enabled
+		now := time.Now()
+		m.UpdatedAt = &now
 	}
+
+	if uc.Eventer != nil {
+		err := biz.DefaultResourceSendEvent(ctx, m, uc.Eventer, *m.UpdatedAt, eventingapi.OperationTypeUpdated)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if uc.Authz != nil {
+		// Todo: Update workspace if there is any change
+		err := biz.DefaultSetWorkspace(ctx, uc.Namespace, m, uc.Authz)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	uc.log.WithContext(ctx).Infof("Updated Resource: %v(%v)", m.ID, m.ResourceType)
+	return ret, nil
+
 }
 
 // Delete deletes a model from the database, removes related tuples from the relations-api, and issues a delete event.
 func (uc *Usecase) Delete(ctx context.Context, id model.ReporterResourceId) error {
-	// check if the resource exists
-	existingResource, err := uc.repository.FindByReporterResourceId(ctx, id)
+	m := &model.Resource{
+		// TODO: Create model
+	}
 
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return ErrResourceNotFound
-		} else {
+	if !uc.DisablePersistence {
+		// check if the resource exists
+		existingResource, err := uc.repository.FindByReporterResourceId(ctx, id)
+
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrResourceNotFound
+			}
+
 			return ErrDatabaseError
 		}
-	}
 
-	if m, err := uc.repository.Delete(ctx, existingResource.ID); err != nil {
-		return err
-	} else {
-		if uc.Eventer != nil {
-			err := biz.DefaultResourceSendEvent(ctx, m, uc.Eventer, time.Now(), eventingapi.OperationTypeDeleted)
-
-			if err != nil {
-				return err
-			}
+		m, err = uc.repository.Delete(ctx, existingResource.ID)
+		if err != nil {
+			return err
 		}
-
-		// TODO: delete the workspace tuple
-
-		uc.log.WithContext(ctx).Infof("Deleted Resource: %v(%v)", m.ID, m.ResourceType)
-		return nil
 	}
+
+	if uc.Eventer != nil {
+		err := biz.DefaultResourceSendEvent(ctx, m, uc.Eventer, time.Now(), eventingapi.OperationTypeDeleted)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	// TODO: delete the workspace tuple
+
+	uc.log.WithContext(ctx).Infof("Deleted Resource: %v(%v)", m.ID, m.ResourceType)
+	return nil
+
 }

--- a/internal/data/health/health.go
+++ b/internal/data/health/health.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"context"
+
 	"github.com/go-kratos/kratos/v2/log"
 	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1"
 	"github.com/project-kessel/inventory-api/internal/authz"
@@ -54,6 +55,20 @@ func (r *healthRepo) IsBackendAvailable(ctx context.Context) (*pb.GetReadyzRespo
 	}
 
 	return newResponse("Storage type "+storageType, 200), nil
+}
+
+func (r *healthRepo) IsRelationsAvailable(ctx context.Context) (*pb.GetReadyzResponse, error) {
+	health, apiErr := r.Authz.Health(ctx)
+	if apiErr != nil {
+		log.Errorf("RELATIONS-API UNHEALTHY")
+		return newResponse("RELATIONS-API UNHEALTHY", 500), nil
+	}
+	if authz.CheckAuthorizer(r.CompletedAuth) == "Kessel" {
+		if viper.GetBool("log.readyz") {
+			log.Infof("relations-api %s", health.GetStatus())
+		}
+	}
+	return newResponse("RELATIONS-API", 200), nil
 }
 
 func newResponse(status string, code int) *pb.GetReadyzResponse {

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -6,16 +6,17 @@ import (
 )
 
 type Config struct {
-	Database string
-	DSN      string
+	Options *Options
+	DSN     string
 
 	Postgres *postgres.Config
 	SqlLite3 *sqlite3.Config
 }
 
 type completedConfig struct {
-	Database string
-	DSN      string
+	Options *Options
+
+	DSN string
 }
 
 type CompletedConfig struct {
@@ -24,7 +25,7 @@ type CompletedConfig struct {
 
 func NewConfig(o *Options) *Config {
 	cfg := &Config{
-		Database: o.Database,
+		Options: o,
 	}
 
 	switch o.Database {
@@ -39,15 +40,16 @@ func NewConfig(o *Options) *Config {
 
 func (c *Config) Complete() CompletedConfig {
 	cfg := &completedConfig{
-		Database: c.Database,
-		DSN:      c.DSN,
+		Options: c.Options,
+
+		DSN: c.DSN,
 	}
 
 	if c.DSN != "" {
 		return CompletedConfig{cfg}
 	}
 
-	switch c.Database {
+	switch c.Options.Database {
 	case "postgres":
 		cfg.DSN = c.Postgres.Complete().DSN
 	case "sqlite3":

--- a/internal/storage/options.go
+++ b/internal/storage/options.go
@@ -9,9 +9,10 @@ import (
 )
 
 type Options struct {
-	Postgres *postgres.Options `mapstructure:"postgres"`
-	SqlLite3 *sqlite3.Options  `mapstructure:"sqlite3"`
-	Database string            `mapstructure:"database"`
+	Postgres           *postgres.Options `mapstructure:"postgres"`
+	SqlLite3           *sqlite3.Options  `mapstructure:"sqlite3"`
+	Database           string            `mapstructure:"database"`
+	DisablePersistence bool              `mapstructure:"disable-persistence"`
 }
 
 const (
@@ -21,9 +22,10 @@ const (
 
 func NewOptions() *Options {
 	return &Options{
-		Postgres: postgres.NewOptions(),
-		SqlLite3: sqlite3.NewOptions(),
-		Database: "sqlite3",
+		Postgres:           postgres.NewOptions(),
+		SqlLite3:           sqlite3.NewOptions(),
+		Database:           "sqlite3",
+		DisablePersistence: false,
 	}
 }
 
@@ -33,6 +35,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 	}
 
 	fs.StringVar(&o.Database, prefix+"database", o.Database, "The database type to use.  Either sqlite3 or postgres.")
+	fs.BoolVar(&o.DisablePersistence, prefix+"disable-persistence", o.DisablePersistence, "Disable storing data in the database")
 
 	o.Postgres.AddFlags(fs, prefix+"postgres")
 	o.SqlLite3.AddFlags(fs, prefix+"sqlite3")

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -11,17 +11,26 @@ import (
 
 func New(c CompletedConfig, logger *log.Helper) (*gorm.DB, error) {
 	var opener func(string) gorm.Dialector
+	var db *gorm.DB
 
-	switch c.Database {
+	logger.Info("Persistence disabled: ", c.Options.DisablePersistence)
+
+	if c.Options.DisablePersistence {
+		logger.Info("Persistence disabled, skipping database connection...")
+		// Return nil database connection
+		return nil, nil
+	}
+
+	switch c.Options.Database {
 	case "postgres":
 		opener = postgres.Open
 	case "sqlite3":
 		opener = sqlite.Open
 	default:
-		return nil, fmt.Errorf("unrecognized database type: %s", c.Database)
+		return nil, fmt.Errorf("unrecognized database type: %s", c.Options.Database)
 	}
 
-	logger.Infof("Using backing storage: %s", c.Database)
+	logger.Infof("Using backing storage: %s", c.Options.Database)
 	db, err := gorm.Open(opener(c.DSN), &gorm.Config{})
 	if err != nil {
 		return nil, fmt.Errorf("Error opening database: %s", err.Error())

--- a/inventory-api-compose.yaml
+++ b/inventory-api-compose.yaml
@@ -17,6 +17,7 @@ eventing:
   eventer: stdout
   kafka:
 storage:
+  disable-persistence: false
   database: postgres
   sqlite3:
     dsn: inventory.db

--- a/kafka-inventory-api.yaml
+++ b/kafka-inventory-api.yaml
@@ -15,6 +15,7 @@ eventing:
     # security-protocol: "SASL_PLAINTEXT"
     # sasl-mechanism: PLAIN
 storage:
+  disable-persistence: false
   database: sqlite3
   sqlite3:
     dsn: inventory.db

--- a/sso-inventory-api.yaml
+++ b/sso-inventory-api.yaml
@@ -15,6 +15,7 @@ eventing:
   eventer: stdout
   kafka:
 storage:
+  disable-persistence: false
   database: postgres
   sqlite3:
     dsn: inventory.db


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Adds deploy config for disabling persistence
  - Will not make a DB connection during startup when disabled
  - Will not run migrations when disabled
  - Will not create/update/delete resources when disabled
  - Will not check DB during readyz/livez determination

- Flattened biz logic for resource/relationships
  - Example
    ```
    if isTrue, err := checkIfTrue(); err != nil {
       return err
    } else {
      doSomething()
    }
    ```
    turns into
    ```
    isTrue, err := checkIfTrue()
    if err != nil {
      return err
    }
    doSomething()
    ```

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

