### PR TITLE
RHCLOUD-37636: Bump base images to ubi9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154 AS builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1736404155 AS builder
 
 ARG TARGETARCH
 USER root
@@ -22,7 +22,7 @@ RUN VERSION=${VERSION} make build
 # adds fips-detect tool for FIPS validation -- likely not needed long term
 RUN mkdir /tmp/go && GOPATH=/tmp/go GOCACHE=/tmp/go go install github.com/acardace/fips-detect@latest
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1736404155
 
 # installs RHEL fork of go to be able to validate with go tools for FIPS -- likely not needed long term
 RUN microdnf install -y go-toolset

--- a/Dockerfile-e2e
+++ b/Dockerfile-e2e
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154 AS builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1736404155 AS builder
 
 ARG TARGETARCH
 USER root
@@ -22,7 +22,7 @@ COPY test/e2e .
 RUN go mod tidy
 RUN go test -c -o e2e-inventory-tests
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1736404155
 
 COPY --from=builder /workspace/e2e-inventory-tests /usr/local/bin/
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154 AS builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1736404155 AS builder
 
 ARG TARGETARCH
 USER root
@@ -20,7 +20,7 @@ RUN go install github.com/google/gnostic/cmd/protoc-gen-openapi@v0.7.0
 # Latest versions as of 2024-08-08
 RUN go install github.com/bufbuild/buf/cmd/buf@v1.36.0
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1736404155
 
 
 COPY --from=builder /root/go/bin/protoc-gen-go /usr/local/bin/protoc-gen-go


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Bumps all dockerfile base images to ubi 9.5

## Ticket reference (if applicable)
RHCLOUD-37636

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

