### PR TITLE
explicity sets the postgres version provided by ClowdEnv

### DIFF
--- a/deploy/kessel-inventory-ephem.yaml
+++ b/deploy/kessel-inventory-ephem.yaml
@@ -41,6 +41,7 @@ objects:
       envName: ${ENV_NAME}
       database:
         name: kessel-inventory
+        version: 16
       optionalDependencies:
         - kessel-relations
       deployments:


### PR DESCRIPTION
### PR Template:

## Describe your changes

* TIL you can specify the postgres version in the clowdapp, otherwise you get the default of postgresql 12

# Validation

```shell
kessel-inventory=# select version();
                                                   version                                                   
-------------------------------------------------------------------------------------------------------------
 PostgreSQL 16.4 on x86_64-redhat-linux-gnu, compiled by gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-22), 64-bit
(1 row)

$ oc get pod kessel-inventory-db-98c44dbff-brtxs -o yaml | grep image:
    image: quay.io/cloudservices/postgresql-rds:16-759c25d
    image: quay.io/cloudservices/postgresql-rds:16-759c25d
```




## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

