### PR TITLE
RHCLOUD-39132: Updates for adding debezium:

### DIFF
--- a/deploy/debezium/debezium-connector.yaml
+++ b/deploy/debezium/debezium-connector.yaml
@@ -13,12 +13,12 @@ objects:
     class: io.debezium.connector.postgresql.PostgresConnector
     tasksMax: ${{MAX_TASKS}}
     config:
-      database.server.name: ${DB_SERVERNAME}
-      database.dbname: ${DB_NAME}
-      database.hostname: ${DB_HOSTNAME}
-      database.port: ${DB_PORT}
-      database.user: ${DB_USER}
-      database.password: ${DB_PASSWORD}
+      database.server.name: kessel-inventory-db
+      database.dbname: ${secrets:kessel-inventory-db:db.name}
+      database.hostname: ${secrets:kessel-inventory-db:db.host}
+      database.port: ${secrets:kessel-inventory-db:db.port}
+      database.user: ${secrets:kessel-inventory-db:db.user}
+      database.password: ${secrets:kessel-inventory-db:db.password}
       topic.prefix: kessel-inventory
       table.include.list: public.outbox_events
       transforms: outbox
@@ -28,25 +28,6 @@ objects:
       heartbeat.action.query: ${DEBEZIUM_ACTION_QUERY}
       topic.heartbeat.prefix: ${TOPIC_HEARTBEAT_PREFIX}
 parameters:
-- name: DB_SERVERNAME
-  required: true
-  description: Logical name that identifies and provides a namespace for the particular database server
-  value: kessel-inventory-db
-- name: DB_NAME
-  required: true
-  description: Name for the database
-- name: DB_HOSTNAME
-  required: true
-  description: URI for the target postgres database
-- name: DB_PORT
-  value: "5432"
-  description: Port on which the target postgres database is listening for connections
-- name: DB_USER
-  description: Username the connector should use to connect to the target postgres database
-  required: true
-- name: DB_PASSWORD
-  description: Password for the above user on the target postgres database
-  required: true
 - name: KAFKA_CONNECT_INSTANCE
   value: platform-kafka-connect
   description: Name of the target Kafka Connect instance for Connector

