### PR TITLE
Return errors from checkforview calls in list endpoint

### DIFF
--- a/internal/authz/kessel/kessel.go
+++ b/internal/authz/kessel/kessel.go
@@ -169,6 +169,8 @@ func (a *KesselAuthz) CheckForView(ctx context.Context, namespace string, viewPe
 		},
 	})
 
+	log.Infof("CheckForView resp: %v err: %v", resp, err)
+
 	if err != nil {
 		return kessel.CheckResponse_ALLOWED_UNSPECIFIED, nil, err
 	}

--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -159,7 +159,7 @@ func (uc *Usecase) CheckForCreate(ctx context.Context, permission, namespace str
 
 func (uc *Usecase) ListResourcesInWorkspace(ctx context.Context, permission, namespace string, sub *kessel.SubjectReference, id string) (chan *model.Resource, chan error, error) {
 	resource_chan := make(chan *model.Resource)
-	error_chan := make(chan error)
+	error_chan := make(chan error, 1)
 
 	resources, err := uc.repository.FindByWorkspaceId(ctx, id)
 	if err != nil {
@@ -175,6 +175,7 @@ func (uc *Usecase) ListResourcesInWorkspace(ctx context.Context, permission, nam
 				resource_chan <- resource
 			} else if err != nil {
 				error_chan <- err
+				break
 			} else if allowed != kessel.CheckResponse_ALLOWED_TRUE {
 				log.Infof("Response was not allowed: %v", allowed)
 			}

--- a/internal/service/resources/notificationsintegrations/notificationsintegrations.go
+++ b/internal/service/resources/notificationsintegrations/notificationsintegrations.go
@@ -113,6 +113,8 @@ func (c *NotificationsIntegrationsService) ListNotificationsIntegrations(r *pb.L
 		return fmt.Errorf("failed to retrieve integrations: %w", err)
 	}
 
+	log.Infof("ListNotificationsIntegrations: got some resources %v", resources)
+
 	for resource := range resources {
 		re, err := notificationsIntegrationFromResource(resource)
 		if err != nil {


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Passes errors from err channel up to service level to return.

Example usage (running relations & inventory locally)
- passing an invalid relation

BEFORE:
```
MESSAGE='{"integration":{"metadata":{"workspace_id":"1234","resource_type":"notifications/integration"},"reporter_data":{"reporter_instance_id":"service-account-1","reporter_type":"NOTIFICATIONS","local_resource_id":"1234"}}}'
grpcurl -H "Authorization: bearer 1234" -plaintext -d $MESSAGE \
    localhost:9081 \
    kessel.inventory.v1beta1.resources.KesselNotificationsIntegrationService.CreateNotificationsIntegration

# usin this to hang inventory
MESSAGE='{"resource_type":{"namespace": "notifications", "name": "integration"}, "relation": "waaaorkspace", "subject": {"subject": {"type": {"namespace": "rbac", "name": "workspace"}, "id": "1234"}}, "parent": {"type": {"namespace": "rbac", "name": "workspace"}, "id": "1234"}}'
grpcurl -H "Authorization: bearer 1234" -plaintext -d "$MESSAGE" localhost:9081 kessel.inventory.v1beta1.resources.KesselNotificationsIntegrationService.ListNotificationsIntegrations

# Inventory hangs
```

AFTER:
```
MESSAGE='{"integration":{"metadata":{"workspace_id":"1234","resource_type":"notifications/integration"},"reporter_data":{"reporter_instance_id":"service-account-1","reporter_type":"NOTIFICATIONS","local_resource_id":"1234"}}}'
grpcurl -H "Authorization: bearer 1234" -plaintext -d $MESSAGE \
    localhost:9081 \
    kessel.inventory.v1beta1.resources.KesselNotificationsIntegrationService.CreateNotificationsIntegration

# usin this to hang inventory
MESSAGE='{"resource_type":{"namespace": "notifications", "name": "integration"}, "relation": "waaaorkspace", "subject": {"subject": {"type": {"namespace": "rbac", "name": "workspace"}, "id": "1234"}}, "parent": {"type": {"namespace": "rbac", "name": "workspace"}, "id": "1234"}}'
grpcurl -H "Authorization: bearer 1234" -plaintext -d "$MESSAGE" localhost:9081 kessel.inventory.v1beta1.resources.KesselNotificationsIntegrationService.ListNotificationsIntegrations

ERROR:
  Code: FailedPrecondition
  Message: error while streaming: rpc error: code = FailedPrecondition desc = failed to perform check: error invoking CheckPermission in SpiceDB: rpc error: code = FailedPrecondition desc = relation/permission `waaaorkspace` not found under definition `notifications/integration`
  Details:
  1)    {
          "@type": "type.googleapis.com/google.rpc.ErrorInfo",
          "domain": "authzed.com",
          "metadata": {
            "definition_name": "notifications/integration",
            "relation_or_permission_name": "waaaorkspace"
          },
          "reason": "ERROR_REASON_UNKNOWN_RELATION_OR_PERMISSION"
        }
```

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

