### PR TITLE
Postgres Listen PoC (no notify, only Create)

### DIFF
--- a/internal/pubsub/driver.go
+++ b/internal/pubsub/driver.go
@@ -1,0 +1,103 @@
+package pubsub
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Driver interface {
+	Close(ctx context.Context) error
+	Connect(ctx context.Context) error
+	Listen(ctx context.Context, topic string) error
+	Ping(ctx context.Context) error
+	Unlisten(ctx context.Context, topic string) error
+	WaitForNotification(ctx context.Context) (*Notification, error)
+}
+
+func NewDriver(dbp *pgxpool.Pool) Driver {
+	return &driver{
+		mu:     sync.Mutex{},
+		dbPool: dbp,
+	}
+}
+
+type driver struct {
+	conn   *pgxpool.Conn
+	dbPool *pgxpool.Pool
+	mu     sync.Mutex
+}
+
+func (d *driver) Close(ctx context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.conn == nil {
+		return nil
+	}
+	err := d.conn.Conn().Close(ctx)
+	d.conn.Release()
+	d.conn = nil
+
+	return err
+}
+
+func (d *driver) Connect(ctx context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.conn != nil {
+		return errors.New("connection already established")
+	}
+
+	conn, err := d.dbPool.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+
+	d.conn = conn
+	return nil
+}
+
+func (d *driver) Listen(ctx context.Context, topic string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	_, err := d.conn.Exec(ctx, "LISTEN \""+topic+"\"")
+	return err
+}
+
+func (d *driver) Ping(ctx context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return d.conn.Ping(ctx)
+}
+
+func (d *driver) Unlisten(ctx context.Context, topic string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	_, err := d.conn.Exec(ctx, "UNLISTEN \""+topic+"\"")
+	return err
+}
+
+func (d *driver) WaitForNotification(ctx context.Context) (*Notification, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	pgn, err := d.conn.Conn().WaitForNotification(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	n := Notification{
+		Channel: pgn.Channel,
+		Payload: []byte(pgn.Payload),
+	}
+
+	return &n, nil
+}

--- a/internal/pubsub/listenmanager.go
+++ b/internal/pubsub/listenmanager.go
@@ -1,0 +1,144 @@
+package pubsub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-kratos/kratos/v2/log"
+)
+
+type ListenManager interface {
+	Subscribe(txId string) Subscription
+	Run(ctx context.Context) error
+}
+
+type Subscription interface {
+	NotificationC() <-chan []byte
+	Unsubscribe(ctx context.Context)
+}
+
+type Notification struct {
+	Channel string `json:"channel"`
+	Payload []byte `json:"payload"`
+}
+
+type subscription struct {
+	txId          string
+	listenChan    chan []byte
+	listenManager *listenManager
+	unsubOnce     sync.Once
+}
+
+func (s *subscription) NotificationC() <-chan []byte { return s.listenChan }
+
+func (s *subscription) Unsubscribe(ctx context.Context) {
+	s.unsubOnce.Do(func() {
+		// Unlisten uses background context in case of cancellation.
+		if err := s.listenManager.unsubscribe(context.Background(), s); err != nil {
+			s.listenManager.logger.Error("error unlistening on channel", "err", err, "txId", s.txId)
+		}
+	})
+}
+
+type listenManager struct {
+	mu                        sync.RWMutex
+	logger                    *log.Helper
+	driver                    Driver
+	subscriptions             map[string]*subscription
+	waitForNotificationCancel context.CancelFunc
+}
+
+func NewListenManager(logger *log.Helper, driver Driver) ListenManager {
+	return &listenManager{
+		mu:                        sync.RWMutex{},
+		logger:                    logger,
+		driver:                    driver,
+		subscriptions:             make(map[string]*subscription),
+		waitForNotificationCancel: context.CancelFunc(func() {}),
+	}
+}
+
+type channelChange struct {
+	channel   string
+	close     func()
+	operation string
+}
+
+// Listen returns a Subscription.
+// TODO change to Subscribe
+func (l *listenManager) Subscribe(txId string) Subscription {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	sub := &subscription{
+		txId:          txId,
+		listenChan:    make(chan []byte, 2),
+		listenManager: l,
+	}
+	l.subscriptions[txId] = sub
+
+	return sub
+}
+
+func (l *listenManager) waitAndDistribute(ctx context.Context) error {
+	// TODO: handle automatic reconnects
+	notification, err := func() (*Notification, error) {
+		const listenTimeout = 30 * time.Second
+
+		timeoutCtx, cancel := context.WithTimeout(ctx, listenTimeout)
+		defer cancel()
+
+		notification, err := l.driver.WaitForNotification(timeoutCtx)
+		if err != nil {
+			return nil, fmt.Errorf("error waiting for notification: %w", err)
+		}
+
+		return notification, nil
+	}()
+	if err != nil {
+		// If the error was a cancellation or the deadline being exceeded but
+		// there's no error in the parent context, return no error.
+		if (errors.Is(err, context.Canceled) ||
+			errors.Is(err, context.DeadlineExceeded)) && ctx.Err() == nil {
+			return nil
+		}
+
+		return err
+	}
+
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	for _, sub := range l.subscriptions {
+		select {
+		case sub.listenChan <- []byte(notification.Payload):
+		default:
+			l.logger.Error("dropped notification due to full buffer", "payload", notification.Payload)
+		}
+	}
+
+	return nil
+}
+
+func (l *listenManager) unsubscribe(ctx context.Context, sub *subscription) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	delete(l.subscriptions, sub.txId)
+
+	l.logger.Debugf("removed subscription by txId: %s", sub.txId)
+
+	return nil
+}
+
+func (l *listenManager) Run(ctx context.Context) error {
+	for {
+		err := l.waitAndDistribute(ctx)
+		if err != nil || ctx.Err() != nil {
+			return err
+		}
+	}
+}


### PR DESCRIPTION
- Implemented Listen/Notify PoC
  - Listens to a single pg channel `consumer-notifications` on app startup
  - Subscribers to `ListenManager` determine what notifications they care about based on a generated transaction ID (`txId`)
  - Request handlers create subscriptions to receive notifications and block the request context

### Components
**Driver:** Manages postgres connection and initiates `LISTEN`

**ListenManager:** Initiates `waitForNotification` via `Driver`. Manages subscriptions for all requests handlers. Receives and distributes notifications to subscriptions

**Subscriptions:** Created by request handlers via `ListenManager`. Have their own golang channels to receive notifications.


### TODO:
* Handle update & upsert (v1beta2) requests
* Handle automatic reconnects in case postgres goes down
* Remove debugging logs
* Do not crash when using sqlite