### PR TITLE
fix default workspace for v1beta2

### DIFF
--- a/internal/biz/common.go
+++ b/internal/biz/common.go
@@ -2,6 +2,7 @@ package biz
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	authzapi "github.com/project-kessel/inventory-api/internal/authz/api"
@@ -51,7 +52,10 @@ func DefaultRelationshipSendEvent(ctx context.Context, m *model.Relationship, ev
 }
 
 func DefaultSetWorkspace(ctx context.Context, namespace string, model *model.Resource, authz authzapi.Authorizer) (string, error) {
-	r, err := authz.SetWorkspace(ctx, model.Reporter.LocalResourceId, model.WorkspaceId, namespace, model.ResourceType) //nolint:staticcheck
+	if model.ReporterType != "" {
+		namespace = strings.ToLower(model.ReporterType)
+	}
+	r, err := authz.SetWorkspace(ctx, model.ReporterResourceId, model.WorkspaceId, namespace, model.ResourceType) //nolint:staticcheck
 	if err != nil {
 		return "", err
 	}

--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -336,7 +337,11 @@ func (uc *Usecase) Delete(ctx context.Context, id model.ReporterResourceId) erro
 	}
 
 	if uc.Authz != nil {
-		err := biz.DefaultUnsetWorkspace(ctx, uc.Namespace, id.LocalResourceId, id.ResourceType, uc.Authz)
+		namespace := uc.Namespace
+		if id.ReporterType != "" {
+			namespace = strings.ToLower(id.ReporterType)
+		}
+		err := biz.DefaultUnsetWorkspace(ctx, namespace, id.LocalResourceId, id.ResourceType, uc.Authz)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/inventory_http_test.go
+++ b/test/e2e/inventory_http_test.go
@@ -139,7 +139,7 @@ func TestInventoryAPIHTTP_RHELHostLifecycle(t *testing.T) {
 			},
 			ReporterData: &resources.ReporterData{
 				ReporterInstanceId: "user@example.com",
-				ReporterType:       resources.ReporterData_ACM,
+				ReporterType:       resources.ReporterData_HBI,
 				ConsoleHref:        "www.example.com",
 				ApiHref:            "www.example.com",
 				LocalResourceId:    "0123",
@@ -160,7 +160,7 @@ func TestInventoryAPIHTTP_RHELHostLifecycle(t *testing.T) {
 			},
 			ReporterData: &resources.ReporterData{
 				ReporterInstanceId: "user@example.com",
-				ReporterType:       resources.ReporterData_ACM,
+				ReporterType:       resources.ReporterData_HBI,
 				ConsoleHref:        "www.exampleConsole.com",
 				ApiHref:            "www.exampleAPI.com",
 				LocalResourceId:    "0123",
@@ -174,7 +174,7 @@ func TestInventoryAPIHTTP_RHELHostLifecycle(t *testing.T) {
 	deleteRequest := resources.DeleteRhelHostRequest{
 		ReporterData: &resources.ReporterData{
 			ReporterInstanceId: "user@example.com",
-			ReporterType:       resources.ReporterData_ACM,
+			ReporterType:       resources.ReporterData_HBI,
 			ConsoleHref:        "www.exampleConsole.com",
 			ApiHref:            "www.exampleAPI.com",
 			LocalResourceId:    "0123",


### PR DESCRIPTION
### PR Template:

Fix the issue with a null resource.id send it to relationapi 
```
{
    "code": 400,
    "reason": "VALIDATOR",
    "message": "validation error:\n - tuples[0].resource.id: value length must be at least 1 characters [string.min_len]",
    "metadata": {}
}
```

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

