### PR TITLE
Increase test coverage of internal/data

### DIFF
--- a/internal/data/health/health_test.go
+++ b/internal/data/health/health_test.go
@@ -1,0 +1,48 @@
+package health
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kratos/kratos/v2/log"
+	"github.com/project-kessel/inventory-api/internal/authz"
+	"github.com/project-kessel/inventory-api/internal/authz/kessel"
+	"github.com/project-kessel/inventory-api/internal/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupGorm(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.Nil(t, err)
+
+	err = data.Migrate(db, log.NewHelper(log.DefaultLogger))
+	require.Nil(t, err)
+
+	return db
+}
+
+func TestHealthInit(t *testing.T) {
+	db := setupGorm(t)
+	ctx := context.TODO()
+	authConfig, _ := authz.NewConfig(authz.NewOptions()).Complete(ctx)
+	kesselConfig, _ := kessel.NewConfig(kessel.NewOptions()).Complete(ctx)
+	authorizer, _ := kessel.New(ctx, kesselConfig, log.NewHelper(log.DefaultLogger))
+
+	healthRepo := New(db, authorizer, authConfig)
+	assert.NotNil(t, healthRepo)
+
+	// just check default negative case for now when using sqlite db, and empty config
+	// storage should be okay, relations api should not because tokenConfig is empty
+	resp, err := healthRepo.IsBackendAvailable(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, uint32(500), resp.Code)
+	assert.Equal(t, "RELATIONS-API UNHEALTHY", resp.Status)
+
+	resp, err = healthRepo.IsRelationsAvailable(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, uint32(500), resp.Code)
+	assert.Equal(t, "RELATIONS-API UNHEALTHY", resp.Status)
+}


### PR DESCRIPTION
## Describe your changes

Adds some additional unit tests to internal/data. This was partly does as an excuse for me to familiarize myself more with the code.

Coverage change should be 17.5% -> 19.8%.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