--- a/deploy/kessel-inventory-ephem-w-debezium.yaml
+++ b/deploy/kessel-inventory-ephem-w-debezium.yaml
@@ -1,0 +1,304 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: inventory
+objects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: inventory-api-config
+    data:
+      inventory-api-config.yaml: |
+        storage:
+          disable-persistence: false
+        authn:
+          allow-unauthenticated: true
+        authz:
+          kessel:
+            insecure-client: true
+            enable-oidc-auth: false
+        consumer:
+          bootstrap-servers: inventory-kafka-kafka-bootstrap:9092
+          topic: outbox.event.kessel.tuples
+        log:
+          level: "debug"
+
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: connector-configuration-role
+    rules:
+    - apiGroups: [""]
+      resources: ["secrets"]
+      resourceNames: ["kessel-inventory-db"]
+      verbs: ["get"]
+
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: connector-configuration-rolebinding
+    subjects:
+    - kind: ServiceAccount
+      name: inventory-kafka-connect-connect
+    roleRef:
+      kind: Role
+      name: connector-configuration-role
+      apiGroup: rbac.authorization.k8s.io
+
+  - apiVersion: kafka.strimzi.io/v1beta2
+    kind: Kafka
+    metadata:
+      name: inventory-kafka
+    spec:
+      entityOperator:
+        template:
+          pod:
+            metadata:
+              labels:
+                service: strimziKafka
+          topicOperatorContainer:
+            env:
+            - name: STRIMZI_USE_FINALIZERS
+              value: "false"
+        tlsSidecar:
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 50Mi
+        topicOperator:
+          resources:
+            limits:
+              cpu: 200m
+              memory: 500Mi
+            requests:
+              cpu: 50m
+              memory: 250Mi
+        userOperator:
+          resources:
+            limits:
+              cpu: 400m
+              memory: 500Mi
+            requests:
+              cpu: 50m
+              memory: 250Mi
+      kafka:
+        config:
+          offsets.topic.replication.factor: "1"
+        jvmOptions: {}
+        listeners:
+        - name: tcp
+          port: 9092
+          tls: false
+          type: internal
+        replicas: 1
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 250m
+            memory: 600Mi
+        storage:
+          type: ephemeral
+        template:
+          perPodService:
+            metadata:
+              labels:
+                service: strimziKafka
+          pod:
+            metadata:
+              labels:
+                service: strimziKafka
+        version: 3.7.0
+      zookeeper:
+        replicas: 1
+        resources:
+          limits:
+            cpu: 350m
+            memory: 800Mi
+          requests:
+            cpu: 200m
+            memory: 400Mi
+        storage:
+          type: ephemeral
+        template:
+          nodesService:
+            metadata:
+              labels:
+                service: strimziKafka
+          pod:
+            metadata:
+              labels:
+                service: strimziKafka
+
+  - apiVersion: kafka.strimzi.io/v1beta2
+    kind: KafkaTopic
+    metadata:
+      name: "outbox.event.kessel.tuples"
+      labels:
+        strimzi.io/cluster: inventory-kafka
+    spec:
+      partitions: 1
+      replicas: 1
+      topicName: "outbox.event.kessel.tuples"
+
+  - apiVersion: kafka.strimzi.io/v1beta2
+    kind: KafkaTopic
+    metadata:
+      name: "outbox.event.kessel.resources"
+      labels:
+        strimzi.io/cluster: inventory-kafka
+    spec:
+      partitions: 1
+      replicas: 1
+      topicName: "outbox.event.kessel.resources"
+
+  - apiVersion: kafka.strimzi.io/v1beta2
+    kind: KafkaConnect
+    metadata:
+      annotations:
+        strimzi.io/use-connector-resources: "true"
+      generation: 1
+      name: inventory-kafka-connect
+    spec:
+      bootstrapServers: inventory-kafka-kafka-bootstrap:9092
+      config:
+        config.storage.replication.factor: "1"
+        config.storage.topic: connect-cluster-configs
+        connector.client.config.override.policy: All
+        group.id: connect-cluster
+        offset.storage.replication.factor: "1"
+        offset.storage.topic: connect-cluster-offsets
+        status.storage.replication.factor: "1"
+        status.storage.topic: connect-cluster-status
+        config.providers: secrets
+        config.providers.secrets.class: io.strimzi.kafka.KubernetesSecretConfigProvider
+      image: quay.io/cloudservices/kafka-connect:latest
+      replicas: 1
+      resources:
+        limits:
+          cpu: 500m
+          memory: 1Gi
+        requests:
+          cpu: 250m
+          memory: 512Mi
+      template:
+        pod:
+          imagePullSecrets:
+          - name: quay-cloudservices-pull
+      version: 3.7.0
+
+  - apiVersion: kafka.strimzi.io/v1beta2
+    kind: KafkaConnector
+    metadata:
+      name: kessel-inventory-source-connector
+      labels:
+        strimzi.io/cluster: inventory-kafka-connect
+    spec:
+      class: io.debezium.connector.postgresql.PostgresConnector
+      tasksMax: ${{MAX_TASKS}}
+      config:
+        database.server.name: kessel-inventory-db
+        database.dbname: ${secrets:kessel-inventory-db:db.name}
+        database.hostname: ${secrets:kessel-inventory-db:db.host}
+        database.port: ${secrets:kessel-inventory-db:db.port}
+        database.user: ${secrets:kessel-inventory-db:db.user}
+        database.password: ${secrets:kessel-inventory-db:db.password}
+        topic.prefix: kessel-inventory
+        table.whitelist: public.outbox_events # Required for Debezium < v1.3.0 support
+        table.include.list: public.outbox_events # Required for Debezium > v1.3.0
+        transforms: outbox
+        transforms.outbox.type: io.debezium.transforms.outbox.EventRouter
+        transforms.outbox.table.fields.additional.placement: operation:header
+        plugin.name: pgoutput
+        heartbeat.interval.ms: ${DEBEZIUM_HEARTBEAT_INTERVAL_MS}
+        heartbeat.action.query: ${DEBEZIUM_ACTION_QUERY}
+        topic.heartbeat.prefix: ${TOPIC_HEARTBEAT_PREFIX}
+
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdApp
+    metadata:
+      name: kessel-inventory
+    spec:
+      envName: ${ENV_NAME}
+      database:
+        name: kessel-inventory
+        version: 16
+      optionalDependencies:
+        - kessel-relations
+      deployments:
+        - name: api
+          replicas: ${{REPLICAS}}
+          podSpec:
+            initContainers:
+            - name: migration
+              image: ${INVENTORY_IMAGE}:${IMAGE_TAG}
+              imagePullPolicy: Always
+              command: ["inventory-api"]
+              args: ["migrate"]
+              inheritEnv: true
+            image: ${INVENTORY_IMAGE}:${IMAGE_TAG}
+            imagePullPolicy: Always
+            command: ["inventory-api"]
+            args: ["serve"]
+            livenessProbe:
+              httpGet:
+                path: /api/inventory/v1/livez
+                port: 8000
+            readinessProbe:
+              httpGet:
+                path: /api/inventory/v1/readyz
+                port: 8000
+            env:
+            - name: CLOWDER_ENABLED
+              value: "true"
+            - name: INVENTORY_API_CONFIG
+              value: "/inventory/inventory-api-config.yaml"
+            - name: PGDATA
+              value: /temp/data
+            volumeMounts:
+                - name: config-volume
+                  mountPath: "/inventory"
+            volumes:
+              - name: config-volume
+                configMap:
+                  name: inventory-api-config
+          webServices:
+            public:
+              enabled: true
+              apiPath: inventory
+      testing:
+        iqePlugin: kessel-inventory
+
+parameters:
+  - description: ClowdEnvironment name (ephemeral, stage, prod)
+    name: ENV_NAME
+    required: true
+  - description: App Image
+    name: INVENTORY_IMAGE
+    value: quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api
+  - description: Image Tag
+    name: IMAGE_TAG
+    required: true
+    value: latest
+  - description: Number of replicas
+    name: REPLICAS
+    value: "1"
+  - name: KAFKA_CONNECT_INSTANCE
+    value: inventory-kafka-connect
+    description: Name of the target Kafka Connect instance for Connector
+  - name: MAX_TASKS
+    value: "1"
+    description: How many tasks the Kafka Connect instance can create to process this Connector's work
+  - name: TOPIC_HEARTBEAT_PREFIX
+    value: debezium-heartbeat
+    description: Prefix for the connector heartbeat topic
+  - name: DEBEZIUM_ACTION_QUERY
+    value: "SELECT pg_logical_emit_message(false, 'heartbeat', now()::varchar);"
+    description: Query action that runs for each heartbeat event
+  - name: DEBEZIUM_HEARTBEAT_INTERVAL_MS
+    value: "300000"
+    description: The interval for the Debezium heartbeat in ms


### PR DESCRIPTION
### PR Template:

## Describe your changes
* adds deploy file for deplying inventory to ephemeral with debezium
* updates debezium deploy file to use secrets for stage/prod use

## Ticket reference (if applicable)
For # RHCLOUD-39132

## Summary by Sourcery

Add Debezium configuration for inventory service deployment with secrets-based configuration and ephemeral Kafka setup

New Features:
- Introduce a new deployment template for inventory service with Debezium connector integration

Enhancements:
- Modify Debezium connector to use secret-based configuration instead of direct environment variables
- Configure Kafka Connect with secret provider for secure configuration management

Deployment:
- Update Debezium connector configuration to use Kubernetes secrets for database connection parameters
- Add Kafka and KafkaConnect resources for ephemeral environment deployment