### PR TITLE
Skip code coverage report on push to main

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,6 +39,7 @@ jobs:
   # XXX this will fail if main does not already have a coverage.out report uploaded by the previous job
   code-coverage:
     name: Code coverage report
+    if: github.event_name == "pull_request"
     runs-on: ubuntu-latest
     needs: build-and-test
     steps:
@@ -47,7 +48,7 @@ jobs:
         uses: fgrosse/go-coverage-report@v1.2.0
         with:
           coverage-file-name: coverage.out
-          skip-comment: true # requires write permissin on pull requests
+          skip-comment: true # requires write permission on pull requests
           # below options help track coverage across forks
           trim: github.com/project-kessel/inventory-api
           root-package: ""


### PR DESCRIPTION
## Describe your changes

- Skip running code coverage report summary on push to main branch, it should only run on PRs
- Fixes failing jobs like this: https://github.com/project-kessel/inventory-api/actions/runs/12710365549/job/35431332309

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

