### PR TITLE
Align Resource ID Definitions Between Eventing API and Inventory API

### DIFF
--- a/internal/eventing/api/event.go
+++ b/internal/eventing/api/event.go
@@ -59,7 +59,7 @@ type ResourceReporter struct {
 }
 
 type RelationshipMetadata struct {
-	Id               string     `json:"id"`
+	Id               int64      `json:"id"`
 	RelationshipType string     `json:"relationship_type"`
 	CreatedAt        *time.Time `json:"created_at,omitempty"`
 	UpdatedAt        *time.Time `json:"updated_at,omitempty"`

--- a/internal/eventing/api/event.go
+++ b/internal/eventing/api/event.go
@@ -2,10 +2,11 @@ package api
 
 import (
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/project-kessel/inventory-api/internal/biz/model"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/project-kessel/inventory-api/internal/biz/model"
 )
 
 // Todo: get rid of this Event and have an Event (as event output) with all the assignments going on the New* functions
@@ -33,7 +34,7 @@ type RelationshipData struct {
 }
 
 type ResourceMetadata struct {
-	Id           string          `json:"id"`
+	Id           int64           `json:"id"`
 	ResourceType string          `json:"resource_type"`
 	OrgId        string          `json:"org_id"`
 	CreatedAt    *time.Time      `json:"created_at,omitempty"`


### PR DESCRIPTION
### PR Template:

## Describe your changes

While attempting to decode events by the [eventing api](https://github.com/project-kessel/inventory-api/blob/main/internal/eventing/api/event.go#L23), I encountered the following error

`json: cannot unmarshal number into Go struct field ResourceMetadata.metadata.id of type string`

This issue arises because the [resource ID in the eventing API](https://github.com/project-kessel/inventory-api/blob/main/internal/eventing/api/event.go#L23) differs from the [resource ID in the inventory API](https://github.com/project-kessel/inventory-api/blob/main/api/kessel/inventory/v1beta1/resources/metadata.pb.go#L31)

This PR aligns the definitions of `resource ID` in both APIs to ensure compatibility and resolve the encoding/decoding issue

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

