### PR TITLE
minor tweaks to scripts/docs for better podman support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ export DOCKER=docker
 make api
 ```
 
+> Note: The `podman-compose` provider struggles with compose files that leverage `depends_on` as it can't properly handle the dependency graphs. You can fix this issue on Linux by installing the `docker-compose-plugin` or also having `docker-compose` installed. When installed, podman uses the `docker-compose` provider by default instead. The benefit of the `docker-compose-plugin` is that it doesn't require the full Docker setup or docker daemon!
+
 ### Debugging
 
 See [DEBUG](./DEBUG.md) for instructions on how to debug
@@ -287,7 +289,7 @@ curl -XPUT -H "Content-Type: application/json" --data "@data/host.json" http://l
 
 To hit the gRPC endpoint
 
-``` 
+```
 grpcurl -plaintext -d @ localhost:9000 kessel.inventory.v1beta1.resources.KesselRhelHostService.UpdateRhelHost < data/host.json
 ```
 
@@ -302,7 +304,7 @@ curl -XDELETE -H "Content-Type: application/json" --data "@data/host-reporter.js
 
 To hit the gRPC endpoint
 
-``` 
+```
 grpcurl -plaintext -d @ localhost:9000 kessel.inventory.v1beta1.resources.KesselRhelHostService.DeleteRhelHost < data/host-reporter.json
 ```
 To add a notifications integration (useful for testing in stage)

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,5 +1,8 @@
 set -exv
 
+# check for podman or docker
+DOCKER=$(command -v podman || command -v docker)
+
 if [[ -z "$IMAGE" ]]; then
     IMAGE="quay.io/cloudservices/kessel-inventory"
 fi
@@ -31,15 +34,15 @@ trap job_cleanup EXIT ERR SIGINT SIGTERM
 DOCKER_CONF="$TMP_JOB_DIR/.docker"
 
 mkdir -p "$DOCKER_CONF"
-docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
-docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
-docker --config="$DOCKER_CONF" build --build-arg GIT_COMMIT=$GIT_COMMIT --no-cache -t "${IMAGE}:${IMAGE_TAG}" . -f ./Dockerfile
+$DOCKER --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
+$DOCKER --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
+$DOCKER --config="$DOCKER_CONF" build --build-arg GIT_COMMIT=$GIT_COMMIT --no-cache -t "${IMAGE}:${IMAGE_TAG}" . -f ./Dockerfile
 
 if [[ "$GIT_BRANCH" == "origin/security-compliance" ]]; then
-    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
-    docker --config="$DOCKER_CONF" push "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
+    $DOCKER --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
+    $DOCKER --config="$DOCKER_CONF" push "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
 else
-    docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
-    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"
-    docker --config="$DOCKER_CONF" push "${IMAGE}:latest"
+    $DOCKER --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+    $DOCKER --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"
+    $DOCKER --config="$DOCKER_CONF" push "${IMAGE}:latest"
 fi


### PR DESCRIPTION
### PR Template:

## Describe your changes

* adds note to docs about podman and potential issues seen when using the compose make targets with only podman installed
* updates the build_deploy.sh script to account for docker or podman so that it can be leveraged by anyone locally, and still function with jenkins (pretty sure jenkins nodes no longer have docker anyway)


## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

