### PR TITLE
Test buf-action can comment on PRs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,3 +14,4 @@ jobs:
           lint: true
           breaking: true
           input: "api"
+          pr_comment: true


### PR DESCRIPTION
Only testing github actions permissions. Do not merge.

[Default value](https://github.com/bufbuild/buf-action/blob/d5697c6563d51b0247005e9ef64e97277de3a8f5/action.yml#L61) of `pr_comment` for this action is:

`default: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}` which evalutes to false on PRs from forked repos.

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

