### PR TITLE
Updates to E2e Test and log updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ inventory.db
 
 inventory-api.tar
 inventory-e2e-tests.tar
+kafka-connect.tar
 
 multicluster-global-hub/
 scripts/kubeconfig-global-hub

--- a/Dockerfile.connect
+++ b/Dockerfile.connect
@@ -1,0 +1,7 @@
+FROM quay.io/strimzi/kafka:0.45.0-kafka-3.9.0
+USER root:root
+RUN microdnf install wget tar -y && \
+    wget -O debezium-connector-postgres.tar.gz https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/2.5.4.Final/debezium-connector-postgres-2.5.4.Final-plugin.tar.gz && \
+    tar -zxvf debezium-connector-postgres.tar.gz -C /opt/kafka/plugins/ && \
+    microdnf clean all -y
+USER 1001

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -3,10 +3,11 @@ package serve
 import (
 	"context"
 	"fmt"
-	"github.com/project-kessel/inventory-api/internal/consumer"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/project-kessel/inventory-api/internal/consumer"
 
 	"github.com/project-kessel/inventory-api/cmd/common"
 	relationshipsctl "github.com/project-kessel/inventory-api/internal/biz/relationships"

--- a/data/notifications-integrations.json
+++ b/data/notifications-integrations.json
@@ -1,7 +1,7 @@
 {
   "integration": {
       "metadata": {
-          "workspace_id": "1234",
+          "workspace_id": "my_workspace",
           "resource_type": "notifications/integration"
       },
       "reporter_data": {

--- a/deploy/kessel-inventory-ephem-w-debezium.yaml
+++ b/deploy/kessel-inventory-ephem-w-debezium.yaml
@@ -21,7 +21,7 @@ objects:
           bootstrap-servers: inventory-kafka-kafka-bootstrap:9092
           topic: outbox.event.kessel.tuples
         log:
-          level: "info"
+          level: "debug"
 
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: Role

--- a/deploy/kessel-inventory-ephem-w-debezium.yaml
+++ b/deploy/kessel-inventory-ephem-w-debezium.yaml
@@ -21,7 +21,7 @@ objects:
           bootstrap-servers: inventory-kafka-kafka-bootstrap:9092
           topic: outbox.event.kessel.tuples
         log:
-          level: "debug"
+          level: "info"
 
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: Role

--- a/deploy/kind/inventory/invdatabase.yaml
+++ b/deploy/kind/inventory/invdatabase.yaml
@@ -1,3 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config
+data:
+  postgresql.conf: |
+    max_connections = 100
+    listen_addresses = '*'
+    shared_buffers = 128MB
+    work_mem = 4MB
+    wal_level = logical
+    log_destination = 'stderr'
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -17,6 +31,11 @@ spec:
       containers:
         - name: postgres
           image: postgres:latest
+          command: [ "docker-entrypoint.sh", "-c", "config_file=/etc/postgresql/postgresql.conf" ]
+          volumeMounts:
+          - name: postgres-config
+            mountPath: /etc/postgresql/postgresql.conf
+            subPath: postgresql.conf
           env:
             - name: POSTGRES_DB
               value: spicedb
@@ -29,6 +48,11 @@ spec:
                   key: db_password
           ports:
             - containerPort: 5432
+      volumes:
+        - name: postgres-config
+          configMap:
+            name: postgres-config
+
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/kind/inventory/kessel-inventory.yaml
+++ b/deploy/kind/inventory/kessel-inventory.yaml
@@ -23,8 +23,8 @@ spec:
             - "-c"
             - |
               echo "Waiting for PostgreSQL to be ready..."
-              sleep 20 
-              
+              sleep 20
+
               inventory-api migrate
           env:
             - name: CLOWDER_ENABLED
@@ -151,8 +151,11 @@ stringData:
       eventer: kafka
       kafka:
         bootstrap-servers: "my-cluster-kafka-bootstrap.default.svc.cluster.local:9092"
+    consumer:
+      bootstrap-servers: "my-cluster-kafka-bootstrap.default.svc.cluster.local:9092"
+      topic: outbox.event.kessel.tuples
     storage:
-      disable-persistence: true
+      disable-persistence: false
       database: postgres
       sqlite3:
         dsn: inventory.db

--- a/deploy/kind/inventory/strimzi.yaml
+++ b/deploy/kind/inventory/strimzi.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
@@ -32,3 +33,52 @@ spec:
     storage:
       type: ephemeral
 
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnect
+metadata:
+  annotations:
+    strimzi.io/use-connector-resources: "true"
+  name: inventory-kafka-connect
+spec:
+  bootstrapServers: my-cluster-kafka-bootstrap.default.svc.cluster.local:9092
+  config:
+    group.id: connect-cluster
+    config.storage.topic: connect-cluster-configs
+    offset.storage.topic: connect-cluster-offsets
+    status.storage.topic: connect-cluster-status
+    topic.creation.enable: true
+    config.storage.replication.factor: 1
+    offset.storage.replication.factor: 1
+    status.storage.replication.factor: 1
+    offset.storage.partitions: 1
+    status.storage.partitions: 1
+    config.storage.partitions: 1
+  image: localhost/kafka-connect:e2e-test
+  replicas: 3
+  version: 3.8.0
+
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnector
+metadata:
+  name: kessel-inventory-source-connector
+  labels:
+    strimzi.io/cluster: inventory-kafka-connect
+spec:
+  class: io.debezium.connector.postgresql.PostgresConnector
+  tasksMax: 1
+  config:
+    database.server.name: kessel-inventory-db
+    database.dbname: spicedb
+    database.hostname: invdatabase
+    database.port: 5433
+    database.user: postgres
+    database.password: "yPsw5e6ab4bvAGe5H"
+    topic.prefix: kessel-inventory
+    table.whitelist: public.outbox_events # Required for Debezium < v1.3.0 support
+    table.include.list: public.outbox_events # Required for Debezium > v1.3.0
+    transforms: outbox
+    transforms.outbox.type: io.debezium.transforms.outbox.EventRouter
+    transforms.outbox.table.fields.additional.placement: operation:header
+    plugin.name: pgoutput

--- a/internal/consumer/consumer_test.go
+++ b/internal/consumer/consumer_test.go
@@ -5,9 +5,7 @@ import (
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/project-kessel/inventory-api/cmd/common"
 	"github.com/project-kessel/inventory-api/internal/authz"
-	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
-	"testing"
 )
 
 // Test if Kafka message is received and its fatal or all brokers are down, run is false
@@ -45,19 +43,4 @@ func (t *TestCase) TestSetup() []error {
 		errs = append(errs, err)
 	}
 	return errs
-}
-
-func TestInventoryConsumer_Consume(t *testing.T) {
-	tests := []*TestCase{
-		{
-			name: "ConsumerHandlesKafkaError",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			var errs []error = test.TestSetup()
-			assert.Nil(t, errs)
-		})
-	}
 }


### PR DESCRIPTION
### PR Template:

## Describe your changes

Overhaul of E2E Test infra setup:
* adds required Kafka connect and connector for Debezium and inventory consumer use
* updates postgres config to set wal_level for Debezium compatability
* adds build steps for building the Debezium connect container
* starts laying out consumer_test file
* minor updates to consumer to address consumer error handling in loop
* minor updates to e2e tests of for changes to ensure it passes

Test Output:

```shell
# Kind cluster and all pods running
]$ kc get pods
NAME                                        READY   STATUS    RESTARTS      AGE
e2e-inventory-http-tests-n7chc              0/1     Completed   0               14s
invdatabase-67c6b878f4-4g8tx                1/1     Running   0             22m
inventory-kafka-connect-connect-0           1/1     Running   4 (21m ago)   22m
inventory-kafka-connect-connect-1           1/1     Running   4 (21m ago)   22m
inventory-kafka-connect-connect-2           1/1     Running   4 (21m ago)   22m
kessel-inventory-6d7c8d6db6-9tn64           1/1     Running   0             22m
my-cluster-kafka-0                          1/1     Running   0             21m
my-cluster-kafka-1                          1/1     Running   0             21m
my-cluster-kafka-2                          1/1     Running   0             21m
my-cluster-zookeeper-0                      1/1     Running   0             22m
my-cluster-zookeeper-1                      1/1     Running   0             22m
my-cluster-zookeeper-2                      1/1     Running   0             22m
postgres-7f4f855598-24snz                   1/1     Running   0             22m
relationships-7f9656ff68-dll9n              1/1     Running   0             22m
spicedb-cr-spicedb-7849b95878-hcjgq         1/1     Running   0             21m
spicedb-operator-7d9c5c5c7d-xvxn4           1/1     Running   0             22m
strimzi-cluster-operator-5488944db6-pklqz   1/1     Running   0             22m

# All tests pass
ntegrationLifecycle
=== PAUSE TestInventoryAPIHTTP_NotificationsIntegrationLifecycle
=== RUN   TestInventoryAPIHTTP_K8SPolicy_is_propagated_to_K8sClusterLifecycle
=== PAUSE TestInventoryAPIHTTP_K8SPolicy_is_propagated_to_K8sClusterLifecycle
=== RUN   Test_ACMKafkaConsumer
=== PAUSE Test_ACMKafkaConsumer
=== CONT  TestInventoryAPIHTTP_Livez
=== CONT  TestInventoryAPIHTTP_K8SPolicyLifecycle
=== CONT  TestInventoryAPIHTTP_NotificationsIntegrationLifecycle
=== CONT  TestInventoryAPIHTTP_K8SPolicy_is_propagated_to_K8sClusterLifecycle
=== CONT  Test_ACMKafkaConsumer
=== CONT  TestInventoryAPIHTTP_RHELHostLifecycle
=== CONT  TestInventoryAPIHTTP_K8SClusterLifecycle
=== CONT  TestInventoryAPIHTTP_Readyz
--- PASS: TestInventoryAPIHTTP_Livez (0.00s)
--- PASS: TestInventoryAPIHTTP_Readyz (0.00s)
--- PASS: TestInventoryAPIHTTP_NotificationsIntegrationLifecycle (0.09s)
--- PASS: TestInventoryAPIHTTP_K8SPolicyLifecycle (0.11s)
--- PASS: TestInventoryAPIHTTP_RHELHostLifecycle (0.13s)
--- PASS: TestInventoryAPIHTTP_K8SClusterLifecycle (0.13s)
--- PASS: TestInventoryAPIHTTP_K8SPolicy_is_propagated_to_K8sClusterLifecycle (0.18s)
% Message on kessel-inventory[0]@0:
{"specversion":"1.0","id":"7409b33e-09ba-11f0-b173-0ef40c4ca0d2","source":"http://localhost:8000","type":"redhat.inventory.resources-relationship.k8s-policy_is-propagated-to_k8s-cluster.created","subject":"/resources-relationship/k8s-policy_is-propagated-to_k8s-cluster/0195cf0f-fcd6-77b2-b2a3-e915a20246f1","datacontenttype":"application/json","time":"2025-03-25T20:48:06.358514654Z","data":{"metadata":{"id":"0195cf0f-fcd6-77b2-b2a3-e915a20246f1","relationship_type":"k8s-policy_is-propagated-to_k8s-cluster","created_at":"2025-03-25T20:48:06.358514654Z"},"reporter_data":{"reporter_type":"ACM","subject_local_resource_id":"789","object_local_resource_id":"987","reporter_version":"0.1","reporter_instance_id":"Go-http-client/1.1"},"resource_data":{"status":3}}}
% Headers: [content-type="application/cloudevents+json"]
The message is valid!
=== NAME  Test_ACMKafkaConsumer
    kafkaconsumer_test.go:230: Schema validation passed
--- PASS: Test_ACMKafkaConsumer (3.35s)
PASS
```

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

