### PR TITLE
RHCLOUD-36298 - Exposing Internal Event API Externally

### DIFF
--- a/api/structs.go
+++ b/api/structs.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"time"
+)
+
+// JsonObject type taken from: https://github.com/project-kessel/inventory-api/blob/main/internal/biz/model/common.go
+type JsonObject map[string]interface{}
+
+// Event types taken from: https://github.com/project-kessel/inventory-api/blob/main/internal/eventing/api/event.go
+type Event struct {
+	Specversion     string      `json:"specversion"`
+	Type            string      `json:"type"`
+	Source          string      `json:"source"`
+	Id              string      `json:"id"`
+	Subject         string      `json:"subject"`
+	Time            time.Time   `json:"time"`
+	DataContentType string      `json:"datacontenttype"`
+	Data            interface{} `json:"data"`
+}
+
+type ResourceData struct {
+	Metadata     ResourceMetadata `json:"metadata"`
+	ReporterData ResourceReporter `json:"reporter_data"`
+	ResourceData JsonObject       `json:"resource_data,omitempty"`
+}
+
+type RelationshipData struct {
+	Metadata     RelationshipMetadata `json:"metadata"`
+	ReporterData RelationshipReporter `json:"reporter_data"`
+	ResourceData JsonObject           `json:"resource_data,omitempty"`
+}
+
+type ResourceMetadata struct {
+	Id           string          `json:"id"`
+	ResourceType string          `json:"resource_type"`
+	OrgId        string          `json:"org_id"`
+	CreatedAt    *time.Time      `json:"created_at,omitempty"`
+	UpdatedAt    *time.Time      `json:"updated_at,omitempty"`
+	DeletedAt    *time.Time      `json:"deleted_at,omitempty"`
+	WorkspaceId  string          `json:"workspace_id"`
+	Labels       []ResourceLabel `json:"labels,omitempty"`
+}
+
+type ResourceLabel struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type ResourceReporter struct {
+	ReporterInstanceId string `json:"reporter_instance_id"`
+	ReporterType       string `json:"reporter_type"`
+	ConsoleHref        string `json:"console_href"`
+	ApiHref            string `json:"api_href"`
+	LocalResourceId    string `json:"local_resource_id"`
+	ReporterVersion    string `json:"reporter_version"`
+}
+
+type RelationshipMetadata struct {
+	Id               string     `json:"id"`
+	RelationshipType string     `json:"relationship_type"`
+	CreatedAt        *time.Time `json:"created_at,omitempty"`
+	UpdatedAt        *time.Time `json:"updated_at,omitempty"`
+	DeletedAt        *time.Time `json:"deleted_at,omitempty"`
+}
+
+type RelationshipReporter struct {
+	ReporterType           string `json:"reporter_type"`
+	SubjectLocalResourceId string `json:"subject_local_resource_id"`
+	ObjectLocalResourceId  string `json:"object_local_resource_id"`
+	ReporterVersion        string `json:"reporter_version"`
+	ReporterInstanceId     string `json:"reporter_instance_id"`
+}


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Exposes eventing api structs for use in `/api/structs.go`

Once merged structs can be imported to other go projects:
```go
import (
        "fmt"
	api "github.com/inventory-api/api"
)

func main() {
	
	resource := api.ResourceData{
		Metadata: api.ResourceMetadata{
			ResourceType: "k8s_cluster",
			WorkspaceId:  "workspace1",
			OrgId:        "org-1",
		},
	}
	
	fmt.Printf("Resource Data: %+v\n", resource)
	
}
```


## Ticket reference (if applicable)
Fixes #[RHCLOUD-36298](https://issues.redhat.com/browse/RHCLOUD-36298)

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

