### PR TITLE
updates compose setup to remove relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,13 @@ See [DEBUG](./DEBUG.md) for instructions on how to debug
 
 #### Kessel Inventory + Kessel Relations
 
-There is Make target to run inventory-api (with postgres) and relations api (with spicedb).
-It uses compose to build the current inventory code and spin up containers with the required dependecies.
+In order to test Kessel Inventory with Kessel Relations, we recommend cloning the Relations API repo locally and leveraging their existing [Docker Compose process](https://github.com/project-kessel/relations-api/tree/main?tab=readme-ov-file#spicedb-using-dockerpodman) to spin up the Relations API.
 
-- This provides a [PSK file](./config/psks.yaml#L1) with a token "1234".
-- Default ports in this setup are `8081` for http and `9091` for grpc.
+Both Inventory and Relations compose files are configured to use the same docker network (`kessel`) to ensure network connectivity between all containers.
+
+For the Inventory Compose deployment:
+- A [PSK file](./config/psks.yaml#L1) is provided with the token "1234".
+- Default ports in this setup are `8081` for http and `9091` for grpc to not conflict with Relations
 - Refer to [inventory-api-compose.yaml](./inventory-api-compose.yaml) for additional configuration
 
 To start use:
@@ -168,6 +170,8 @@ Similar as above, but instead of running Kafka, this will configure inventory to
 - Sets up a keycloak instance running at port 8084 with [myrealm](myrealm.json) config file.
 - Set up a default service account with clientId: `test-svc`. Refer to [get-token](scripts/get-token.sh) to learn how to fetch a token.
 - Refer to [sso-inventory-api.yaml](./sso-inventory-api.yaml) for additional configuration
+
+As before you'll need to run the Relations Compose steps available in the [Relations API repo](https://github.com/project-kessel/relations-api/tree/main?tab=readme-ov-file#spicedb-using-dockerpodman)
 
 To start use:
 ```shell

--- a/docker-compose-kafka.yaml
+++ b/docker-compose-kafka.yaml
@@ -9,6 +9,8 @@ services:
       - "2181:2181"
     environment:
       LOG_DIR: /tmp/logs
+    networks:
+      - kessel
 
   kafka:
     image: quay.io/strimzi/kafka:latest-kafka-3.8.0
@@ -25,4 +27,10 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    networks:
+      - kessel
 
+networks:
+  kessel:
+    name: kessel
+    external: true

--- a/docker-compose-sso.yaml
+++ b/docker-compose-sso.yaml
@@ -2,10 +2,6 @@ services:
   inventory-api:
     environment:
       INVENTORY_API_CONFIG: /inventory-api-compose.yaml
-#      - "INVENTORY_API_STORAGE_DBNAME=postgres"
-#      - "INVENTORY_API_STORAGE_POSTGRES_DBNAME=database"
-#      - "INVENTORY_API_STORAGE_POSTGRES_USER=${POSTGRES_USER}"
-#      - "INVENTORY_API_STORAGE_POSTGRES_PASSWORD=${POSTGRES_PASSWORD}"
     build:
       dockerfile: Dockerfile
     volumes:
@@ -18,6 +14,8 @@ services:
       - "9081:9081"
     depends_on:
       - keycloak
+    networks:
+      - kessel
 
   invmigrate:
     environment:
@@ -30,6 +28,8 @@ services:
     restart: "on-failure"
     depends_on:
       - invdatabase
+    networks:
+      - kessel
 
   invdatabase:
     image: "postgres"
@@ -43,57 +43,12 @@ services:
       - "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}"
       - "POSTGRES_DB=${POSTGRES_DBNAME}"
       - "PGPORT=5433"
-
-  relations-api:
-    image: "quay.io/cloudservices/kessel-relations:latest"
-    hostname: relations-api
-    environment:
-      - "SPICEDB_PRESHARED=${SPICEDB_GRPC_PRESHARED_KEY}"
-      # - "SPICEDB_PRESHARED_FILE=/run/secrets/spicedb_pre_shared"
-      - "SPICEDB_ENDPOINT=spicedb:50051"
-    secrets:
-      - spicedb_pre_shared
-    restart: "always"
-    ports:
-      - "8000:8000"
-      - "9000:9000"
-    depends_on:
-      - spicedb
-
-  spicedb:
-    image: "authzed/spicedb"
-    command: "serve"
-    restart: "always"
-    hostname: spicedb
-    volumes:
-      - ./deploy/schema.yaml:/schema.yaml:ro,z
-    secrets:
-      - spicedb_pre_shared
-    ports:
-      - "8080:8080"
-      - "9090:9090"
-      - "50051:50051"
-    environment:
-      - "SPICEDB_GRPC_PRESHARED_KEY=${SPICEDB_GRPC_PRESHARED_KEY}"
-      - "SPICEDB_DATASTORE_ENGINE=postgres"
-      - "SPICEDB_DATASTORE_BOOTSTRAP_FILES=/schema.yaml"
-      - "SPICEDB_DATASTORE_CONN_URI=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database:5432/spicedb?sslmode=disable"
-
-  migrate:
-    image: "authzed/spicedb"
-    command: "datastore migrate head"
-    restart: "on-failure"
-    secrets:
-      - spicedb_pre_shared
-    environment:
-      - "SPICEDB_DATASTORE_ENGINE=postgres"
-      - "SPICEDB_DATASTORE_CONN_URI=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database:5432/spicedb?sslmode=disable"
-    depends_on:
-      - database
+    networks:
+      - kessel
 
   keycloak:
     image: "quay.io/keycloak/keycloak:latest"
-    command: "start-dev --http-port=8084 --import-realm"
+    command: "start-dev --http-port=8084 --db-url-port 5434 --import-realm"
     restart: "on-failure"
     environment:
       - "KEYCLOAK_ADMIN=admin"
@@ -102,20 +57,22 @@ services:
       - ./myrealm.json:/opt/keycloak/data/import/myrealm.json:rw,z
     ports:
       - 8084:8084
+    networks:
+      - kessel
+
   database:
     image: "postgres"
     command: -c track_commit_timestamp=on
     hostname: database
     ports:
-      - "5432:5432"
+      - "5434:5434"
     environment:
       - "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}"
       - "POSTGRES_DB=${POSTGRES_DBNAME}"
+    networks:
+      - kessel
 
-configs:
-  spicedb_pre_shared:
-    environment: "SPICEDB_GRPC_PRESHARED_KEY"
-
-secrets:
-  spicedb_pre_shared:
-    file: ./.secrets/local-spicedb-secret
+networks:
+  kessel:
+    name: kessel
+    external: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,10 +5,6 @@ services:
       - invmigrate
     environment:
       INVENTORY_API_CONFIG: /inventory-api-compose.yaml
-#      - "INVENTORY_API_STORAGE_DBNAME=postgres"
-#      - "INVENTORY_API_STORAGE_POSTGRES_DBNAME=database"
-#      - "INVENTORY_API_STORAGE_POSTGRES_USER=${POSTGRES_USER}"
-#      - "INVENTORY_API_STORAGE_POSTGRES_PASSWORD=${POSTGRES_PASSWORD}"
     build:
       dockerfile: Dockerfile
       args:
@@ -21,6 +17,8 @@ services:
     ports:
       - "8081:8081"
       - "9081:9081"
+    networks:
+      - kessel
 
   invmigrate:
     environment:
@@ -35,6 +33,8 @@ services:
     restart: "on-failure"
     depends_on:
       - invdatabase
+    networks:
+      - kessel
 
   invdatabase:
     image: "postgres"
@@ -48,70 +48,10 @@ services:
       - "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}"
       - "POSTGRES_DB=${POSTGRES_DBNAME}"
       - "PGPORT=5433"
+    networks:
+      - kessel
 
-  relations-api:
-    image: "quay.io/cloudservices/kessel-relations:latest"
-    hostname: relations-api
-    volumes:
-      - ./deploy/schema.zed:/deploy/schema.zed:ro,z
-    environment:
-      - "SPICEDB_PRESHARED=${SPICEDB_GRPC_PRESHARED_KEY}"
-      # - "SPICEDB_PRESHARED_FILE=/run/secrets/spicedb_pre_shared"
-      - "SPICEDB_ENDPOINT=spicedb:50051"
-    secrets:
-      - spicedb_pre_shared
-    restart: "always"
-    ports:
-      - "8000:8000"
-      - "9000:9000"
-    depends_on:
-      - spicedb
-
-  spicedb:
-    image: "authzed/spicedb"
-    command: "serve"
-    restart: "always"
-    hostname: spicedb
-    volumes:
-      - ./deploy/schema.yaml:/schema.yaml:ro,z
-    secrets:
-      - spicedb_pre_shared
-    ports:
-      - "8080:8080"
-      - "9090:9090"
-      - "50051:50051"
-    environment:
-      - "SPICEDB_GRPC_PRESHARED_KEY=${SPICEDB_GRPC_PRESHARED_KEY}"
-      - "SPICEDB_DATASTORE_ENGINE=postgres"
-      - "SPICEDB_DATASTORE_BOOTSTRAP_FILES=/schema.yaml"
-      - "SPICEDB_DATASTORE_CONN_URI=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database:5432/spicedb?sslmode=disable"
-
-  migrate:
-    image: "authzed/spicedb"
-    command: "datastore migrate head"
-    restart: "on-failure"
-    secrets:
-      - spicedb_pre_shared
-    environment:
-      - "SPICEDB_DATASTORE_ENGINE=postgres"
-      - "SPICEDB_DATASTORE_CONN_URI=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database:5432/spicedb?sslmode=disable"
-    depends_on:
-      - database
-
-  database:
-    image: "postgres"
-    command: -c track_commit_timestamp=on
-    hostname: database
-    ports:
-      - "5432:5432"
-    environment:
-      - "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}"
-      - "POSTGRES_DB=${POSTGRES_DBNAME}"
-
-configs:
-  spicedb_pre_shared:
-    environment: "SPICEDB_GRPC_PRESHARED_KEY"
-
-secrets:
-  spicedb_pre_shared:
-    file: ./.secrets/local-spicedb-secret
+networks:
+  kessel:
+    name: kessel
+    external: true

--- a/scripts/start-inventory-kafka.sh
+++ b/scripts/start-inventory-kafka.sh
@@ -2,4 +2,6 @@
 set -e
 # Function to check if a command is available
 source ./scripts/check_docker_podman.sh
+NETWORK_CHECK=$(${DOCKER} network ls --filter name=kessel --format json)
+if [[ -z "${NETWORK_CHECK}" ]]; then ${DOCKER} network create kessel; fi
 ${DOCKER} compose --env-file ./scripts/.env -f ./docker-compose-kafka.yaml up -d --build

--- a/scripts/start-inventory-kc.sh
+++ b/scripts/start-inventory-kc.sh
@@ -2,4 +2,6 @@
 set -e
 # Function to check if a command is available
 source ./scripts/check_docker_podman.sh
+NETWORK_CHECK=$(${DOCKER} network ls --filter name=kessel --format json)
+if [[ -z "${NETWORK_CHECK}" ]]; then ${DOCKER} network create kessel; fi
 ${DOCKER} compose --env-file ./scripts/.env -f ./docker-compose-sso.yaml up -d --build

--- a/scripts/start-inventory.sh
+++ b/scripts/start-inventory.sh
@@ -2,4 +2,6 @@
 set -e
 # Function to check if a command is available
 source ./scripts/check_docker_podman.sh
+NETWORK_CHECK=$(${DOCKER} network ls --filter name=kessel --format json)
+if [[ -z "${NETWORK_CHECK}" ]]; then ${DOCKER} network create kessel; fi
 ${DOCKER} compose --env-file ./scripts/.env -f ./docker-compose.yaml up -d --build


### PR DESCRIPTION
### PR Template:

## Describe your changes
Maintaining deployment configurations for relations is getting burdensome and is causing issues with other teams testing due to how relations now handles importing the schema. These changes move away from handling relations and instead point to there process on deploying relations on its own. It does however account for teams mostly looking to deploy both services locally and ensures connectivity between services and no overlapping of ports to ensure successful deployments locally with docker compose

Related PR in Relations: https://github.com/project-kessel/relations-api/pull/342

Changes:
* removes relations-api and spicedb from all compose files
* ensures the existence and use of a `kessel` docker network so all services can communicate (also done in relations-api compose setup as well)
* updates any conflicting ports when attempting to deploy both services using each repo's compose files
* updates compose file to use the `kessel` network for all services

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

