### PR TITLE
Update Makefile to give make run options to supply a MODE=local option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ pr-check:
 	make generate;
 	make test;
 	make lint;
-	make build;
+	make local-build;
 	#
 
 .PHONY: inventory-up
@@ -183,20 +183,10 @@ inventory-down-kind:
 
 .PHONY: run
 # run api locally
-run: 
-ifeq ($(MODE),local)
-	$(MAKE) local-build
-else
-	$(MAKE) build
-endif
+run: local-build
 	$(GO) run main.go serve
 
-run-help:
-ifeq ($(MODE),local)
-	$(MAKE) local-build
-else
-	$(MAKE) build
-endif
+run-help: local-build
 	$(GO) run main.go serve --help
 
 .PHONY: migrate

--- a/Makefile
+++ b/Makefile
@@ -183,10 +183,20 @@ inventory-down-kind:
 
 .PHONY: run
 # run api locally
-run: build
+run: 
+ifeq ($(MODE),local)
+	$(MAKE) local-build
+else
+	$(MAKE) build
+endif
 	$(GO) run main.go serve
 
-run-help: build
+run-help:
+ifeq ($(MODE),local)
+	$(MAKE) local-build
+else
+	$(MAKE) build
+endif
 	$(GO) run main.go serve --help
 
 .PHONY: migrate

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ for information on the different parameters.
     ```
 
 5. Start the development server
+
     ```shell
-    make run
+    make run MODE=local
     ```
 
 ### Overriding commands in the Makefile

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ for information on the different parameters.
 5. Start the development server
 
     ```shell
-    make run MODE=local
+    make run
     ```
 
 ### Overriding commands in the Makefile

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ for information on the different parameters.
     ```
 
 5. Start the development server
-
     ```shell
     make run
     ```


### PR DESCRIPTION
### PR Template:

## Describe your changes

- We recently introduced a local-build option to run the application locally without doing a FIPS compliance check. 
- Updated the Makefile targets, run and run-help to allow specification of a MODE=local option so we can run the application using a non FIPS compliant build.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

