### PR TITLE
RHCLOUD-35836 - Increase e2e test coverage

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -22,7 +22,12 @@ jobs:
       - name: View Test Pod Logs
         run: |
           TEST_POD=$(kubectl get pods --selector=job-name=e2e-inventory-http-tests -o jsonpath='{.items[0].metadata.name}')
-          kubectl logs $TEST_POD
+          kubectl logs $TEST_POD | tee test_logs.txt
+          
+          if grep -q -E "FAIL" test_logs.txt; then
+            echo "Test failed. Errors found in logs."
+            exit 1
+          fi
 
       - name: Inventory Down - Kind Cluster
         run: make inventory-down-kind

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -17,13 +17,15 @@ jobs:
 
       - name: Monitor Pods in Kind
         run: |
-          for i in {1..50}; do
+          for i in {1..300}; do
             STATUS=$(kubectl get pods --selector=job-name=e2e-inventory-http-tests -o jsonpath='{.items[0].status.phase}')
             if [ "$STATUS" = "Succeeded" ]; then
               echo "Test pod completed successfully."
               exit 0
             elif [ "$STATUS" = "Failed" ]; then
               echo "Test pod failed."
+              TEST_POD=$(kubectl get pods --selector=job-name=e2e-inventory-http-tests -o jsonpath='{.items[0].metadata.name}')
+              kubectl logs $TEST_POD
               exit 1
             fi
             sleep 1

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -17,17 +17,25 @@ jobs:
 
       - name: Monitor Pods in Kind
         run: |
-          timeout 90s kubectl get pods -w || exit 0
+          for i in {1..50}; do
+            STATUS=$(kubectl get pods --selector=job-name=e2e-inventory-http-tests -o jsonpath='{.items[0].status.phase}')
+            if [ "$STATUS" = "Succeeded" ]; then
+              echo "Test pod completed successfully."
+              exit 0
+            elif [ "$STATUS" = "Failed" ]; then
+              echo "Test pod failed."
+              exit 1
+            fi
+            sleep 1
+          done
+
+          echo "Timeout reached while waiting for the test pod to complete."
+          exit 1
 
       - name: View Test Pod Logs
         run: |
           TEST_POD=$(kubectl get pods --selector=job-name=e2e-inventory-http-tests -o jsonpath='{.items[0].metadata.name}')
-          kubectl logs $TEST_POD | tee test_logs.txt
-          
-          if grep -q -E "FAIL" test_logs.txt; then
-            echo "Test failed. Errors found in logs."
-            exit 1
-          fi
+          kubectl logs $TEST_POD
 
       - name: Inventory Down - Kind Cluster
         run: make inventory-down-kind

--- a/deploy/kind/inventory/kessel-inventory.yaml
+++ b/deploy/kind/inventory/kessel-inventory.yaml
@@ -139,6 +139,8 @@ stringData:
         address: 0.0.0.0:9081
     authn:
       allow-unauthenticated: true
+      #psk:
+          #pre-shared-key-file: /psks.yaml
     authz:
       impl: allow-all
     eventing:

--- a/deploy/kind/inventory/kessel-inventory.yaml
+++ b/deploy/kind/inventory/kessel-inventory.yaml
@@ -138,8 +138,7 @@ stringData:
       grpc:
         address: 0.0.0.0:9081
     authn:
-      psk:
-        pre-shared-key-file: /psks.yaml
+      allow-unauthenticated: true
     authz:
       impl: allow-all
     eventing:

--- a/test/e2e/inventory_http_test.go
+++ b/test/e2e/inventory_http_test.go
@@ -138,7 +138,7 @@ func TestInventoryAPIHTTP_Metrics(t *testing.T) {
 	assert.Equal(t, expectedStatusString, resp.Status)
 }
 
