### PR TITLE
RHCLOUD-38543: Consumer change post-zookie updates

### DIFF
--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -136,7 +136,7 @@ func (uc *Usecase) CheckForUpdate(ctx context.Context, permission, namespace str
 
 		if consistency != nil {
 			res.ConsistencyToken = consistency.Token
-			_, _, err := uc.reporterResourceRepository.Update(ctx, res, res.ID)
+			_, err := uc.reporterResourceRepository.Update(ctx, res, res.ID, uc.Namespace)
 			if err != nil {
 				return false, err // we're allowed, but failed to update consistency token
 			}

--- a/internal/data/relationships/relationships_test.go
+++ b/internal/data/relationships/relationships_test.go
@@ -164,7 +164,7 @@ func assertEqualRelationshipHistory(t *testing.T, r *model.Relationship, rh *mod
 //}
 
 func createResource(t *testing.T, db *gorm.DB, resource *model.Resource) uuid.UUID {
-	res, _, err := resources.New(db).Create(context.TODO(), resource)
+	res, err := resources.New(db).Create(context.TODO(), resource, "foobar-namespace")
 	assert.Nil(t, err)
 	return res.ID
 }

--- a/internal/data/resources/resources_test.go
+++ b/internal/data/resources/resources_test.go
@@ -403,7 +403,7 @@ func TestFindByWorkspaceId(t *testing.T) {
 	res.WorkspaceId = "1234"
 
 	// Saving a resource not present in the system saves correctly
-	r, _, err := repo.Create(ctx, res)
+	r, err := repo.Create(ctx, res, namespace)
 	assert.NotNil(t, r)
 	assert.Nil(t, err)
 


### PR DESCRIPTION
- Updated use of resource update to supply correct params & return
- Updated consumer for new params
- Updated tests for namespace addition