### PR TITLE
Dont update consistency token when deleting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,15 +234,15 @@ check-kafka-status:
 
 .PHONY: create-test-notification
 create-test-notification:
-	curl -H "Content-Type: application/json" -d @data/notifications-integrations.json localhost:8000/api/inventory/v1beta1/resources/notifications-integrations
+	curl -H "Content-Type: application/json" -d @data/testData/v1beta1/notifications-integrations.json localhost:8000/api/inventory/v1beta1/resources/notifications-integrations
 
 .PHONY: update-test-notification
 update-test-notification:
-	curl -X PUT -H "Content-Type: application/json" -d @data/notifications-integrations.json localhost:8000/api/inventory/v1beta1/resources/notifications-integrations
+	curl -X PUT -H "Content-Type: application/json" -d @data/testData/v1beta1/notifications-integrations.json localhost:8000/api/inventory/v1beta1/resources/notifications-integrations
 
 .PHONY: delete-test-notification
 delete-test-notification:
-	curl -X DELETE -H "Content-Type: application/json" -d @data/notifications-integration-reporter.json localhost:8000/api/inventory/v1beta1/resources/notifications-integrations
+	curl -X DELETE -H "Content-Type: application/json" -d @data/testData/v1beta1/notifications-integration-reporter.json localhost:8000/api/inventory/v1beta1/resources/notifications-integrations
 
 .PHONY: check-tuple-messages
 check-tuple-messages:

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"go.opentelemetry.io/otel"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"go.opentelemetry.io/otel"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/go-kratos/kratos/v2/log"
@@ -143,7 +144,7 @@ func (i *InventoryConsumer) Consume() error {
 					}
 				case "deleted":
 					i.Logger.Infof("operation=%s tuple=%s", operation, e.Value)
-					resp, err = i.DeleteTuple(context.Background(), e.Value)
+					_, err = i.DeleteTuple(context.Background(), e.Value)
 					if err != nil {
 						i.Logger.Infof("failed to delete tuple: %v", err)
 						continue
@@ -295,6 +296,11 @@ func (i *InventoryConsumer) DeleteTuple(ctx context.Context, msg []byte) (string
 // UpdateConsistencyToken updates the resource in the inventory DB to add the consistency token
 func (i *InventoryConsumer) UpdateConsistencyToken(msg []byte, token string) error {
 	var msgPayload *KeyPayload
+
+	// no consistency token to update with
+	if token == "" {
+		return nil
+	}
 
 	// msg key is expected to be the inventory_id of a resource
 	err := json.Unmarshal(msg, &msgPayload)


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Don't update the consistency token of a resource that has been deleted in the db.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