-func TestInventoryAPIHTTP_CreateRHELHost(t *testing.T) {
+func TestInventoryAPIHTTP_RHELHostLifecycle(t *testing.T) {
 	t.Parallel()
 	c := v1beta1.NewConfig(
 		v1beta1.WithHTTPUrl(inventoryapi_http_url),
@@ -149,12 +149,49 @@ func TestInventoryAPIHTTP_CreateRHELHost(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	request := resources.CreateRhelHostRequest{RhelHost: &resources.RhelHost{
-		Metadata: &resources.Metadata{
-			ResourceType: "rhel_host",
-			WorkspaceId:  "workspace1",
-			OrgId:        "",
+
+	createRequest := resources.CreateRhelHostRequest{
+		RhelHost: &resources.RhelHost{
+			Metadata: &resources.Metadata{
+				ResourceType: "rhel_host",
+				WorkspaceId:  "workspace0",
+				OrgId:        "",
+			},
+			ReporterData: &resources.ReporterData{
+				ReporterInstanceId: "user@email.com",
+				ReporterType:       resources.ReporterData_OCM,
+				ConsoleHref:        "www.web.com",
+				ApiHref:            "www.wb.com",
+				LocalResourceId:    "0123",
+				ReporterVersion:    "0.2",
+			},
 		},
+	}
+	opts := getCallOptions()
+	_, err = client.RhelHostServiceClient.CreateRhelHost(context.Background(), &createRequest, opts...)
+	assert.NoError(t, err)
+
+	updateRequest := resources.UpdateRhelHostRequest{
+		RhelHost: &resources.RhelHost{
+			Metadata: &resources.Metadata{
+				ResourceType: "rhel_host",
+				WorkspaceId:  "workspace0",
+				OrgId:        "",
+			},
+			ReporterData: &resources.ReporterData{
+				ReporterInstanceId: "user@email.com",
+				ReporterType:       resources.ReporterData_OCM,
+				ConsoleHref:        "www.web.com",
+				ApiHref:            "www.wb.com",
+				LocalResourceId:    "0123",
+				ReporterVersion:    "0.2",
+			},
+		},
+	}
+	_, err = client.RhelHostServiceClient.UpdateRhelHost(context.Background(), &updateRequest, opts...)
+	assert.NoError(t, err)
+
+	deleteRequest := resources.DeleteRhelHostRequest{
 		ReporterData: &resources.ReporterData{
 			ReporterInstanceId: "user@email.com",
 			ReporterType:       resources.ReporterData_OCM,
@@ -163,75 +200,8 @@ func TestInventoryAPIHTTP_CreateRHELHost(t *testing.T) {
 			LocalResourceId:    "0123",
 			ReporterVersion:    "0.2",
 		},
-	}}
-	opts := getCallOptions()
-	_, err = client.RhelHostServiceClient.CreateRhelHost(context.Background(), &request, opts...)
-	assert.NoError(t, err)
-
-}
-
-func TestInventoryAPIHTTP_UpdateRHELHost(t *testing.T) {
-	t.Parallel()
-	c := v1beta1.NewConfig(
-		v1beta1.WithHTTPUrl(inventoryapi_http_url),
-		v1beta1.WithTLSInsecure(insecure),
-		v1beta1.WithHTTPTLSConfig(tlsConfig),
-	)
-	client, err := v1beta1.NewHttpClient(context.Background(), c)
-	if err != nil {
-		t.Error(err)
 	}
-
-	reporterData := &resources.ReporterData{
-		ReporterInstanceId: "user@email.com",
-		ReporterType:       resources.ReporterData_OCM,
-		ConsoleHref:        "www.web.com",
-		ApiHref:            "www.wb.com",
-		LocalResourceId:    "0123",
-		ReporterVersion:    "0.2",
-	}
-
-	request := resources.UpdateRhelHostRequest{RhelHost: &resources.RhelHost{
-		Metadata: &resources.Metadata{
-			ResourceType: "rhel-host",
-			WorkspaceId:  "workspace0",
-			OrgId:        "",
-		},
-		ReporterData: reporterData,
-	}}
-	opts := getCallOptions()
-	_, err = client.RhelHostServiceClient.UpdateRhelHost(context.Background(), &request, opts...)
-	assert.NoError(t, err)
-
-}
-
-func TestInventoryAPIHTTP_DeleteRHELHost(t *testing.T) {
-	t.Parallel()
-	c := v1beta1.NewConfig(
-		v1beta1.WithHTTPUrl(inventoryapi_http_url),
-		v1beta1.WithTLSInsecure(insecure),
-		v1beta1.WithHTTPTLSConfig(tlsConfig),
-	)
-	client, err := v1beta1.NewHttpClient(context.Background(), c)
-	if err != nil {
-		t.Error(err)
-	}
-
-	reporter := &resources.ReporterData{
-		ReporterInstanceId: "user@email.com",
-		ReporterType:       resources.ReporterData_OCM,
-		ConsoleHref:        "www.web.com",
-		ApiHref:            "www.wb.com",
-		LocalResourceId:    "0123",
-		ReporterVersion:    "0.2",
-	}
-
-	request1 := resources.DeleteRhelHostRequest{
-		ReporterData: reporter,
-	}
-
-	opts := getCallOptions()
-	_, err = client.RhelHostServiceClient.DeleteRhelHost(context.Background(), &request1, opts...)
+	_, err = client.RhelHostServiceClient.DeleteRhelHost(context.Background(), &deleteRequest, opts...)
 	assert.NoError(t, err)
 }
 

--- a/test/e2e/inventory_http_test.go
+++ b/test/e2e/inventory_http_test.go
@@ -5,17 +5,16 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	nethttp "net/http"
-	"os"
-	"strconv"
-	"testing"
-
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/transport/http"
 	v1 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1"
 	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1/resources"
 	"github.com/project-kessel/inventory-client-go/v1beta1"
 	"github.com/stretchr/testify/assert"
+	nethttp "net/http"
+	"os"
+	"strconv"
+	"testing"
 )
 
 var inventoryapi_http_url string
@@ -29,9 +28,7 @@ func TestMain(m *testing.M) {
 		log.Error(err)
 		inventoryapi_http_url = "localhost:8081"
 	}
-
 	insecure = true
-
 	insecureTLSstr := os.Getenv("INV_TLS_INSECURE")
 	if insecureTLSstr != "" {
 		var err error
@@ -40,7 +37,6 @@ func TestMain(m *testing.M) {
 			log.Errorf("faild to parse bool INV_TLS_INSECURE %s", err)
 		}
 	}
-
 	certFile := os.Getenv("INV_TLS_CERT_FILE")
 	keyFile := os.Getenv("INV_TLS_KEY_FILE")
 	caFile := os.Getenv("INV_TLS_CA_FILE")
@@ -50,18 +46,15 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			log.Errorf("failed to load client certificate: %v", err)
 		}
-
 		// Load CA cert
 		caCert, err := os.ReadFile(caFile)
 		if err != nil {
 			log.Errorf("failed to read CA certificate: %v", err)
 		}
-
 		caCertPool := x509.NewCertPool()
 		if !caCertPool.AppendCertsFromPEM(caCert) {
 			log.Errorf("failed to append CA certificate")
 		}
-
 		tlsConfig = &tls.Config{
 			Certificates: []tls.Certificate{cert},
 			RootCAs:      caCertPool,
@@ -70,11 +63,9 @@ func TestMain(m *testing.M) {
 		insecure = true
 		log.Info("TLS environment variables not set")
 	}
-
 	result := m.Run()
 	os.Exit(result)
 }
-
 func TestInventoryAPIHTTP_Livez(t *testing.T) {
 	t.Parallel()
 	httpClient, err := http.NewClient(
@@ -84,20 +75,15 @@ func TestInventoryAPIHTTP_Livez(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to create HTTP client: ", err)
 	}
-
 	healthClient := v1.NewKesselInventoryHealthServiceHTTPClient(httpClient)
 	resp, err := healthClient.GetLivez(context.Background(), &v1.GetLivezRequest{})
-
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
-
 	expectedStatus := "OK"
 	expectedCode := uint32(200)
-
 	assert.Equal(t, expectedStatus, resp.Status)
 	assert.Equal(t, expectedCode, resp.Code)
 }
-
 func TestInventoryAPIHTTP_Readyz(t *testing.T) {
 	t.Parallel()
 	httpClient, err := http.NewClient(
@@ -107,33 +93,25 @@ func TestInventoryAPIHTTP_Readyz(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to create HTTP client: ", err)
 	}
-
 	healthClient := v1.NewKesselInventoryHealthServiceHTTPClient(httpClient)
 	resp, err := healthClient.GetReadyz(context.Background(), &v1.GetReadyzRequest{})
-
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
-
 	expectedStatus := "Storage type postgres"
 	expectedCode := uint32(200)
-
 	assert.Equal(t, expectedStatus, resp.Status)
 	assert.Equal(t, expectedCode, resp.Code)
 }
-
 func TestInventoryAPIHTTP_Metrics(t *testing.T) {
 	resp, err := nethttp.Get("http://" + inventoryapi_http_url + "/metrics")
 	if err != nil {
 		t.Fatal("Failed to send request: ", err)
 	}
 	defer resp.Body.Close()
-
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
-
 	expectedStatusCode := 200
 	expectedStatusString := "200 OK"
-
 	assert.Equal(t, expectedStatusCode, resp.StatusCode)
 	assert.Equal(t, expectedStatusString, resp.Status)
 }
@@ -154,58 +132,58 @@ func TestInventoryAPIHTTP_RHELHostLifecycle(t *testing.T) {
 		RhelHost: &resources.RhelHost{
 			Metadata: &resources.Metadata{
 				ResourceType: "rhel_host",
-				WorkspaceId:  "workspace0",
+				WorkspaceId:  "workspace",
 				OrgId:        "",
 			},
 			ReporterData: &resources.ReporterData{
-				ReporterInstanceId: "user@email.com",
+				ReporterInstanceId: "user@example.com",
 				ReporterType:       resources.ReporterData_OCM,
-				ConsoleHref:        "www.web.com",
-				ApiHref:            "www.wb.com",
+				ConsoleHref:        "www.example.com",
+				ApiHref:            "www.example.com",
 				LocalResourceId:    "0123",
-				ReporterVersion:    "0.2",
+				ReporterVersion:    "0.1",
 			},
 		},
 	}
 	opts := getCallOptions()
 	_, err = client.RhelHostServiceClient.CreateRhelHost(context.Background(), &createRequest, opts...)
-	assert.NoError(t, err)
+	assert.NoError(t, err, "Failed to create RhelHost")
 
 	updateRequest := resources.UpdateRhelHostRequest{
 		RhelHost: &resources.RhelHost{
 			Metadata: &resources.Metadata{
 				ResourceType: "rhel_host",
-				WorkspaceId:  "workspace0",
+				WorkspaceId:  "workspace",
 				OrgId:        "",
 			},
 			ReporterData: &resources.ReporterData{
-				ReporterInstanceId: "user@email.com",
+				ReporterInstanceId: "user@example.com",
 				ReporterType:       resources.ReporterData_OCM,
-				ConsoleHref:        "www.web.com",
-				ApiHref:            "www.wb.com",
+				ConsoleHref:        "www.example.com",
+				ApiHref:            "www.example.com",
 				LocalResourceId:    "0123",
-				ReporterVersion:    "0.2",
+				ReporterVersion:    "0.1",
 			},
 		},
 	}
 	_, err = client.RhelHostServiceClient.UpdateRhelHost(context.Background(), &updateRequest, opts...)
-	assert.NoError(t, err)
+	assert.NoError(t, err, "Failed to update RhelHost")
 
 	deleteRequest := resources.DeleteRhelHostRequest{
 		ReporterData: &resources.ReporterData{
-			ReporterInstanceId: "user@email.com",
+			ReporterInstanceId: "user@example.com",
 			ReporterType:       resources.ReporterData_OCM,
-			ConsoleHref:        "www.web.com",
-			ApiHref:            "www.wb.com",
+			ConsoleHref:        "www.example.com",
+			ApiHref:            "www.example.com",
 			LocalResourceId:    "0123",
-			ReporterVersion:    "0.2",
+			ReporterVersion:    "0.1",
 		},
 	}
 	_, err = client.RhelHostServiceClient.DeleteRhelHost(context.Background(), &deleteRequest, opts...)
-	assert.NoError(t, err)
+	assert.NoError(t, err, "Failed to delete RhelHost")
 }
 
-func TestInventoryAPIHTTP_K8SCluster_CreateK8SCluster(t *testing.T) {
+func TestInventoryAPIHTTP_K8SClusterLifecycle(t *testing.T) {
 	t.Parallel()
 	c := v1beta1.NewConfig(
 		v1beta1.WithHTTPUrl(inventoryapi_http_url),
@@ -220,60 +198,6 @@ func TestInventoryAPIHTTP_K8SCluster_CreateK8SCluster(t *testing.T) {
 		K8SCluster: &resources.K8SCluster{
 			Metadata: &resources.Metadata{
 				ResourceType: "k8s_cluster",
-				WorkspaceId:  "",
-				OrgId:        "",
-			},
-			ResourceData: &resources.K8SClusterDetail{
-				ExternalClusterId: "01234",
-				ClusterStatus:     resources.K8SClusterDetail_READY,
-				KubeVersion:       "1.31",
-				KubeVendor:        resources.K8SClusterDetail_OPENSHIFT,
-				VendorVersion:     "4.16",
-				CloudPlatform:     resources.K8SClusterDetail_AWS_UPI,
-				Nodes: []*resources.K8SClusterDetailNodesInner{
-					{
-						Name:   "www.web.com",
-						Cpu:    "7500m",
-						Memory: "30973224Ki",
-						Labels: []*resources.ResourceLabel{
-							{
-								Key:   "has_monster_gpu",
-								Value: "no",
-							},
-						},
-					},
-				},
-			},
-			ReporterData: &resources.ReporterData{
-				ReporterInstanceId: "user@example.com",
-				ReporterType:       resources.ReporterData_ACM,
-				ConsoleHref:        "www.example.com",
-				ApiHref:            "www.example.com",
-				LocalResourceId:    "01234",
-				ReporterVersion:    "0.1",
-			},
-		},
-	}
-	opts := getCallOptions()
-	_, err = client.K8sClusterService.CreateK8SCluster(context.Background(), &request, opts...)
-	assert.NoError(t, err)
-}
-
-func TestInventoryAPIHTTP_K8SCluster_UpdateK8SCluster(t *testing.T) {
-	t.Parallel()
-	c := v1beta1.NewConfig(
-		v1beta1.WithHTTPUrl(inventoryapi_http_url),
-		v1beta1.WithTLSInsecure(insecure),
-		v1beta1.WithHTTPTLSConfig(tlsConfig),
-	)
-	client, err := v1beta1.NewHttpClient(context.Background(), c)
-	if err != nil {
-		t.Error(err)
-	}
-	request := resources.UpdateK8SClusterRequest{
-		K8SCluster: &resources.K8SCluster{
-			Metadata: &resources.Metadata{
-				ResourceType: "k8s-cluster",
 				WorkspaceId:  "workspace1",
 				OrgId:        "",
 			},
@@ -309,51 +233,66 @@ func TestInventoryAPIHTTP_K8SCluster_UpdateK8SCluster(t *testing.T) {
 		},
 	}
 	opts := getCallOptions()
-	_, err = client.K8sClusterService.UpdateK8SCluster(context.Background(), &request, opts...)
-	assert.NoError(t, err)
+	_, err = client.K8sClusterService.CreateK8SCluster(context.Background(), &request, opts...)
+	assert.NoError(t, err, "Failed to create K8sCluster")
 
-}
-
-func TestInventoryAPIHTTP_K8SPolicy_CreateK8SPolicy(t *testing.T) {
-	t.Parallel()
-	c := v1beta1.NewConfig(
-		v1beta1.WithHTTPUrl(inventoryapi_http_url),
-		v1beta1.WithTLSInsecure(insecure),
-		v1beta1.WithHTTPTLSConfig(tlsConfig),
-	)
-	client, err := v1beta1.NewHttpClient(context.Background(), c)
-	if err != nil {
-		t.Error(err)
-	}
-
-	request := resources.CreateK8SPolicyRequest{
-		K8SPolicy: &resources.K8SPolicy{
+	updateRequest := resources.UpdateK8SClusterRequest{
+		K8SCluster: &resources.K8SCluster{
 			Metadata: &resources.Metadata{
-				ResourceType: "k8s_policy",
-				WorkspaceId:  "default",
+				ResourceType: "k8s_cluster",
+				WorkspaceId:  "workspace1",
 				OrgId:        "",
 			},
-			ResourceData: &resources.K8SPolicyDetail{
-				Disabled: false,
-				Severity: resources.K8SPolicyDetail_HIGH,
+			ResourceData: &resources.K8SClusterDetail{
+				ExternalClusterId: "01234",
+				ClusterStatus:     resources.K8SClusterDetail_READY,
+				KubeVersion:       "1.31",
+				KubeVendor:        resources.K8SClusterDetail_OPENSHIFT,
+				VendorVersion:     "4.16",
+				CloudPlatform:     resources.K8SClusterDetail_AWS_UPI,
+				Nodes: []*resources.K8SClusterDetailNodesInner{
+					{
+						Name:   "www.web.com",
+						Cpu:    "7500m",
+						Memory: "30973224Ki",
+						Labels: []*resources.ResourceLabel{
+							{
+								Key:   "has_monster_gpu",
+								Value: "no",
+							},
+						},
+					},
+				},
 			},
 			ReporterData: &resources.ReporterData{
 				ReporterInstanceId: "user@example.com",
-				ReporterType:       resources.ReporterData_OCM,
+				ReporterType:       resources.ReporterData_ACM,
 				ConsoleHref:        "www.example.com",
 				ApiHref:            "www.example.com",
-				LocalResourceId:    "012345",
+				LocalResourceId:    "01234",
 				ReporterVersion:    "0.1",
 			},
 		},
 	}
-	opts := getCallOptions()
-	_, err = client.PolicyServiceClient.CreateK8SPolicy(context.Background(), &request, opts...)
-	assert.NoError(t, err)
 
+	_, err = client.K8sClusterService.UpdateK8SCluster(context.Background(), &updateRequest, opts...)
+	assert.NoError(t, err, "Failed to update K8sCluster")
+
+	deleteRequest := resources.DeleteK8SClusterRequest{
+		ReporterData: &resources.ReporterData{
+			ReporterInstanceId: "user@example.com",
+			ReporterType:       resources.ReporterData_ACM,
+			ConsoleHref:        "www.example.com",
+			ApiHref:            "www.example.com",
+			LocalResourceId:    "01234",
+			ReporterVersion:    "0.1",
+		},
+	}
+	_, err = client.K8sClusterService.DeleteK8SCluster(context.Background(), &deleteRequest, opts...)
+	assert.NoError(t, err, "Failed to delete K8sCluster")
 }
 
-func TestInventoryAPIHTTP_K8SPolicy_UpdateK8SPolicy(t *testing.T) {
+func TestInventoryAPIHTTP_K8SPolicyLifecycle(t *testing.T) {
 	t.Parallel()
 	c := v1beta1.NewConfig(
 		v1beta1.WithHTTPUrl(inventoryapi_http_url),
@@ -364,11 +303,10 @@ func TestInventoryAPIHTTP_K8SPolicy_UpdateK8SPolicy(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
-	request := resources.UpdateK8SPolicyRequest{
+	request := resources.CreateK8SPolicyRequest{
 		K8SPolicy: &resources.K8SPolicy{
 			Metadata: &resources.Metadata{
-				ResourceType: "k8s-policy",
+				ResourceType: "k8s_policy",
 				WorkspaceId:  "workspace2",
 				OrgId:        "",
 			},
@@ -387,9 +325,46 @@ func TestInventoryAPIHTTP_K8SPolicy_UpdateK8SPolicy(t *testing.T) {
 		},
 	}
 	opts := getCallOptions()
-	_, err = client.PolicyServiceClient.UpdateK8SPolicy(context.Background(), &request, opts...)
-	assert.NoError(t, err)
+	_, err = client.PolicyServiceClient.CreateK8SPolicy(context.Background(), &request, opts...)
+	assert.NoError(t, err, "Failed to create K8sPolicy")
 
+	updateRequest := resources.UpdateK8SPolicyRequest{
+		K8SPolicy: &resources.K8SPolicy{
+			Metadata: &resources.Metadata{
+				ResourceType: "k8s_policy",
+				WorkspaceId:  "workspace2",
+				OrgId:        "",
+			},
+			ResourceData: &resources.K8SPolicyDetail{
+				Disabled: true,
+				Severity: resources.K8SPolicyDetail_LOW,
+			},
+			ReporterData: &resources.ReporterData{
+				ReporterInstanceId: "user@example.com",
+				ReporterType:       resources.ReporterData_OCM,
+				ConsoleHref:        "www.example.com",
+				ApiHref:            "www.example.com",
+				LocalResourceId:    "012345",
+				ReporterVersion:    "0.1",
+			},
+		},
+	}
+
+	_, err = client.PolicyServiceClient.UpdateK8SPolicy(context.Background(), &updateRequest, opts...)
+	assert.NoError(t, err, "Failed to update K8sPolicy")
+
+	deleteRequest := resources.DeleteK8SPolicyRequest{
+		ReporterData: &resources.ReporterData{
+			ReporterInstanceId: "user@example.com",
+			ReporterType:       resources.ReporterData_OCM,
+			ConsoleHref:        "www.example.com",
+			ApiHref:            "www.example.com",
+			LocalResourceId:    "012345",
+			ReporterVersion:    "0.1",
+		},
+	}
+	_, err = client.PolicyServiceClient.DeleteK8SPolicy(context.Background(), &deleteRequest, opts...)
+	assert.NoError(t, err, "Failed to delete K8sPolicy")
 }
 
 func getCallOptions() []http.CallOption {

--- a/test/e2e/inventory_http_test.go
+++ b/test/e2e/inventory_http_test.go
@@ -156,18 +156,83 @@ func TestInventoryAPIHTTP_CreateRHELHost(t *testing.T) {
 			OrgId:        "",
 		},
 		ReporterData: &resources.ReporterData{
-			ReporterInstanceId: "user@example.com",
+			ReporterInstanceId: "user@email.com",
 			ReporterType:       resources.ReporterData_OCM,
-			ConsoleHref:        "www.example.com",
-			ApiHref:            "www.example.com",
-			LocalResourceId:    "1",
-			ReporterVersion:    "0.1",
+			ConsoleHref:        "www.web.com",
+			ApiHref:            "www.wb.com",
+			LocalResourceId:    "0123",
+			ReporterVersion:    "0.2",
 		},
 	}}
 	opts := getCallOptions()
 	_, err = client.RhelHostServiceClient.CreateRhelHost(context.Background(), &request, opts...)
 	assert.NoError(t, err)
 
+}
+
+func TestInventoryAPIHTTP_UpdateRHELHost(t *testing.T) {
+	t.Parallel()
+	c := v1beta1.NewConfig(
+		v1beta1.WithHTTPUrl(inventoryapi_http_url),
+		v1beta1.WithTLSInsecure(insecure),
+		v1beta1.WithHTTPTLSConfig(tlsConfig),
+	)
+	client, err := v1beta1.NewHttpClient(context.Background(), c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	reporterData := &resources.ReporterData{
+		ReporterInstanceId: "user@email.com",
+		ReporterType:       resources.ReporterData_OCM,
+		ConsoleHref:        "www.web.com",
+		ApiHref:            "www.wb.com",
+		LocalResourceId:    "0123",
+		ReporterVersion:    "0.2",
+	}
+
+	request := resources.UpdateRhelHostRequest{RhelHost: &resources.RhelHost{
+		Metadata: &resources.Metadata{
+			ResourceType: "rhel-host",
+			WorkspaceId:  "workspace0",
+			OrgId:        "",
+		},
+		ReporterData: reporterData,
+	}}
+	opts := getCallOptions()
+	_, err = client.RhelHostServiceClient.UpdateRhelHost(context.Background(), &request, opts...)
+	assert.NoError(t, err)
+
+}
+
+func TestInventoryAPIHTTP_DeleteRHELHost(t *testing.T) {
+	t.Parallel()
+	c := v1beta1.NewConfig(
+		v1beta1.WithHTTPUrl(inventoryapi_http_url),
+		v1beta1.WithTLSInsecure(insecure),
+		v1beta1.WithHTTPTLSConfig(tlsConfig),
+	)
+	client, err := v1beta1.NewHttpClient(context.Background(), c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	reporter := &resources.ReporterData{
+		ReporterInstanceId: "user@email.com",
+		ReporterType:       resources.ReporterData_OCM,
+		ConsoleHref:        "www.web.com",
+		ApiHref:            "www.wb.com",
+		LocalResourceId:    "0123",
+		ReporterVersion:    "0.2",
+	}
+
+	request1 := resources.DeleteRhelHostRequest{
+		ReporterData: reporter,
+	}
+
+	opts := getCallOptions()
+	_, err = client.RhelHostServiceClient.DeleteRhelHost(context.Background(), &request1, opts...)
+	assert.NoError(t, err)
 }
 
 func TestInventoryAPIHTTP_K8SCluster_CreateK8SCluster(t *testing.T) {
@@ -189,7 +254,7 @@ func TestInventoryAPIHTTP_K8SCluster_CreateK8SCluster(t *testing.T) {
 				OrgId:        "",
 			},
 			ResourceData: &resources.K8SClusterDetail{
-				ExternalClusterId: "1234",
+				ExternalClusterId: "01234",
 				ClusterStatus:     resources.K8SClusterDetail_READY,
 				KubeVersion:       "1.31",
 				KubeVendor:        resources.K8SClusterDetail_OPENSHIFT,
@@ -197,13 +262,13 @@ func TestInventoryAPIHTTP_K8SCluster_CreateK8SCluster(t *testing.T) {
 				CloudPlatform:     resources.K8SClusterDetail_AWS_UPI,
 				Nodes: []*resources.K8SClusterDetailNodesInner{
 					{
-						Name:   "www.example.com",
+						Name:   "www.web.com",
 						Cpu:    "7500m",
 						Memory: "30973224Ki",
 						Labels: []*resources.ResourceLabel{
 							{
 								Key:   "has_monster_gpu",
-								Value: "yes",
+								Value: "no",
 							},
 						},
 					},
@@ -214,7 +279,7 @@ func TestInventoryAPIHTTP_K8SCluster_CreateK8SCluster(t *testing.T) {
 				ReporterType:       resources.ReporterData_ACM,
 				ConsoleHref:        "www.example.com",
 				ApiHref:            "www.example.com",
-				LocalResourceId:    "1",
+				LocalResourceId:    "01234",
 				ReporterVersion:    "0.1",
 			},
 		},
@@ -222,6 +287,61 @@ func TestInventoryAPIHTTP_K8SCluster_CreateK8SCluster(t *testing.T) {
 	opts := getCallOptions()
 	_, err = client.K8sClusterService.CreateK8SCluster(context.Background(), &request, opts...)
 	assert.NoError(t, err)
+}
+
+func TestInventoryAPIHTTP_K8SCluster_UpdateK8SCluster(t *testing.T) {
+	t.Parallel()
+	c := v1beta1.NewConfig(
+		v1beta1.WithHTTPUrl(inventoryapi_http_url),
+		v1beta1.WithTLSInsecure(insecure),
+		v1beta1.WithHTTPTLSConfig(tlsConfig),
+	)
+	client, err := v1beta1.NewHttpClient(context.Background(), c)
+	if err != nil {
+		t.Error(err)
+	}
+	request := resources.UpdateK8SClusterRequest{
+		K8SCluster: &resources.K8SCluster{
+			Metadata: &resources.Metadata{
+				ResourceType: "k8s-cluster",
+				WorkspaceId:  "workspace1",
+				OrgId:        "",
+			},
+			ResourceData: &resources.K8SClusterDetail{
+				ExternalClusterId: "01234",
+				ClusterStatus:     resources.K8SClusterDetail_READY,
+				KubeVersion:       "1.31",
+				KubeVendor:        resources.K8SClusterDetail_OPENSHIFT,
+				VendorVersion:     "4.16",
+				CloudPlatform:     resources.K8SClusterDetail_AWS_UPI,
+				Nodes: []*resources.K8SClusterDetailNodesInner{
+					{
+						Name:   "www.web.com",
+						Cpu:    "7500m",
+						Memory: "30973224Ki",
+						Labels: []*resources.ResourceLabel{
+							{
+								Key:   "has_monster_gpu",
+								Value: "no",
+							},
+						},
+					},
+				},
+			},
+			ReporterData: &resources.ReporterData{
+				ReporterInstanceId: "user@example.com",
+				ReporterType:       resources.ReporterData_ACM,
+				ConsoleHref:        "www.example.com",
+				ApiHref:            "www.example.com",
+				LocalResourceId:    "01234",
+				ReporterVersion:    "0.1",
+			},
+		},
+	}
+	opts := getCallOptions()
+	_, err = client.K8sClusterService.UpdateK8SCluster(context.Background(), &request, opts...)
+	assert.NoError(t, err)
+
 }
 
 func TestInventoryAPIHTTP_K8SPolicy_CreateK8SPolicy(t *testing.T) {
@@ -244,21 +364,60 @@ func TestInventoryAPIHTTP_K8SPolicy_CreateK8SPolicy(t *testing.T) {
 				OrgId:        "",
 			},
 			ResourceData: &resources.K8SPolicyDetail{
-				Disabled: true,
-				Severity: resources.K8SPolicyDetail_MEDIUM,
+				Disabled: false,
+				Severity: resources.K8SPolicyDetail_HIGH,
 			},
 			ReporterData: &resources.ReporterData{
 				ReporterInstanceId: "user@example.com",
-				ReporterType:       resources.ReporterData_ACM,
+				ReporterType:       resources.ReporterData_OCM,
 				ConsoleHref:        "www.example.com",
 				ApiHref:            "www.example.com",
-				LocalResourceId:    "1",
+				LocalResourceId:    "012345",
 				ReporterVersion:    "0.1",
 			},
 		},
 	}
 	opts := getCallOptions()
 	_, err = client.PolicyServiceClient.CreateK8SPolicy(context.Background(), &request, opts...)
+	assert.NoError(t, err)
+
+}
+
+func TestInventoryAPIHTTP_K8SPolicy_UpdateK8SPolicy(t *testing.T) {
+	t.Parallel()
+	c := v1beta1.NewConfig(
+		v1beta1.WithHTTPUrl(inventoryapi_http_url),
+		v1beta1.WithTLSInsecure(insecure),
+		v1beta1.WithHTTPTLSConfig(tlsConfig),
+	)
+	client, err := v1beta1.NewHttpClient(context.Background(), c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	request := resources.UpdateK8SPolicyRequest{
+		K8SPolicy: &resources.K8SPolicy{
+			Metadata: &resources.Metadata{
+				ResourceType: "k8s-policy",
+				WorkspaceId:  "workspace2",
+				OrgId:        "",
+			},
+			ResourceData: &resources.K8SPolicyDetail{
+				Disabled: false,
+				Severity: resources.K8SPolicyDetail_HIGH,
+			},
+			ReporterData: &resources.ReporterData{
+				ReporterInstanceId: "user@example.com",
+				ReporterType:       resources.ReporterData_OCM,
+				ConsoleHref:        "www.example.com",
+				ApiHref:            "www.example.com",
+				LocalResourceId:    "012345",
+				ReporterVersion:    "0.1",
+			},
+		},
+	}
+	opts := getCallOptions()
+	_, err = client.PolicyServiceClient.UpdateK8SPolicy(context.Background(), &request, opts...)
 	assert.NoError(t, err)
 
 }

--- a/test/e2e/inventory_http_test.go
+++ b/test/e2e/inventory_http_test.go
@@ -8,13 +8,16 @@ import (
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/transport/http"
 	v1 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1"
+	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1/relationships"
 	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1/resources"
 	"github.com/project-kessel/inventory-client-go/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	nethttp "net/http"
 	"os"
 	"strconv"
 	"testing"
+	"time"
 )
 
 var inventoryapi_http_url string
@@ -365,6 +368,142 @@ func TestInventoryAPIHTTP_K8SPolicyLifecycle(t *testing.T) {
 	}
 	_, err = client.PolicyServiceClient.DeleteK8SPolicy(context.Background(), &deleteRequest, opts...)
 	assert.NoError(t, err, "Failed to delete K8sPolicy")
+}
+
+func TestInventoryAPIHTTP_K8SPolicy_is_propagated_to_K8sClusterLifecycle(t *testing.T) {
+	t.Parallel()
+	c := v1beta1.NewConfig(
+		v1beta1.WithHTTPUrl(inventoryapi_http_url),
+		v1beta1.WithTLSInsecure(insecure),
+		v1beta1.WithHTTPTLSConfig(tlsConfig),
+	)
+	client, err := v1beta1.NewHttpClient(context.Background(), c)
+	if err != nil {
+		t.Error(err)
+	}
+	request := resources.CreateK8SPolicyRequest{
+		K8SPolicy: &resources.K8SPolicy{
+			Metadata: &resources.Metadata{
+				ResourceType: "k8s_policy",
+				WorkspaceId:  "workspace2",
+				OrgId:        "",
+			},
+			ResourceData: &resources.K8SPolicyDetail{
+				Disabled: false,
+				Severity: resources.K8SPolicyDetail_HIGH,
+			},
+			ReporterData: &resources.ReporterData{
+				ReporterInstanceId: "user@example.com",
+				ReporterType:       resources.ReporterData_ACM,
+				ConsoleHref:        "www.example.com",
+				ApiHref:            "www.example.com",
+				LocalResourceId:    "789",
+				ReporterVersion:    "0.1",
+			},
+		},
+	}
+	opts := getCallOptions()
+	_, err = client.PolicyServiceClient.CreateK8SPolicy(context.Background(), &request, opts...)
+	assert.NoError(t, err, "Failed to create K8sPolicy")
+
+	request1 := resources.CreateK8SClusterRequest{
+		K8SCluster: &resources.K8SCluster{
+			Metadata: &resources.Metadata{
+				ResourceType: "k8s_cluster",
+				WorkspaceId:  "workspace2",
+				OrgId:        "",
+			},
+			ResourceData: &resources.K8SClusterDetail{
+				ExternalClusterId: "01234",
+				ClusterStatus:     resources.K8SClusterDetail_READY,
+				KubeVersion:       "1.31",
+				KubeVendor:        resources.K8SClusterDetail_OPENSHIFT,
+				VendorVersion:     "4.16",
+				CloudPlatform:     resources.K8SClusterDetail_AWS_UPI,
+				Nodes: []*resources.K8SClusterDetailNodesInner{
+					{
+						Name:   "www.web.com",
+						Cpu:    "7500m",
+						Memory: "30973224Ki",
+						Labels: []*resources.ResourceLabel{
+							{
+								Key:   "has_a_monster_gpu",
+								Value: "no",
+							},
+						},
+					},
+				},
+			},
+			ReporterData: &resources.ReporterData{
+				ReporterInstanceId: "user@example.com",
+				ReporterType:       resources.ReporterData_ACM,
+				ConsoleHref:        "www.example.com",
+				ApiHref:            "www.example.com",
+				LocalResourceId:    "987",
+				ReporterVersion:    "0.1",
+			},
+		},
+	}
+	_, err = client.K8sClusterService.CreateK8SCluster(context.Background(), &request1, opts...)
+	assert.NoError(t, err, "Failed to create K8sCluster")
+
+	requestRelationship := relationships.CreateK8SPolicyIsPropagatedToK8SClusterRequest{
+		K8SpolicyIspropagatedtoK8Scluster: &relationships.K8SPolicyIsPropagatedToK8SCluster{
+			Metadata: &relationships.Metadata{
+				RelationshipType: "k8spolicy_ispropagatedto_k8scluster",
+				OrgId:            "",
+				CreatedAt:        timestamppb.New(time.Now()),
+				UpdatedAt:        timestamppb.New(time.Now()),
+			},
+			ReporterData: &relationships.ReporterData{
+				ReporterType:           relationships.ReporterData_ACM,
+				ReporterVersion:        "0.1",
+				SubjectLocalResourceId: "789", // LocalResourceID of K8SPolicy
+				ObjectLocalResourceId:  "987", // LocalResourceID of K8SCluster
+			},
+			RelationshipData: &relationships.K8SPolicyIsPropagatedToK8SClusterDetail{
+				Status: relationships.K8SPolicyIsPropagatedToK8SClusterDetail_NO_VIOLATIONS,
+			},
+		},
+	}
+
+	_, err = client.K8SPolicyIsPropagatedToK8SClusterServiceHTTPClient.CreateK8SPolicyIsPropagatedToK8SCluster(context.Background(), &requestRelationship, opts...)
+	assert.NoError(t, err, "Failed to create relationship between K8sPolicy and K8sCluster")
+
+	updateRequest := relationships.UpdateK8SPolicyIsPropagatedToK8SClusterRequest{
+		K8SpolicyIspropagatedtoK8Scluster: &relationships.K8SPolicyIsPropagatedToK8SCluster{
+			Metadata: &relationships.Metadata{
+				RelationshipType: "k8spolicy_ispropagatedto_k8scluster",
+				OrgId:            "",
+				CreatedAt:        timestamppb.New(time.Now()),
+				UpdatedAt:        timestamppb.New(time.Now()),
+			},
+			ReporterData: &relationships.ReporterData{
+				ReporterType:           relationships.ReporterData_ACM,
+				ReporterVersion:        "0.1",
+				SubjectLocalResourceId: "789", // LocalResourceID of K8SPolicy
+				ObjectLocalResourceId:  "987", // LocalResourceID of K8SCluster
+			},
+			RelationshipData: &relationships.K8SPolicyIsPropagatedToK8SClusterDetail{
+				Status: relationships.K8SPolicyIsPropagatedToK8SClusterDetail_VIOLATIONS,
+			},
+		},
+	}
+
+	_, err = client.K8SPolicyIsPropagatedToK8SClusterServiceHTTPClient.UpdateK8SPolicyIsPropagatedToK8SCluster(context.Background(), &updateRequest, opts...)
+	assert.NoError(t, err, "Failed to update relationship between K8sPolicy and K8sCluster")
+
+	deleteRequest := relationships.DeleteK8SPolicyIsPropagatedToK8SClusterRequest{
+		ReporterData: &relationships.ReporterData{
+			ReporterType:           relationships.ReporterData_ACM,
+			ReporterVersion:        "0.1",
+			SubjectLocalResourceId: "789", // LocalResourceID of K8SPolicy
+			ObjectLocalResourceId:  "987", // LocalResourceID of K8SCluster
+		},
+	}
+
+	_, err = client.K8SPolicyIsPropagatedToK8SClusterServiceHTTPClient.DeleteK8SPolicyIsPropagatedToK8SCluster(context.Background(), &deleteRequest, opts...)
+	assert.NoError(t, err, "Failed to delete relationship between K8sPolicy and K8sCluster")
 }
 
 func getCallOptions() []http.CallOption {

--- a/test/e2e/inventory_http_test.go
+++ b/test/e2e/inventory_http_test.go
@@ -137,7 +137,7 @@ func TestInventoryAPIHTTP_RHELHostLifecycle(t *testing.T) {
 			},
 			ReporterData: &resources.ReporterData{
 				ReporterInstanceId: "user@example.com",
-				ReporterType:       resources.ReporterData_OCM,
+				ReporterType:       resources.ReporterData_ACM,
 				ConsoleHref:        "www.example.com",
 				ApiHref:            "www.example.com",
 				LocalResourceId:    "0123",
@@ -158,7 +158,7 @@ func TestInventoryAPIHTTP_RHELHostLifecycle(t *testing.T) {
 			},
 			ReporterData: &resources.ReporterData{
 				ReporterInstanceId: "user@example.com",
-				ReporterType:       resources.ReporterData_OCM,
+				ReporterType:       resources.ReporterData_ACM,
 				ConsoleHref:        "www.example.com",
 				ApiHref:            "www.example.com",
 				LocalResourceId:    "0123",
@@ -172,7 +172,7 @@ func TestInventoryAPIHTTP_RHELHostLifecycle(t *testing.T) {
 	deleteRequest := resources.DeleteRhelHostRequest{
 		ReporterData: &resources.ReporterData{
 			ReporterInstanceId: "user@example.com",
-			ReporterType:       resources.ReporterData_OCM,
+			ReporterType:       resources.ReporterData_ACM,
 			ConsoleHref:        "www.example.com",
 			ApiHref:            "www.example.com",
 			LocalResourceId:    "0123",
@@ -316,7 +316,7 @@ func TestInventoryAPIHTTP_K8SPolicyLifecycle(t *testing.T) {
 			},
 			ReporterData: &resources.ReporterData{
 				ReporterInstanceId: "user@example.com",
-				ReporterType:       resources.ReporterData_OCM,
+				ReporterType:       resources.ReporterData_ACM,
 				ConsoleHref:        "www.example.com",
 				ApiHref:            "www.example.com",
 				LocalResourceId:    "012345",
@@ -341,7 +341,7 @@ func TestInventoryAPIHTTP_K8SPolicyLifecycle(t *testing.T) {
 			},
 			ReporterData: &resources.ReporterData{
 				ReporterInstanceId: "user@example.com",
-				ReporterType:       resources.ReporterData_OCM,
+				ReporterType:       resources.ReporterData_ACM,
 				ConsoleHref:        "www.example.com",
 				ApiHref:            "www.example.com",
 				LocalResourceId:    "012345",
@@ -356,7 +356,7 @@ func TestInventoryAPIHTTP_K8SPolicyLifecycle(t *testing.T) {
 	deleteRequest := resources.DeleteK8SPolicyRequest{
 		ReporterData: &resources.ReporterData{
 			ReporterInstanceId: "user@example.com",
-			ReporterType:       resources.ReporterData_OCM,
+			ReporterType:       resources.ReporterData_ACM,
 			ConsoleHref:        "www.example.com",
 			ApiHref:            "www.example.com",
 			LocalResourceId:    "012345",


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Fixes e2e test pipeline so that it fails when the tests fail (it would previously pass when tests fail)
- Added update and delete test cases for resources
- Added test cases for relationships
- Combined create, update and deletes into their own functions to ensure they execute in the correct order


Tested using:
```sh
make inventory-up-kind
kubectl get pods
kubectl logs e2e-inventory-http-tests-<pod-id>
make inventory-down-kind
```


## Ticket reference (if applicable)
Fixes [RHCLOUD-35836](https://issues.redhat.com/browse/RHCLOUD-35836)

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

