### PR TITLE
Add timeout to scripts/check-e2e-tests.sh

### DIFF
--- a/scripts/check-e2e-tests.sh
+++ b/scripts/check-e2e-tests.sh
@@ -26,3 +26,5 @@ for i in {1..50}; do
   sleep 3
 done
 kubectl logs $TEST_POD
+echo "Unexpected timeout, test pod did not complete"
+exit 1


### PR DESCRIPTION
## Describe your changes

Example of tests failing but success is reported https://github.com/project-kessel/inventory-api/actions/runs/13248301217/job/36980006159#step:5:39

Using commit [(8bffb56)](https://github.com/project-kessel/inventory-api/pull/319/commits/8bffb56e52864a9b8bb3f8c03454c1061b8abe2e)  the test pod seems stuck and does not complete. The `check-e2e-tests.sh` script tries 50 times to check the pod termination reason, which do not succeed, then exits with error code 0.

This adds an error message and non-zero exit code if the test pod does not complete within the 50 checks by the  `check-e2e-tests.sh` script.

## Ticket reference (if applicable)
RHCLOUD-37804

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

