### PR TITLE
RHCLOUD-38920 - Check fallback to minimize latency & only record ktn if resource exists

### DIFF
--- a/internal/authz/kessel/kessel.go
+++ b/internal/authz/kessel/kessel.go
@@ -152,6 +152,8 @@ func (a *KesselAuthz) UnsetWorkspace(ctx context.Context, local_resource_id, nam
 
 func (a *KesselAuthz) Check(ctx context.Context, namespace string, viewPermission string, resource *model.Resource, sub *kessel.SubjectReference) (kessel.CheckResponse_Allowed, *kessel.ConsistencyToken, error) {
 	log.Infof("Check: on %+v", resource)
+	// If resource doesn't exist in inventory DB
+	// default send a minimize_latency check request
 	consistency := &kessel.Consistency{Requirement: &kessel.Consistency_MinimizeLatency{MinimizeLatency: true}}
 
 	if resource.ConsistencyToken != "" {

--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -214,11 +214,10 @@ func updateExistingReporterResource(ctx context.Context, m *model.Resource, exis
 func (uc *Usecase) Check(ctx context.Context, permission, namespace string, sub *kessel.SubjectReference, id model.ReporterResourceId) (bool, error) {
 	res, err := uc.reporterResourceRepository.FindByReporterResourceId(ctx, id)
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			// resource doesn't exist.
-			return false, nil
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, err
 		}
-		return false, err
+		res = &model.Resource{ResourceType: id.ResourceType, ReporterResourceId: id.LocalResourceId}
 	}
 
 	allowed, _, err := uc.Authz.Check(ctx, namespace, permission, res, sub)
@@ -234,9 +233,11 @@ func (uc *Usecase) Check(ctx context.Context, permission, namespace string, sub 
 
 func (uc *Usecase) CheckForUpdate(ctx context.Context, permission, namespace string, sub *kessel.SubjectReference, id model.ReporterResourceId) (bool, error) {
 	res, err := uc.reporterResourceRepository.FindByReporterResourceId(ctx, id)
+	recordToken := true
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			// resource doesn't exist yet.
+			recordToken = false
 			res = &model.Resource{ResourceType: id.ResourceType, ReporterResourceId: id.LocalResourceId}
 		} else {
 			return false, err
@@ -253,11 +254,13 @@ func (uc *Usecase) CheckForUpdate(ctx context.Context, permission, namespace str
 			return true, nil
 		}
 
-		if consistency != nil {
-			res.ConsistencyToken = consistency.Token
-			_, _, err := uc.reporterResourceRepository.Update(ctx, res, res.ID)
-			if err != nil {
-				return false, err // we're allowed, but failed to update consistency token
+		if recordToken {
+			if consistency != nil {
+				res.ConsistencyToken = consistency.Token
+				_, _, err := uc.reporterResourceRepository.Update(ctx, res, res.ID)
+				if err != nil {
+					return false, err // we're allowed, but failed to update consistency token
+				}
 			}
 		}
 

--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -254,13 +254,11 @@ func (uc *Usecase) CheckForUpdate(ctx context.Context, permission, namespace str
 			return true, nil
 		}
 
-		if recordToken {
-			if consistency != nil {
-				res.ConsistencyToken = consistency.Token
-				_, _, err := uc.reporterResourceRepository.Update(ctx, res, res.ID)
-				if err != nil {
-					return false, err // we're allowed, but failed to update consistency token
-				}
+		if recordToken && consistency != nil {
+			res.ConsistencyToken = consistency.Token
+			_, _, err := uc.reporterResourceRepository.Update(ctx, res, res.ID)
+			if err != nil {
+				return false, err // we're allowed, but failed to update consistency token
 			}
 		}
 


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Check will fallback to using minimize latency if no resource can be found.
- - Will already use minimize latency in the case that a resource exists but has no ktn (if that's possible?)
- CheckForUpdate will only update the consistency token if the resource already exists, otherwise no side effect.

## Ticket reference (if applicable)
Fixes # https://issues.redhat.com/browse/RHCLOUD-38920

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

