### PR TITLE
update resource type from notifications-integration to integration

### DIFF
--- a/internal/service/resources/notificationsintegrations/notificationsintegrations.go
+++ b/internal/service/resources/notificationsintegrations/notificationsintegrations.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	ResourceType = "notifications-integration"
+	ResourceType = "integration"
 )
 
 // NotificationsIntegrationsService handles requests for Notifications Integrations


### PR DESCRIPTION
### PR Template:

## Describe your changes
Updating resource type for notifications from `notificaitons-integration` to `integration`

if the Spicedb schema is like

```
definition notification/integration{}
``` 
for the request type:

```
{
  "integration": {
    "metadata": {
      "workspace_id": "w1",
      "labels": [
        {
          "key": "test",
          "value": "vv"
        }
      ]
    },
    "reporter_data": {
      "reporter_type": "NOTIFICATIONS",
      "console_href": "www.example.com",
      "api_href": "www.example.com",
      "local_resource_id": "4",
      "reporter_version": "0.1"
    }
  }
}
```

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

