### PR TITLE
RHCLOUD-37203: updates build and code to add FIPS support

### DIFF
--- a/cmd/fips.go
+++ b/cmd/fips.go
@@ -1,0 +1,13 @@
+//go:build fips_enabled
+// +build fips_enabled
+
+package cmd
+
+import (
+	_ "crypto/tls/fipsonly"
+	"fmt"
+)
+
+func init() {
+	fmt.Println("***** Starting with FIPS crypto enabled *****")
+}

--- a/data/notifications-integration-reporter.json
+++ b/data/notifications-integration-reporter.json
@@ -1,0 +1,6 @@
+{
+    "reporter_data": {
+      "reporter_type": "NOTIFICATIONS",
+      "local_resource_id": "1234"
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/project-kessel/inventory-api
 
-go 1.23.1
+go 1.22.9
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.2-20241127180247-a33202765966.1


### PR DESCRIPTION
### PR Template:

## Describe your changes

**Adds `fips.go`:**
* new package to restrict all TLS configuration to FIPS-approved settings (See [fipsonly.go](https://go.dev/src/crypto/tls/fipsonly/fipsonly.go))

**Rolls back go version:**
* `go-toolset` currently installs go 1.22.9, so `go.mod` has been updated to ensure a supported version of Go is used for builds to work

**Updates to Dockerfile:**
* adds the `go-toolset` package to both  the builder container and the final container versus installing Go from upstream
  * the version of Go from `go-toolset` contains modifications made for RHEL which replaces BoringSSL with OpenSSL. OpenSSL is approved and validated for FedRAMP and FIPS, BoringSSL is not
  * making `go tool` available on the final image will also aid in proving FIPS compliance for audits
* installs `fips-detect` to simplify proving FIPS validation during audits as well (More on [fips-detect](https://github.com/acardace/fips-detect)

**Updates to Makefile:**
* adds a `FIPS_ENABLED` var that defaults to true
* adds some GO env vars to be more explicit for builds, including setting GOBUILDFLAGS to remove paths with compiler and assembler (cleaner errors for things like panic's by stripping full paths to packages)
* adds conditional to enforce FIPS during build if FIPS_ENABLED=true
* updates build command to use new buildflags and account for FIPS or not
* adds `local-build` target since building with FIPS_ENABLED will fail locally and wanted to make it easier to build locally without having to set FIPS_ENABLED=false

Updates to README:
* adds info on building locally 
* adds notes on testing the API in stage and how to test creating/deleting notifications-integrations which work in stage
* adds info on how to validate FIPS for audits/any other reason

Some notes/useful links:
* many of the FIPS changes to build flags, fips.go etc are well tested in SREP for ensuring all operators deployed for managed openshift are FIPS compliant as they run in FedRAMP. Some info on those changes are available [HERE](https://github.com/openshift/boilerplate/tree/master/boilerplate/openshift/golang-osd-operator#fips-federal-information-processing-standards) and can also be found in the Makefile in the same repo path
* [Is your Go Application FIPS Compliant?](https://developers.redhat.com/articles/2022/05/31/your-go-application-fips-compliant)
* long term we probably dont want to install go onto the running image, or install fips-detect at all but for the purpose of the FedRAMP build out and SCR ive added them now to simplify testing. We can remove them at a later day and come up with a better validation proof method


## Ticket reference (if applicable)
For RHCLOUD-37203

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

