### PR TITLE
Fix delete api

### DIFF
--- a/internal/authz/allow/allow.go
+++ b/internal/authz/allow/allow.go
@@ -38,6 +38,10 @@ func (a *AllowAllAuthz) DeleteTuples(ctx context.Context, r *kessel.DeleteTuples
 	return &kessel.DeleteTuplesResponse{}, nil
 }
 
+func (a *AllowAllAuthz) UnsetWorkspace(ctx context.Context, local_resource_id, name, namespace string) (*kessel.DeleteTuplesResponse, error) {
+	return &kessel.DeleteTuplesResponse{}, nil
+}
+
 func (a *AllowAllAuthz) SetWorkspace(ctx context.Context, local_resource_id, workspace, name, namespace string) (*kessel.CreateTuplesResponse, error) {
 	return &kessel.CreateTuplesResponse{}, nil
 }

--- a/internal/authz/api/authz-service.go
+++ b/internal/authz/api/authz-service.go
@@ -11,5 +11,6 @@ type Authorizer interface {
 	Check(context.Context, *kessel.CheckRequest) (*kessel.CheckResponse, error)
 	CreateTuples(context.Context, *kessel.CreateTuplesRequest) (*kessel.CreateTuplesResponse, error)
 	DeleteTuples(context.Context, *kessel.DeleteTuplesRequest) (*kessel.DeleteTuplesResponse, error)
+	UnsetWorkspace(context.Context, string, string, string) (*kessel.DeleteTuplesResponse, error)
 	SetWorkspace(context.Context, string, string, string, string) (*kessel.CreateTuplesResponse, error)
 }

--- a/internal/authz/kessel/kessel.go
+++ b/internal/authz/kessel/kessel.go
@@ -3,6 +3,7 @@ package kessel
 import (
 	"context"
 	"fmt"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/spf13/viper"
 
@@ -148,6 +149,19 @@ func (a *KesselAuthz) DeleteTuples(ctx context.Context, r *kessel.DeleteTuplesRe
 
 	a.incrSuccessCounter("DeleteTuples")
 	return resp, nil
+}
+
+func (a *KesselAuthz) UnsetWorkspace(ctx context.Context, local_resource_id, namespace, name string) (*kessel.DeleteTuplesResponse, error) {
+
+	req := &kessel.RelationTupleFilter{
+		ResourceNamespace: proto.String(namespace),
+		ResourceType:      proto.String(name),
+		ResourceId:        proto.String(local_resource_id),
+		Relation:          proto.String("workspace"),
+	}
+	return a.DeleteTuples(ctx, &kessel.DeleteTuplesRequest{
+		Filter: req,
+	})
 }
 
 func (a *KesselAuthz) SetWorkspace(ctx context.Context, local_resource_id, workspace, namespace, name string) (*kessel.CreateTuplesResponse, error) {

--- a/internal/biz/common.go
+++ b/internal/biz/common.go
@@ -57,3 +57,12 @@ func DefaultSetWorkspace(ctx context.Context, namespace string, model *model.Res
 
 	return nil
 }
+
+func DefaultUnsetWorkspace(ctx context.Context, namespace string, localResourceId string, resourceType string, authz authzapi.Authorizer) error {
+	_, err := authz.UnsetWorkspace(ctx, localResourceId, namespace, resourceType)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -174,7 +174,12 @@ func (uc *Usecase) Delete(ctx context.Context, id model.ReporterResourceId) erro
 		}
 	}
 
-	// TODO: delete the workspace tuple
+	if uc.Authz != nil {
+		_, err := uc.Authz.UnsetWorkspace(ctx, id.LocalResourceId, uc.Namespace, id.ResourceType)
+		if err != nil {
+			return err
+		}
+	}
 
 	uc.log.WithContext(ctx).Infof("Deleted Resource: %v(%v)", m.ID, m.ResourceType)
 	return nil

--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -175,7 +175,7 @@ func (uc *Usecase) Delete(ctx context.Context, id model.ReporterResourceId) erro
 	}
 
 	if uc.Authz != nil {
-		_, err := uc.Authz.UnsetWorkspace(ctx, id.LocalResourceId, uc.Namespace, id.ResourceType)
+		err := biz.DefaultUnsetWorkspace(ctx, uc.Namespace, id.LocalResourceId, id.ResourceType, uc.Authz)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Currently the delete API has a TODO in main to forward the call to RELATIONS
- This PR implements that
- [Confirmation from the relations team ](https://redhat-internal.slack.com/archives/C059NUD49PD/p1738692896892169?thread_ts=1738687564.185699&cid=C059NUD49PD) re. the call that needs to be made 

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

