### PR TITLE
RHCLOUD-38738: metrics setup

### DIFF
--- a/data/notifications-integrations.json
+++ b/data/notifications-integrations.json
@@ -1,7 +1,7 @@
 {
   "integration": {
       "metadata": {
-          "workspace_id": "my_workspace",
+          "workspace_id": "1234",
           "resource_type": "notifications/integration"
       },
       "reporter_data": {

--- a/deploy/kessel-inventory-ephem-w-debezium.yaml
+++ b/deploy/kessel-inventory-ephem-w-debezium.yaml
@@ -21,7 +21,7 @@ objects:
           bootstrap-servers: inventory-kafka-kafka-bootstrap:9092
           topic: outbox.event.kessel.tuples
         log:
-          level: "info"
+          level: "debug"
 
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: Role

--- a/deploy/kessel-inventory-ephem-w-debezium.yaml
+++ b/deploy/kessel-inventory-ephem-w-debezium.yaml
@@ -21,7 +21,7 @@ objects:
           bootstrap-servers: inventory-kafka-kafka-bootstrap:9092
           topic: outbox.event.kessel.tuples
         log:
-          level: "debug"
+          level: "info"
 
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: Role

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,5 +126,4 @@ func (o *OptionsConfig) ConfigureStorage(appconfig *clowder.AppConfig) error {
 // ConfigureConsumer updates Consumer settings based on ClowdApp AppConfig
 func (o *OptionsConfig) ConfigureConsumer() {
 	o.Consumer.BootstrapServers = clowder.KafkaServers[0]
-	log.Info("Bootstrap inside inject: ", o.Consumer.BootstrapServers)
 }

--- a/internal/consumer/config.go
+++ b/internal/consumer/config.go
@@ -59,6 +59,9 @@ func (c *Config) Complete() (CompletedConfig, []error) {
 		if err := config.SetKey("auto.offset.reset", c.AutoOffsetReset); err != nil {
 			errs = append(errs, fmt.Errorf("cannot set auto.offset.reset value: %w", err))
 		}
+		if err := config.SetKey("statistics.interval.ms", c.StatisticsInterval); err != nil {
+			errs = append(errs, fmt.Errorf("cannot set statistics.interval.ms value: %w", err))
+		}
 	}
 
 	if len(errs) > 0 {

--- a/internal/consumer/config.go
+++ b/internal/consumer/config.go
@@ -5,6 +5,8 @@ import (
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
 
+const clientID = "inventory-consumer"
+
 type Config struct {
 	*Options
 	KafkaConfig *kafka.ConfigMap
@@ -37,6 +39,9 @@ func (c *Config) Complete() (CompletedConfig, []error) {
 			if err := config.SetKey("debug", c.Debug); err != nil {
 				errs = append(errs, fmt.Errorf("cannot set debug value: %w", err))
 			}
+		}
+		if err := config.SetKey("client.id", clientID); err != nil {
+			errs = append(errs, fmt.Errorf("cannot set client.id value: %w", err))
 		}
 		if err := config.SetKey("bootstrap.servers", c.BootstrapServers); err != nil {
 			errs = append(errs, fmt.Errorf("cannot set bootstrap.servers value: %w", err))

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"go.opentelemetry.io/otel"
 	"os"
 	"os/signal"
 	"syscall"
@@ -21,17 +22,54 @@ import (
 
 type Consumer interface {
 	Consume() error
+	CreateTuple(ctx context.Context, msg []byte) (string, error)
+	UpdateTuple(ctx context.Context, msg []byte) (string, error)
+	DeleteTuple(ctx context.Context, msg []byte) (string, error)
+	UpdateConsistencyToken(msg []byte, token string) error
+	Errs() <-chan error
+	Shutdown() error
 }
 
 // InventoryConsumer defines a Kafka Consumer with required clients and configs to call Relations API and update the Inventory DB with consistency tokens
 type InventoryConsumer struct {
-	Consumer    *kafka.Consumer
-	Config      CompletedConfig
-	DB          *gorm.DB
-	AuthzConfig authz.CompletedConfig
-	Authorizer  api.Authorizer
-	Errors      chan error
-	Logger      *log.Helper
+	Consumer         *kafka.Consumer
+	Config           CompletedConfig
+	DB               *gorm.DB
+	AuthzConfig      authz.CompletedConfig
+	Authorizer       api.Authorizer
+	Errors           chan error
+	MetricsCollector MetricsCollector
+	Logger           *log.Helper
+}
+
+// New instantiates a new InventoryConsumer
+func New(config CompletedConfig, db *gorm.DB, authz authz.CompletedConfig, authorizer api.Authorizer, logger *log.Helper) (InventoryConsumer, error) {
+	logger.Info("Setting up kafka consumer")
+	consumer, err := kafka.NewConsumer(config.KafkaConfig)
+	if err != nil {
+		logger.Errorf("error creating kafka consumer: %v", err)
+		return InventoryConsumer{}, err
+	}
+
+	mc := MetricsCollector{}
+	err = mc.New(otel.Meter("github.com/project-kessel/inventory-api/blob/main/internal/server/otel"))
+	if err != nil {
+		logger.Errorf("error creating metrics collector: %v", err)
+		return InventoryConsumer{}, err
+	}
+
+	var errChan chan error
+
+	return InventoryConsumer{
+		Consumer:         consumer,
+		Config:           config,
+		DB:               db,
+		AuthzConfig:      authz,
+		Authorizer:       authorizer,
+		Errors:           errChan,
+		MetricsCollector: mc,
+		Logger:           logger,
+	}, nil
 }
 
 // KeyPayload stores the event message key captured from the topic as emitted by Debezium
@@ -44,27 +82,6 @@ type KeyPayload struct {
 type MessagePayload struct {
 	MessageSchema    map[string]interface{} `json:"schema"`
 	RelationsRequest interface{}            `json:"payload"`
-}
-
-// New instantiates a new InventoryConsumer
-func New(config CompletedConfig, db *gorm.DB, authz authz.CompletedConfig, authorizer api.Authorizer, logger *log.Helper) (InventoryConsumer, error) {
-	logger.Info("Setting up kafka consumer")
-	consumer, err := kafka.NewConsumer(config.KafkaConfig)
-	if err != nil {
-		logger.Errorf("error creating kafka consumer: %v", err)
-		return InventoryConsumer{}, err
-	}
-
-	var errChan chan error
-	return InventoryConsumer{
-		Consumer:    consumer,
-		Config:      config,
-		DB:          db,
-		AuthzConfig: authz,
-		Authorizer:  authorizer,
-		Errors:      errChan,
-		Logger:      logger,
-	}, nil
 }
 
 // Consume begins the consumption loop for the Consumer

--- a/internal/consumer/metrics.go
+++ b/internal/consumer/metrics.go
@@ -1,88 +1,199 @@
 package consumer
 
 import (
+	"context"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
-type MetricsCollector struct {
-	// Top-Level Metrics
-	Replyq metric.Int64Gauge
+const (
+	outboxTopic = "outbox.event.kessel.tuples"
+	prefix      = "inventory_consumer_"
+)
 
-	// Topic.Partitions Metrics
-	FetchqCnt         metric.Int64Gauge
-	FetchqSize        metric.Int64Gauge
-	FetchState        string
-	LoOffset          metric.Int64Gauge
-	HiOffset          metric.Int64Gauge
-	LsOffset          metric.Int64Gauge
-	ConsumerLag       metric.Int64Gauge
-	ConsumerLagStored metric.Int64Gauge
-	Rxmsgs            metric.Int64Counter
-	Rxbytes           metric.Int64Counter
-	MsgsInflight      metric.Int64Gauge
-
-	// CGRP Metrics
-	State           string
-	StateAge        metric.Int64Gauge
-	JoinState       string
-	RebalanceAge    metric.Int64Gauge
-	RebalanceCnt    metric.Int64Counter
-	RebalanceReason string
-	AssignmentSize  metric.Int64Gauge
+func (s *StatsData) LabelSet(key string) metric.MeasurementOption {
+	if key == "" {
+		m := metric.WithAttributes(
+			attribute.String("name", s.Name),
+			attribute.String("client_id", s.ClientID))
+		return m
+	}
+	m := metric.WithAttributes(
+		attribute.String("name", s.Name),
+		attribute.String("client_id", s.ClientID),
+		attribute.String("topic", outboxTopic),
+		attribute.String("partition", key))
+	return m
 }
 
-func (m MetricsCollector) New(meter metric.Meter) error {
+type StatsData struct {
+	Name     string               `json:"name"`
+	ClientID string               `json:"client_id"`
+	Replyq   int64                `json:"replyq"`
+	Topics   map[string]TopicData `json:"topics"`
+	CGRP     CGRPData             `json:"cgrp"`
+}
+
+type TopicData struct {
+	Topic      string                   `json:"topic"`
+	Partitions map[string]PartitionData `json:"partitions"`
+}
+
+type PartitionData struct {
+	FetchqCnt         int64  `json:"fetchq_cnt"`
+	FetchqSize        int64  `json:"fetchq_size"`
+	FetchState        string `json:"fetch_state"`
+	LoOffset          int64  `json:"lo_offset"`
+	HiOffset          int64  `json:"hi_offset"`
+	LsOffset          int64  `json:"ls_offset"`
+	ConsumerLag       int64  `json:"consumer_lag"`
+	ConsumerLagStored int64  `json:"consumer_lag_stored"`
+	Rxmsgs            int64  `json:"rxmsgs"`
+	Rxbytes           int64  `json:"rxbytes"`
+	MsgsInflight      int64  `json:"msgs_inflight"`
+}
+
+type CGRPData struct {
+	State           string `json:"state"`
+	StateAge        int64  `json:"stageage"`
+	RebalanceAge    int64  `json:"rebalance_age"`
+	RebalanceCnt    int64  `json:"rebalance_cnt"`
+	RebalanceReason string `json:"rebalance_reason"`
+	AssignmentSize  int64  `json:"assignment_size"`
+}
+
+type MetricsCollector struct {
+	// Top-Level Metrics
+	replyq metric.Int64Gauge
+
+	// Topic.Partitions Metrics
+	fetchqCnt         metric.Int64Gauge
+	fetchqSize        metric.Int64Gauge
+	fetchState        metric.Int64Gauge
+	loOffset          metric.Int64Gauge
+	hiOffset          metric.Int64Gauge
+	lsOffset          metric.Int64Gauge
+	consumerLag       metric.Int64Gauge
+	consumerLagStored metric.Int64Gauge
+	rxmsgs            metric.Int64Counter
+	rxbytes           metric.Int64Counter
+	msgsInflight      metric.Int64Gauge
+
+	// CGRP Metrics
+	state          metric.Int64Gauge
+	stateAge       metric.Int64Gauge
+	rebalanceAge   metric.Int64Gauge
+	rebalanceCnt   metric.Int64Counter
+	assignmentSize metric.Int64Gauge
+}
+
+func (m *MetricsCollector) New(meter metric.Meter) error {
 	var err error
 
 	// create top-level metrics
-	if m.Replyq, err = meter.Int64Gauge("replyq", nil); err != nil {
+	if m.replyq, err = meter.Int64Gauge(prefix + "replyq"); err != nil {
 		return err
 	}
 
 	// create topic.partitions metrics
-	if m.FetchqCnt, err = meter.Int64Gauge("fetchq_cnt", nil); err != nil {
+	if m.fetchqCnt, err = meter.Int64Gauge(prefix + "fetchq_cnt"); err != nil {
 		return err
 	}
-	if m.FetchqSize, err = meter.Int64Gauge("fetchq_size", nil); err != nil {
+	if m.fetchqSize, err = meter.Int64Gauge(prefix + "fetchq_size"); err != nil {
 		return err
 	}
-	if m.LoOffset, err = meter.Int64Gauge("lo_offset", nil); err != nil {
+	if m.fetchState, err = meter.Int64Gauge(prefix + "fetchq_state"); err != nil {
 		return err
 	}
-	if m.HiOffset, err = meter.Int64Gauge("hi_offset", nil); err != nil {
+	if m.loOffset, err = meter.Int64Gauge(prefix + "lo_offset"); err != nil {
 		return err
 	}
-	if m.LsOffset, err = meter.Int64Gauge("ls_offset", nil); err != nil {
+	if m.hiOffset, err = meter.Int64Gauge(prefix + "hi_offset"); err != nil {
 		return err
 	}
-	if m.ConsumerLag, err = meter.Int64Gauge("consumer_lag", nil); err != nil {
+	if m.lsOffset, err = meter.Int64Gauge(prefix + "ls_offset"); err != nil {
 		return err
 	}
-	if m.ConsumerLagStored, err = meter.Int64Gauge("consumer_lag_stored", nil); err != nil {
+	if m.consumerLag, err = meter.Int64Gauge(prefix + "consumer_lag"); err != nil {
 		return err
 	}
-	if m.Rxmsgs, err = meter.Int64Counter("rxmsgs", nil); err != nil {
+	if m.consumerLagStored, err = meter.Int64Gauge(prefix + "consumer_lag_stored"); err != nil {
 		return err
 	}
-	if m.Rxbytes, err = meter.Int64Counter("rxbytes", nil); err != nil {
+	if m.rxmsgs, err = meter.Int64Counter(prefix + "rxmsgs"); err != nil {
 		return err
 	}
-	if m.MsgsInflight, err = meter.Int64Gauge("msgs_inflight", nil); err != nil {
+	if m.rxbytes, err = meter.Int64Counter(prefix + "rxbytes"); err != nil {
+		return err
+	}
+	if m.msgsInflight, err = meter.Int64Gauge(prefix + "msgs_inflight"); err != nil {
 		return err
 	}
 
 	// create cgrp metrics
-	if m.StateAge, err = meter.Int64Gauge("stateage", nil); err != nil {
+	if m.state, err = meter.Int64Gauge(prefix + "state"); err != nil {
 		return err
 	}
-	if m.RebalanceAge, err = meter.Int64Gauge("rebalance_age", nil); err != nil {
+	if m.stateAge, err = meter.Int64Gauge(prefix + "stateage"); err != nil {
 		return err
 	}
-	if m.RebalanceCnt, err = meter.Int64Counter("rebalance_cnt", nil); err != nil {
+	if m.rebalanceAge, err = meter.Int64Gauge(prefix + "rebalance_age"); err != nil {
 		return err
 	}
-	if m.AssignmentSize, err = meter.Int64Gauge("assignment_size", nil); err != nil {
+	if m.rebalanceCnt, err = meter.Int64Counter(prefix + "rebalance_cnt"); err != nil {
+		return err
+	}
+	if m.assignmentSize, err = meter.Int64Gauge(prefix + "assignment_size"); err != nil {
 		return err
 	}
 	return nil
+}
+
+func (m *MetricsCollector) Collect(stats StatsData) {
+	// top-level
+	ctx := context.Background()
+	m.replyq.Record(ctx, stats.Replyq, stats.LabelSet(""))
+
+	// topics.partitions
+	for partitionKey, _ := range stats.Topics[outboxTopic].Partitions {
+		if partitionKey != "-1" {
+			m.fetchqCnt.Record(ctx, stats.Topics[outboxTopic].Partitions[partitionKey].FetchqCnt, stats.LabelSet(partitionKey))
+			m.fetchqSize.Record(ctx, stats.Topics[outboxTopic].Partitions[partitionKey].FetchqSize, stats.LabelSet(partitionKey))
+
+			if stats.Topics[outboxTopic].Partitions[partitionKey].FetchState != "active" {
+				m.fetchState.Record(ctx, int64(1),
+					stats.LabelSet(""),
+					metric.WithAttributes(attribute.String("fetch_state", stats.Topics[outboxTopic].Partitions[partitionKey].FetchState)))
+			} else {
+				m.fetchState.Record(ctx, int64(0),
+					stats.LabelSet(""),
+					metric.WithAttributes(attribute.String("fetch_state", stats.Topics[outboxTopic].Partitions[partitionKey].FetchState)))
+			}
+
+			m.loOffset.Record(ctx, stats.Topics[outboxTopic].Partitions[partitionKey].LoOffset, stats.LabelSet(partitionKey))
+			m.hiOffset.Record(ctx, stats.Topics[outboxTopic].Partitions[partitionKey].HiOffset, stats.LabelSet(partitionKey))
+
+			m.lsOffset.Record(ctx, stats.Topics[outboxTopic].Partitions[partitionKey].LsOffset, stats.LabelSet(partitionKey))
+			m.consumerLag.Record(ctx, stats.Topics[outboxTopic].Partitions[partitionKey].ConsumerLag, stats.LabelSet(partitionKey))
+			m.consumerLagStored.Record(ctx, stats.Topics[outboxTopic].Partitions[partitionKey].ConsumerLagStored, stats.LabelSet(partitionKey))
+			m.rxmsgs.Add(ctx, stats.Topics[outboxTopic].Partitions[partitionKey].Rxmsgs, stats.LabelSet(partitionKey))
+			m.rxbytes.Add(ctx, stats.Topics[outboxTopic].Partitions[partitionKey].Rxbytes, stats.LabelSet(partitionKey))
+			m.msgsInflight.Record(ctx, stats.Topics[outboxTopic].Partitions[partitionKey].MsgsInflight, stats.LabelSet(partitionKey))
+		}
+	}
+
+	// cgrp
+	if stats.CGRP.State != "up" {
+		m.state.Record(ctx, int64(1),
+			stats.LabelSet(""),
+			metric.WithAttributes(attribute.String("state", stats.CGRP.State)))
+	} else {
+		m.state.Record(ctx, int64(0),
+			stats.LabelSet(""),
+			metric.WithAttributes(attribute.String("state", stats.CGRP.State)))
+	}
+	m.stateAge.Record(ctx, stats.CGRP.StateAge, stats.LabelSet(""))
+	m.rebalanceAge.Record(ctx, stats.CGRP.RebalanceAge, stats.LabelSet(""), metric.WithAttributes(attribute.String("last_rebalance_reason", stats.CGRP.RebalanceReason)))
+	m.rebalanceCnt.Add(ctx, stats.CGRP.RebalanceCnt, stats.LabelSet(""))
+	m.assignmentSize.Record(ctx, stats.CGRP.AssignmentSize, stats.LabelSet(""))
 }

--- a/internal/consumer/metrics.go
+++ b/internal/consumer/metrics.go
@@ -1,0 +1,88 @@
+package consumer
+
+import (
+	"go.opentelemetry.io/otel/metric"
+)
+
+type MetricsCollector struct {
+	// Top-Level Metrics
+	Replyq metric.Int64Gauge
+
+	// Topic.Partitions Metrics
+	FetchqCnt         metric.Int64Gauge
+	FetchqSize        metric.Int64Gauge
+	FetchState        string
+	LoOffset          metric.Int64Gauge
+	HiOffset          metric.Int64Gauge
+	LsOffset          metric.Int64Gauge
+	ConsumerLag       metric.Int64Gauge
+	ConsumerLagStored metric.Int64Gauge
+	Rxmsgs            metric.Int64Counter
+	Rxbytes           metric.Int64Counter
+	MsgsInflight      metric.Int64Gauge
+
+	// CGRP Metrics
+	State           string
+	StateAge        metric.Int64Gauge
+	JoinState       string
+	RebalanceAge    metric.Int64Gauge
+	RebalanceCnt    metric.Int64Counter
+	RebalanceReason string
+	AssignmentSize  metric.Int64Gauge
+}
+
+func (m MetricsCollector) New(meter metric.Meter) error {
+	var err error
+
+	// create top-level metrics
+	if m.Replyq, err = meter.Int64Gauge("replyq", nil); err != nil {
+		return err
+	}
+
+	// create topic.partitions metrics
+	if m.FetchqCnt, err = meter.Int64Gauge("fetchq_cnt", nil); err != nil {
+		return err
+	}
+	if m.FetchqSize, err = meter.Int64Gauge("fetchq_size", nil); err != nil {
+		return err
+	}
+	if m.LoOffset, err = meter.Int64Gauge("lo_offset", nil); err != nil {
+		return err
+	}
+	if m.HiOffset, err = meter.Int64Gauge("hi_offset", nil); err != nil {
+		return err
+	}
+	if m.LsOffset, err = meter.Int64Gauge("ls_offset", nil); err != nil {
+		return err
+	}
+	if m.ConsumerLag, err = meter.Int64Gauge("consumer_lag", nil); err != nil {
+		return err
+	}
+	if m.ConsumerLagStored, err = meter.Int64Gauge("consumer_lag_stored", nil); err != nil {
+		return err
+	}
+	if m.Rxmsgs, err = meter.Int64Counter("rxmsgs", nil); err != nil {
+		return err
+	}
+	if m.Rxbytes, err = meter.Int64Counter("rxbytes", nil); err != nil {
+		return err
+	}
+	if m.MsgsInflight, err = meter.Int64Gauge("msgs_inflight", nil); err != nil {
+		return err
+	}
+
+	// create cgrp metrics
+	if m.StateAge, err = meter.Int64Gauge("stateage", nil); err != nil {
+		return err
+	}
+	if m.RebalanceAge, err = meter.Int64Gauge("rebalance_age", nil); err != nil {
+		return err
+	}
+	if m.RebalanceCnt, err = meter.Int64Counter("rebalance_cnt", nil); err != nil {
+		return err
+	}
+	if m.AssignmentSize, err = meter.Int64Gauge("assignment_size", nil); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/consumer/options.go
+++ b/internal/consumer/options.go
@@ -6,27 +6,29 @@ import (
 )
 
 type Options struct {
-	BootstrapServers  string `mapstructure:"bootstrap-servers"`
-	ConsumerGroupID   string `mapstructure:"consumer-group-id"`
-	Topic             string `mapstructure:"topic"`
-	SessionTimeout    string `mapstructure:"session-timeout"`
-	HeartbeatInterval string `mapstructure:"heartbeat-interval"`
-	MaxPollInterval   string `mapstructure:"max-poll-interval"`
-	EnableAutoCommit  string `mapstructure:"enable-auto-commit"`
-	AutoOffsetReset   string `mapstructure:"auto-offset-reset"`
-	Debug             string `mapstructure:"debug"`
+	BootstrapServers   string `mapstructure:"bootstrap-servers"`
+	ConsumerGroupID    string `mapstructure:"consumer-group-id"`
+	Topic              string `mapstructure:"topic"`
+	SessionTimeout     string `mapstructure:"session-timeout"`
+	HeartbeatInterval  string `mapstructure:"heartbeat-interval"`
+	MaxPollInterval    string `mapstructure:"max-poll-interval"`
+	EnableAutoCommit   string `mapstructure:"enable-auto-commit"`
+	AutoOffsetReset    string `mapstructure:"auto-offset-reset"`
+	StatisticsInterval string `mapstructure:"statistics-interval-ms"`
+	Debug              string `mapstructure:"debug"`
 }
 
 func NewOptions() *Options {
 	return &Options{
-		ConsumerGroupID:   "inventory-consumer",
-		Topic:             "outbox.event.kessel.tuples",
-		SessionTimeout:    "45000",
-		HeartbeatInterval: "3000",
-		MaxPollInterval:   "300000",
-		EnableAutoCommit:  "false",
-		AutoOffsetReset:   "earliest",
-		Debug:             "",
+		ConsumerGroupID:    "inventory-consumer",
+		Topic:              "outbox.event.kessel.tuples",
+		SessionTimeout:     "45000",
+		HeartbeatInterval:  "3000",
+		MaxPollInterval:    "300000",
+		EnableAutoCommit:   "false",
+		AutoOffsetReset:    "earliest",
+		StatisticsInterval: "15000",
+		Debug:              "",
 	}
 }
 
@@ -37,9 +39,12 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 	fs.StringVar(&o.BootstrapServers, prefix+"bootstrap-servers", o.BootstrapServers, "sets the bootstrap server address and port for Kafka")
 	fs.StringVar(&o.ConsumerGroupID, prefix+"consumer-groupd-id", o.ConsumerGroupID, "sets the Kafka consumer group name (default: inventory-consumer)")
 	fs.StringVar(&o.Topic, prefix+"topic", o.Topic, "Kafka topic to monitor for events")
-	fs.StringVar(&o.SessionTimeout, prefix+"session-timeout", o.SessionTimeout, "time a consumer can live without sending heartbeat (default: 45000)")
-	fs.StringVar(&o.HeartbeatInterval, prefix+"heartbeat-interval", o.HeartbeatInterval, "interval between heartbeats sent to Kafka (default: 3000, must be lower then session-timeout)")
-	fs.StringVar(&o.MaxPollInterval, prefix+"max-poll", o.MaxPollInterval, "length of time consumer can go without polling before considered dead (default: 300000)")
+	fs.StringVar(&o.SessionTimeout, prefix+"session-timeout", o.SessionTimeout, "time a consumer can live without sending heartbeat (default: 45000ms)")
+	fs.StringVar(&o.HeartbeatInterval, prefix+"heartbeat-interval", o.HeartbeatInterval, "interval between heartbeats sent to Kafka (default: 3000ms, must be lower then session-timeout)")
+	fs.StringVar(&o.MaxPollInterval, prefix+"max-poll", o.MaxPollInterval, "length of time consumer can go without polling before considered dead (default: 300000ms)")
+	fs.StringVar(&o.EnableAutoCommit, prefix+"enable-auto-commit", o.EnableAutoCommit, "enables auto commit on consumer when messages are consumed (default: false)")
+	fs.StringVar(&o.AutoOffsetReset, prefix+"auto-offset-reset", o.AutoOffsetReset, "action to take when there is no initial offset in offset store (default: earliest)")
+	fs.StringVar(&o.StatisticsInterval, prefix+"statistics-interval", o.StatisticsInterval, "librdkafka statistics emit interval (default: 15000ms)")
 }
 
 func (o *Options) Validate() []error {

--- a/scripts/load-generator.sh
+++ b/scripts/load-generator.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+LIVEZ_URL="localhost:8000/api/inventory/v1/livez"
+INVENTORY_URL="localhost:8000/api/inventory/v1beta1/resources/notifications-integrations"
+
+# prints a handy help menu with usage
+help_me() {
+    echo "USAGE: load-generator.sh {-n <NUM_RUNS>} {-i <INTERVAL>} [-h]"
+    echo "load-generator: creates load on inventory API by creating, updating, and deleting resources for test purposes"
+    echo "It requires a running local Inventory API or port-forwarding connection to one in ephemeral"
+    echo ""
+    echo "REQUIRED ARGUMENTS:"
+    echo "  -n NUM_RUNS: The number of times to run a test loop (one run is one create, update, and delete loop"
+    echo "  -i INTERVAL: Amount of time between runs"
+    echo ""
+    echo "OPTIONS:"
+    echo "  -h Prints usage information"
+    echo ""
+    echo "EXAMPLE:"
+    echo "# Run 5 test loops with a 3 second break between tests"
+    echo "  load-generator.sh -n 5 -i 3"
+    exit 0
+}
+
+livez_check() {
+  STATUS=$(curl -s $LIVEZ_URL | jq -r '.status')
+  if [[ "${STATUS}" != "OK" ]]; then
+    echo "LiveZ check failed -- is Inventory running or port-forwarded?"
+    exit 1
+  fi
+}
+
+while getopts "n:i:h" flag; do
+    case "${flag}" in
+        n) INTERVAL=${OPTARG};;
+        i) NUM_RUNS=${OPTARG};;
+        h) help_me;;
+    esac
+done
+
+if [[  -z "${NUM_RUNS}" || -z "${INTERVAL}" ]]; then
+  echo "Error: required arguments not provided"
+  help_me
+fi
+
+for ((i = 0 ; i < ${NUM_RUNS} ; i++)); do
+  livez_check
+  WORKSPACE_ID=$(uuidgen)
+  LOCAL_RESOURCE_ID=$(uuidgen)
+
+  REQUEST=$(jq -c --null-input \
+    --arg workspace_id  "$WORKSPACE_ID" \
+    --arg local_resource_id "$LOCAL_RESOURCE_ID" \
+    '{"integration":{"metadata":{"workspace_id":$workspace_id,"resource_type":"notifications/integration"},"reporter_data":{"reporter_instance_id":"service-account-1","reporter_type":"NOTIFICATIONS","local_resource_id":$local_resource_id}}}')
+
+  DELETE_REQUEST=$(jq -c --null-input \
+    --arg local_resource_id "$LOCAL_RESOURCE_ID" \
+    '{"reporter_data":{"reporter_type":"NOTIFICATIONS","local_resource_id":$local_resource_id}}')
+
+  echo "Creating resource..."
+  curl -H "Content-Type: application/json" -d $REQUEST $INVENTORY_URL
+  sleep 1
+
+  echo "Updating resource..."
+  curl -X PUT -H "Content-Type: application/json" -d $REQUEST $INVENTORY_URL
+  sleep 1
+  echo "Deleting resource..."
+  curl -X DELETE -H "Content-Type: application/json" -d $DELETE_REQUEST $INVENTORY_URL
+  sleep 1
+
+  sleep $INTERVAL
+done

--- a/scripts/load-generator.sh
+++ b/scripts/load-generator.sh
@@ -1,17 +1,15 @@
 #!/bin/bash
 
-LIVEZ_URL="localhost:8000/api/inventory/v1/livez"
-INVENTORY_URL="localhost:8000/api/inventory/v1beta1/resources/notifications-integrations"
-
 # prints a handy help menu with usage
 help_me() {
-    echo "USAGE: load-generator.sh {-n <NUM_RUNS>} {-i <INTERVAL>} [-h]"
+    echo "USAGE: load-generator.sh {-n <NUM_RUNS>} {-i <INTERVAL>} {-p <PORT_NUM>} [-h]"
     echo "load-generator: creates load on inventory API by creating, updating, and deleting resources for test purposes"
-    echo "It requires a running local Inventory API or port-forwarding connection to one in ephemeral"
+    echo "It requires a local running Inventory API or port-forwarding connection to one in ephemeral (usig port defined with -p)"
     echo ""
     echo "REQUIRED ARGUMENTS:"
     echo "  -n NUM_RUNS: The number of times to run a test loop (one run is one create, update, and delete loop"
     echo "  -i INTERVAL: Amount of time between runs"
+    echo "  -p PORT_NUM: Port number used for Inventory API"
     echo ""
     echo "OPTIONS:"
     echo "  -h Prints usage information"
@@ -30,18 +28,22 @@ livez_check() {
   fi
 }
 
-while getopts "n:i:h" flag; do
+while getopts "n:i:p:h" flag; do
     case "${flag}" in
-        n) INTERVAL=${OPTARG};;
-        i) NUM_RUNS=${OPTARG};;
+        n) NUM_RUNS=${OPTARG};;
+        i) INTERVAL=${OPTARG};;
+        p) PORT_NUM=${OPTARG};;
         h) help_me;;
     esac
 done
 
-if [[  -z "${NUM_RUNS}" || -z "${INTERVAL}" ]]; then
+if [[  -z "${NUM_RUNS}" || -z "${INTERVAL}"  || -z "${PORT_NUM}" ]]; then
   echo "Error: required arguments not provided"
   help_me
 fi
+
+LIVEZ_URL="localhost:${PORT_NUM}/api/inventory/v1/livez"
+INVENTORY_URL="localhost:${PORT_NUM}/api/inventory/v1beta1/resources/notifications-integrations"
 
 for ((i = 0 ; i < ${NUM_RUNS} ; i++)); do
   livez_check


### PR DESCRIPTION
### PR Template:

## Describe your changes

Metrics Updates:
* adds logic to consume loop to capture stats messages for client side metrics aggregation
* enables stats messages in Kafka config
* adds metrics package to capture and update metrics provided from stats message
* adds client_id setting to kafka config for use in labels

Non-Metrics Updates:
* code clean up (reshuffling, removes extra logging)
* adds load-generator script that can be used to spam the API to generate metrics or load test perhaps (very basic)
* updates notifications integration data file to use number over name for workspace ID

## Validation
```shell
# output of metrics endpoint with all the new metrics from stats

$ curl -s localhost:8000/metrics | grep inventory_consumer
# HELP inventory_consumer_assignment_size 
# TYPE inventory_consumer_assignment_size gauge
inventory_consumer_assignment_size{client_id="inventory-consumer",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version=""} 1
# HELP inventory_consumer_consumer_lag 
# TYPE inventory_consumer_consumer_lag gauge
inventory_consumer_consumer_lag{client_id="inventory-consumer",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version="",partition="0",topic="outbox.event.kessel.tuples"} 0
# HELP inventory_consumer_consumer_lag_stored 
# TYPE inventory_consumer_consumer_lag_stored gauge
inventory_consumer_consumer_lag_stored{client_id="inventory-consumer",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version="",partition="0",topic="outbox.event.kessel.tuples"} 0
# HELP inventory_consumer_fetchq_cnt 
# TYPE inventory_consumer_fetchq_cnt gauge
inventory_consumer_fetchq_cnt{client_id="inventory-consumer",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version="",partition="0",topic="outbox.event.kessel.tuples"} 0
# HELP inventory_consumer_fetchq_size 
# TYPE inventory_consumer_fetchq_size gauge
inventory_consumer_fetchq_size{client_id="inventory-consumer",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version="",partition="0",topic="outbox.event.kessel.tuples"} 0
# HELP inventory_consumer_fetchq_state 
# TYPE inventory_consumer_fetchq_state gauge
inventory_consumer_fetchq_state{client_id="inventory-consumer",fetch_state="active",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version=""} 0
# HELP inventory_consumer_hi_offset 
# TYPE inventory_consumer_hi_offset gauge
inventory_consumer_hi_offset{client_id="inventory-consumer",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version="",partition="0",topic="outbox.event.kessel.tuples"} 78
# HELP inventory_consumer_lo_offset 
# TYPE inventory_consumer_lo_offset gauge
inventory_consumer_lo_offset{client_id="inventory-consumer",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version="",partition="0",topic="outbox.event.kessel.tuples"} 0
# HELP inventory_consumer_ls_offset 
# TYPE inventory_consumer_ls_offset gauge
inventory_consumer_ls_offset{client_id="inventory-consumer",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version="",partition="0",topic="outbox.event.kessel.tuples"} 78
# HELP inventory_consumer_msgs_inflight 
# TYPE inventory_consumer_msgs_inflight gauge
inventory_consumer_msgs_inflight{client_id="inventory-consumer",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version="",partition="0",topic="outbox.event.kessel.tuples"} 0
# HELP inventory_consumer_rebalance_age 
# TYPE inventory_consumer_rebalance_age gauge
inventory_consumer_rebalance_age{client_id="inventory-consumer",last_rebalance_reason="Metadata for subscribed topic(s) has changed",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version=""} 576016
# HELP inventory_consumer_rebalance_cnt_total 
# TYPE inventory_consumer_rebalance_cnt_total counter
inventory_consumer_rebalance_cnt_total{client_id="inventory-consumer",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version=""} 39
# HELP inventory_consumer_replyq 
# TYPE inventory_consumer_replyq gauge
inventory_consumer_replyq{client_id="inventory-consumer",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version=""} 0
# HELP inventory_consumer_rxbytes_total 
# TYPE inventory_consumer_rxbytes_total counter
inventory_consumer_rxbytes_total{client_id="inventory-consumer",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version="",partition="0",topic="outbox.event.kessel.tuples"} 922345
# HELP inventory_consumer_rxmsgs_total 
# TYPE inventory_consumer_rxmsgs_total counter
inventory_consumer_rxmsgs_total{client_id="inventory-consumer",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version="",partition="0",topic="outbox.event.kessel.tuples"} 2021
# HELP inventory_consumer_state 
# TYPE inventory_consumer_state gauge
inventory_consumer_state{client_id="inventory-consumer",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version="",state="up"} 0
# HELP inventory_consumer_stateage 
# TYPE inventory_consumer_stateage gauge
inventory_consumer_stateage{client_id="inventory-consumer",name="inventory-consumer#consumer-1",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version=""} 0
```

## Ticket reference (if applicable)
For: RHCLOUD-38738

