### PR TITLE
Refactor consumer for testing

### DIFF
--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -160,8 +160,11 @@ func (i *InventoryConsumer) Consume() error {
 			switch e := event.(type) {
 			case *kafka.Message:
 				headers := ParseHeaders(e)
+				operation := headers["operation"]
+				txid := headers["txid"]
 
 				var resp interface{}
+
 				resp, err = i.ProcessMessage(headers, relationsEnabled, e)
 				if err != nil {
 					i.Logger.Errorf("error processing message: %v", err)
@@ -169,7 +172,7 @@ func (i *InventoryConsumer) Consume() error {
 					continue
 				}
 
-				if headers["operation"] != string(model.OperationTypeDeleted) {
+				if operation != string(model.OperationTypeDeleted) {
 					inventoryID, err := ParseMessageKey(e.Key)
 					if err != nil {
 						i.Logger.Errorf("failed to parse message key for for ID: %v", err)
@@ -182,13 +185,13 @@ func (i *InventoryConsumer) Consume() error {
 				}
 
 				// if txid is present, we need to notify the producer that we've processed the message
-				if i.Notifier != nil && headers["txid"] != "" {
-					err := i.Notifier.Notify(context.Background(), headers["txid"])
+				if i.Notifier != nil && txid != "" {
+					err := i.Notifier.Notify(context.Background(), txid)
 					if err != nil {
 						i.Logger.Errorf("failed to notify producer: %v", err)
 						// Do not continue here, we should still commit the offset
 					} else {
-						i.Logger.Debugf("notified producer of processed message: %s" + headers["txid"])
+						i.Logger.Debugf("notified producer of processed message: %s" + txid)
 					}
 				} else {
 					i.Logger.Debugf("skipping notification to producer: txid not present or notifier not initialized")
@@ -223,7 +226,7 @@ func (i *InventoryConsumer) Consume() error {
 				}
 				i.MetricsCollector.Collect(stats)
 			default:
-				fmt.Printf("event type ignored %v\n", e)
+				i.Logger.Infof("event type ignored %v", e)
 			}
 		}
 	}
@@ -234,7 +237,7 @@ func (i *InventoryConsumer) Consume() error {
 	return err
 }
 
-func (i *InventoryConsumer) ProcessMessage(headers map[string]string, relationsEnabled bool, msg *kafka.Message) (interface{}, error) {
+func (i *InventoryConsumer) ProcessMessage(headers map[string]string, relationsEnabled bool, msg *kafka.Message) (string, error) {
 	operation := headers["operation"]
 	txid := headers["txid"]
 
@@ -245,13 +248,14 @@ func (i *InventoryConsumer) ProcessMessage(headers map[string]string, relationsE
 			tuple, err := ParseCreateOrUpdateMessage(msg.Value)
 			if err != nil {
 				i.Logger.Errorf("failed to parse message for tuple: %v", err)
+				return "", err
 			}
 			resp, err := i.Retry(func() (string, error) {
 				return i.CreateTuple(context.Background(), tuple)
 			})
 			if err != nil {
 				i.Logger.Errorf("failed to create tuple: %v", err)
-				return nil, err
+				return "", err
 			}
 			return resp, nil
 		}
@@ -262,13 +266,14 @@ func (i *InventoryConsumer) ProcessMessage(headers map[string]string, relationsE
 			tuple, err := ParseCreateOrUpdateMessage(msg.Value)
 			if err != nil {
 				i.Logger.Errorf("failed to parse message for tuple: %v", err)
+				return "", err
 			}
 			resp, err := i.Retry(func() (string, error) {
 				return i.UpdateTuple(context.Background(), tuple)
 			})
 			if err != nil {
 				i.Logger.Errorf("failed to update tuple: %v", err)
-				return nil, err
+				return "", err
 			}
 			return resp, nil
 		}
@@ -278,20 +283,21 @@ func (i *InventoryConsumer) ProcessMessage(headers map[string]string, relationsE
 			filter, err := ParseDeleteMessage(msg.Value)
 			if err != nil {
 				i.Logger.Errorf("failed to parse message for filter: %v", err)
+				return "", err
 			}
 			_, err = i.Retry(func() (string, error) {
 				return i.DeleteTuple(context.Background(), filter)
 			})
 			if err != nil {
 				i.Logger.Errorf("failed to delete tuple: %v", err)
-				return nil, err
+				return "", err
 			}
-			return nil, nil
+			return "", nil
 		}
 	default:
 		i.Logger.Infof("unknown operation: %v -- doing nothing", operation)
 	}
-	return nil, nil
+	return "", nil
 }
 
 func ParseHeaders(msg *kafka.Message) map[string]string {

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -1,0 +1,48 @@
+package mocks
+
+import (
+	"context"
+	"github.com/project-kessel/inventory-api/internal/biz/model"
+	kesselv1 "github.com/project-kessel/relations-api/api/kessel/relations/v1"
+	"github.com/project-kessel/relations-api/api/kessel/relations/v1beta1"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockAuthz struct {
+	mock.Mock
+}
+
+func (m *MockAuthz) Health(ctx context.Context) (*kesselv1.GetReadyzResponse, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(*kesselv1.GetReadyzResponse), args.Error(1)
+}
+
+func (m *MockAuthz) Check(ctx context.Context, namespace string, permission string, res *model.Resource, sub *v1beta1.SubjectReference) (v1beta1.CheckResponse_Allowed, *v1beta1.ConsistencyToken, error) {
+	args := m.Called(ctx, namespace, permission, res, sub)
+	return args.Get(0).(v1beta1.CheckResponse_Allowed), args.Get(1).(*v1beta1.ConsistencyToken), args.Error(2)
+}
+
+func (m *MockAuthz) CheckForUpdate(ctx context.Context, namespace string, permission string, res *model.Resource, sub *v1beta1.SubjectReference) (v1beta1.CheckForUpdateResponse_Allowed, *v1beta1.ConsistencyToken, error) {
+	args := m.Called(ctx, namespace, permission, res, sub)
+	return args.Get(0).(v1beta1.CheckForUpdateResponse_Allowed), args.Get(1).(*v1beta1.ConsistencyToken), args.Error(2)
+}
+
+func (m *MockAuthz) CreateTuples(ctx context.Context, req *v1beta1.CreateTuplesRequest) (*v1beta1.CreateTuplesResponse, error) {
+	args := m.Called(ctx, req)
+	return args.Get(0).(*v1beta1.CreateTuplesResponse), args.Error(1)
+}
+
+func (m *MockAuthz) DeleteTuples(ctx context.Context, request *v1beta1.DeleteTuplesRequest) (*v1beta1.DeleteTuplesResponse, error) {
+	args := m.Called(ctx, request)
+	return args.Get(0).(*v1beta1.DeleteTuplesResponse), args.Error(1)
+}
+
+func (m *MockAuthz) UnsetWorkspace(ctx context.Context, namespace, localResourceId, resourceType string) (*v1beta1.DeleteTuplesResponse, error) {
+	args := m.Called(ctx, namespace, localResourceId, resourceType)
+	return args.Get(0).(*v1beta1.DeleteTuplesResponse), args.Error(1)
+}
+
+func (m *MockAuthz) SetWorkspace(ctx context.Context, local_resource_id, workspace, namespace, name string) (*v1beta1.CreateTuplesResponse, error) {
+	args := m.Called(ctx, local_resource_id, workspace, namespace, name)
+	return args.Get(0).(*v1beta1.CreateTuplesResponse), args.Error(1)
+}


### PR DESCRIPTION
### PR Template:

## Describe your changes

Refactors for the sake of better testing
* creates mocks package to slowly migrate all mock definitions too so they can be used anywhere in code base
* migrates MockAuthz to new mocks pkg for use in consumer tests
* moves header parsing logic to its own function for testing
* moves message parsing logic in consumer switch to its own function to make it more testable outside of consume
* adds tests for testing ParseHeaders, Retry, and ProcessMessages functions

Test:
```shell
$ make test

Running tests.
# TODO: e2e tests are taking too long to be enabled by default. They need to be sped up.
?   	github.com/project-kessel/inventory-api/api	[no test files]
	github.com/project-kessel/inventory-api		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/api/kessel/inventory/v1		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1/authz		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1/relationships		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1/resources		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2/authz		coverage: 0.0% of statements
ok  	github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2	0.008s	coverage: 10.1% of statements
?   	github.com/project-kessel/inventory-api/internal/authn/api	[no test files]
?   	github.com/project-kessel/inventory-api/internal/authz/api	[no test files]
	github.com/project-kessel/inventory-api/internal/authn/clientcert		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/authn/psk		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/cmd/schema		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/cmd/common		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/cmd/serve		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/authn/delegator		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/authz		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/authn/util		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/cmd/migrate		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/authn/oidc		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/authn		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/authz/kessel		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/biz		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/authz/allow		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/authn/guest		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/biz/health		coverage: 0.0% of statements
ok  	github.com/project-kessel/inventory-api/cmd	0.089s	coverage: 55.2% of statements
ok  	github.com/project-kessel/inventory-api/internal/biz/model	0.011s	coverage: 36.7% of statements
ok  	github.com/project-kessel/inventory-api/internal/biz/relationships	0.013s	coverage: 77.1% of statements
ok  	github.com/project-kessel/inventory-api/internal/biz/resources	0.020s	coverage: 61.7% of statements
	github.com/project-kessel/inventory-api/internal/data/inventoryresources		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/consumer/retry		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/data		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/eventing/api		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/consumer/auth		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/consistency		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/errors		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/eventing/kafka		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/eventing/stdout		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/eventing		coverage: 0.0% of statements
ok  	github.com/project-kessel/inventory-api/internal/config	0.032s	coverage: 54.3% of statements
	github.com/project-kessel/inventory-api/internal/server		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/mocks		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/server/grpc		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/service/health		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/service/resources/k8spolicies		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/service/resources		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/service/resources/notificationsintegrations		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/service/resources/hosts		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/service/common		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/service/relationships/k8spolicy		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/service/resources/k8sclusters		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/storage/sqlite3		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/storage		coverage: 0.0% of statements
	github.com/project-kessel/inventory-api/internal/service/authz		coverage: 0.0% of statements
ok  	github.com/project-kessel/inventory-api/internal/consumer	4.542s	coverage: 41.8% of statements
ok  	github.com/project-kessel/inventory-api/internal/data/health	0.073s	coverage: 55.2% of statements
ok  	github.com/project-kessel/inventory-api/internal/data/relationships	0.088s	coverage: 83.3% of statements
ok  	github.com/project-kessel/inventory-api/internal/data/resources	0.089s	coverage: 62.9% of statements
ok  	github.com/project-kessel/inventory-api/internal/middleware	0.019s	coverage: 34.2% of statements
ok  	github.com/project-kessel/inventory-api/internal/pubsub	0.108s	coverage: 35.0% of statements
ok  	github.com/project-kessel/inventory-api/internal/server/http	0.017s	coverage: 1.4% of statements
ok  	github.com/project-kessel/inventory-api/internal/storage/postgres	0.006s	coverage: 52.8% of statements
ok  	github.com/project-kessel/inventory-api/test/e2e	0.012s	coverage: [no statements] [no tests to run]
ok  	github.com/project-kessel/inventory-api/test/e2e/grpc	15.000s	coverage: [no statements] [no tests to run]
Overall test coverage:
19.1%
```

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Refactor consumer package to improve testability and code organization

Enhancements:
- Extracted header parsing logic into a separate function
- Moved message processing logic to a separate method for better modularity
- Created a new mocks package to centralize mock definitions

Tests:
- Added comprehensive tests for ParseHeaders function
- Added tests for Retry method
- Added tests for ProcessMessage method
- Improved test coverage for consumer package

Chores:
- Migrated mock definitions from resources test file to a centralized mocks package