### PR TITLE
RHCLOUD-38741 - Add a doc on how to enable/config read-after-write settings

### DIFF
--- a/deploy/kessel-inventory-ephem-w-debezium.yaml
+++ b/deploy/kessel-inventory-ephem-w-debezium.yaml
@@ -30,7 +30,6 @@ objects:
         consistency:
           read-after-write-enabled: true # false == off for all service providers
           read-after-write-allowlist: [] # specify ["*"] to require all requests
-
         log:
           level: "debug"
 

--- a/deploy/kessel-inventory-ephem-w-debezium.yaml
+++ b/deploy/kessel-inventory-ephem-w-debezium.yaml
@@ -29,7 +29,7 @@ objects:
             sasl-password: REPLACE_ME
         consistency:
           read-after-write-enabled: true # false == off for all service providers
-          read-after-write-allowlist: [] # specify ["*"] to require all requests
+          read-after-write-allowlist: [] # specify ["*"] to allow any request to optionally r-a-w
         log:
           level: "debug"
 

--- a/deploy/kessel-inventory-ephem-w-debezium.yaml
+++ b/deploy/kessel-inventory-ephem-w-debezium.yaml
@@ -29,7 +29,7 @@ objects:
             sasl-password: REPLACE_ME
         consistency:
           read-after-write-enabled: true # false == off for all service providers
-          read-after-write-allowlist: [] # specify ["*"] to allow any request to optionally r-a-w
+          read-after-write-allowlist: ["*"] # specify ["*"] to allow any request to optionally r-a-w
         log:
           level: "debug"
 

--- a/deploy/kessel-inventory-ephem-w-debezium.yaml
+++ b/deploy/kessel-inventory-ephem-w-debezium.yaml
@@ -29,7 +29,8 @@ objects:
             sasl-password: REPLACE_ME
         consistency:
           read-after-write-enabled: true # false == off for all service providers
-          read-after-write-allowlist: [] # specify "*" to require all requests
+          read-after-write-allowlist: [] # specify ["*"] to require all requests
+
         log:
           level: "debug"
 

--- a/docs/read-after-write-enablement.md
+++ b/docs/read-after-write-enablement.md
@@ -20,9 +20,9 @@ Modify [.inventory-api.yaml](../.inventory-api.yaml).
    - Rebuild inventory after making these changes.
 
 ## Ephemeral Setup
-Modify [inventory-api.yaml](../deploy/kessel-inventory-ephem-w-debezium.yaml).
+Modify [kessel-inventory-ephem-w-debezium.yaml](../deploy/kessel-inventory-ephem-w-debezium.yaml).
    - Follow the same steps as for [Local Setup](#local-setup), ensuring to update the `reporter_id` in the allowlist if necessary.
-   - After changes are made, cycle the `inventory-api` pods or deploy them. For deployment instructions, refer to [ephemeral-testing.md](https://link-to-ephemeral-testing-doc).
+   - After changes are made, cycle the `inventory-api` pods or deploy them. For deployment instructions, refer to [ephemeral-testing.md](./ephemeral-testing.md).
 
 ## Stage/Prod Setup
  Changes should be managed via App Interface updates in a similar manner as [local](#local-setup) and [Ephemeral](#ephemeral-setup) setups but for the `inventory-api.yaml` data section.

--- a/docs/read-after-write-enablement.md
+++ b/docs/read-after-write-enablement.md
@@ -1,0 +1,81 @@
+# Configuring Read-After-Write 
+
+This guide walks through the setup of configuring read-after-write (r-a-w) enablement and sample configurations.
+
+## Local Setup 
+Modify [.inventory-api.yaml](../.inventory-api.yaml).
+   - Edit the `consistency` section with desired changes:
+     ```shell
+     consumer:
+       ...
+     consistency:
+       read-after-write-enabled: true # false == off for all service providers
+       read-after-write-allowlist: [] # specify "*" to require all requests
+     ```
+   - Ensure every request from a service provider is r-a-w enabled by updating the allowlist with their `reporter_id` field. For instance, for the Notifications service:
+     ```shell
+     read-after-write-enabled: true
+     read-after-write-allowlist: ["NOTIFICATIONS"]
+     ```
+   - Rebuild inventory after making these changes.
+
+## Ephemeral Setup
+Modify [inventory-api.yaml](../deploy/kessel-inventory-ephem-w-debezium.yaml).
+   - Follow the same steps as for [Local Setup](#local-setup), ensuring to update the `reporter_id` in the allowlist if necessary.
+   - After changes are made, cycle the `inventory-api` pods or deploy them. For deployment instructions, refer to [ephemeral-testing.md](https://link-to-ephemeral-testing-doc).
+
+## Stage/Prod Setup
+ Changes should be managed via App Interface updates in a similar manner as [local](#local-setup) and [Ephemeral](#ephemeral-setup) setups but for the `inventory-api.yaml` data section.
+   - After merging desired changes, pods will cycle to apply these modifications.
+
+
+## Example Configurations
+**Read After Write Enabled & All Service Providers**
+
+inventory-api-config.yaml:
+```shell
+consumer:
+    ...
+consistency:
+    read-after-write-enabled: true 
+    read-after-write-allowlist: ["*"] # ALL requests will be r-a-w
+```
+
+**Read After Write Enabled & Some Service Providers**
+
+NOTE: Requests that explicitly request for r-a-w via the `wait_for_sync` toggle will be allowed even if the SP is not in the allow list.
+
+inventory-api-config.yaml:
+```shell
+consumer:
+    ...
+consistency:
+    read-after-write-enabled: true 
+    read-after-write-allowlist: ["NOTIFICATIONS"] # All of notifications requests will be r-a-w
+```
+
+**Read After Write Enabled Globally (with Explicit Request)**
+
+NOTE: With no SPs in the allowlist all requests must explicitly request to be read after write. Otherwise, the behaviour will be fire-and-forget.
+
+inventory-api-config.yaml:
+```shell
+consumer:
+    ...
+consistency:
+    read-after-write-enabled: true 
+    read-after-write-allowlist: []
+```
+
+**Read After Write Disabled Globally**
+
+NOTE: All requests will behave as fire-and-forget.
+
+inventory-api-config.yaml:
+```shell
+consumer:
+    ...
+consistency:
+    read-after-write-enabled: false 
+    read-after-write-allowlist: []
+```

--- a/docs/read-after-write-enablement.md
+++ b/docs/read-after-write-enablement.md
@@ -10,7 +10,7 @@ Modify [.inventory-api.yaml](../.inventory-api.yaml).
        ...
      consistency:
        read-after-write-enabled: true # false == off for all service providers
-       read-after-write-allowlist: [] # specify "*" to require all requests
+       read-after-write-allowlist: [] # specify ["*"] to require all requests
      ```
    - Ensure every request from a service provider is r-a-w enabled by updating the allowlist with their `reporter_id` field. For instance, for the Notifications service:
      ```shell

--- a/docs/read-after-write-enablement.md
+++ b/docs/read-after-write-enablement.md
@@ -10,9 +10,9 @@ Modify [.inventory-api.yaml](../.inventory-api.yaml).
        ...
      consistency:
        read-after-write-enabled: true # false == off for all service providers
-       read-after-write-allowlist: [] # specify ["*"] to require all requests
+       read-after-write-allowlist: [] # specify ["*"] to allow any request to optionally r-a-w
      ```
-   - Ensure every request from a service provider is r-a-w enabled by updating the allowlist with their `reporter_id` field. For instance, for the Notifications service:
+   - Ensure every request from a service provider can be optionally r-a-w enabled by updating the allowlist with their `reporter_id` field. Individual requests will still be required to toggle `wait_for_sync` to behave as r-a-w. For instance, for the Notifications service:
      ```shell
      read-after-write-enabled: true
      read-after-write-allowlist: ["NOTIFICATIONS"]
@@ -38,12 +38,12 @@ consumer:
     ...
 consistency:
     read-after-write-enabled: true 
-    read-after-write-allowlist: ["*"] # ALL requests will be r-a-w
+    read-after-write-allowlist: ["*"] # ALL requests can optionally be r-a-w
 ```
 
 **Read After Write Enabled & Some Service Providers**
 
-NOTE: Requests that explicitly request for r-a-w via the `wait_for_sync` toggle will be allowed even if the SP is not in the allow list.
+NOTE: Requests that explicitly request for r-a-w via the `wait_for_sync` toggle will be allowed ONLY if the SP is in the allow list.
 
 inventory-api-config.yaml:
 ```shell
@@ -51,12 +51,12 @@ consumer:
     ...
 consistency:
     read-after-write-enabled: true 
-    read-after-write-allowlist: ["NOTIFICATIONS"] # All of notifications requests will be r-a-w
+    read-after-write-allowlist: ["NOTIFICATIONS"] # Notifications requests can optionally be r-a-w
 ```
 
 **Read After Write Enabled Globally (with Explicit Request)**
 
-NOTE: With no SPs in the allowlist all requests must explicitly request to be read after write. Otherwise, the behaviour will be fire-and-forget.
+NOTE: With no SPs in the allowlist all requests will be fire-and-forget.
 
 inventory-api-config.yaml:
 ```shell

--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -443,5 +443,5 @@ func computeReadAfterWrite(uc *Usecase, wait_for_sync bool, m *model.Resource) b
 	// read after write functionality is enabled/disabled globally.
 	// And executed if request specifies or
 	// request came from service provider in allowlist
-	return uc.ListenManager != nil && uc.ReadAfterWriteEnabled && (wait_for_sync || isSPInAllowlist(m, uc.ReadAfterWriteAllowlist))
+	return uc.ListenManager != nil && uc.ReadAfterWriteEnabled && (wait_for_sync && isSPInAllowlist(m, uc.ReadAfterWriteAllowlist))
 }

--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -441,7 +441,7 @@ func isSPInAllowlist(m *model.Resource, allowlist []string) bool {
 
 func computeReadAfterWrite(uc *Usecase, wait_for_sync bool, m *model.Resource) bool {
 	// read after write functionality is enabled/disabled globally.
-	// And executed if request specifies or
-	// request came from service provider in allowlist
-	return uc.ListenManager != nil && uc.ReadAfterWriteEnabled && (wait_for_sync && isSPInAllowlist(m, uc.ReadAfterWriteAllowlist))
+	// And executed if request specifies and
+	// came from service provider in allowlist
+	return uc.ListenManager != nil && uc.ReadAfterWriteEnabled && wait_for_sync && isSPInAllowlist(m, uc.ReadAfterWriteAllowlist)
 }

--- a/internal/biz/resources/resources_test.go
+++ b/internal/biz/resources/resources_test.go
@@ -1084,6 +1084,61 @@ func TestIsSPInAllowlist(t *testing.T) {
 	}
 }
 
+func TestComputeReadAfterWrite(t *testing.T) {
+	tests := []struct {
+		name                    string
+		waitForSync             bool
+		ReadAfterWriteEnabled   bool
+		ReadAfterWriteAllowlist []string
+		expected                bool
+	}{
+		{
+			name:                    "Enable Read After Write, Wait for Sync, SP in Allowlist",
+			ReadAfterWriteEnabled:   true,
+			waitForSync:             true,
+			ReadAfterWriteAllowlist: []string{"SP1"},
+			expected:                true,
+		},
+		{
+			name:                    "Enable Read After Write, No Wait for Sync, SP in Allowlist",
+			ReadAfterWriteEnabled:   true,
+			waitForSync:             false,
+			ReadAfterWriteAllowlist: []string{"SP1"},
+			expected:                false,
+		},
+		{
+			name:                    "Enable Read After Write, Wait for Sync, No SP in Allowlist",
+			ReadAfterWriteEnabled:   true,
+			waitForSync:             true,
+			ReadAfterWriteAllowlist: []string{},
+			expected:                false,
+		},
+		{
+			name:                    "Disable Read After Write, No Wait for Sync, SP not in Allowlist",
+			ReadAfterWriteEnabled:   false,
+			waitForSync:             false,
+			ReadAfterWriteAllowlist: []string{"SP2"},
+			expected:                false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uc := &Usecase{
+				ListenManager:           &pubsub.ListenManager{},
+				ReadAfterWriteEnabled:   tt.ReadAfterWriteEnabled,
+				ReadAfterWriteAllowlist: tt.ReadAfterWriteAllowlist,
+			}
+
+			m := &model.Resource{
+				ReporterId: "SP1",
+			}
+			assert.Equal(t, tt.expected, computeReadAfterWrite(uc, tt.waitForSync, m))
+
+		})
+	}
+}
+
 func TestUpsertReturnsDbError(t *testing.T) {
 	resource := resource1()
 	repo := &MockedReporterResourceRepository{}

--- a/internal/biz/resources/resources_test.go
+++ b/internal/biz/resources/resources_test.go
@@ -1107,10 +1107,31 @@ func TestComputeReadAfterWrite(t *testing.T) {
 			expected:                false,
 		},
 		{
+			name:                    "Enable Read After Write, Wait for Sync, ALL SPs in Allowlist",
+			ReadAfterWriteEnabled:   true,
+			waitForSync:             true,
+			ReadAfterWriteAllowlist: []string{"*"},
+			expected:                true,
+		},
+		{
+			name:                    "Enable Read After Write, No Wait for Sync, ALL SPs in Allowlist",
+			ReadAfterWriteEnabled:   true,
+			waitForSync:             false,
+			ReadAfterWriteAllowlist: []string{"*"},
+			expected:                false,
+		},
+		{
 			name:                    "Enable Read After Write, Wait for Sync, No SP in Allowlist",
 			ReadAfterWriteEnabled:   true,
 			waitForSync:             true,
 			ReadAfterWriteAllowlist: []string{},
+			expected:                false,
+		},
+		{
+			name:                    "Enable Read After Write, Wait for Sync, SP not in Allowlist",
+			ReadAfterWriteEnabled:   true,
+			waitForSync:             true,
+			ReadAfterWriteAllowlist: []string{"SP2"},
 			expected:                false,
 		},
 		{


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Adds a doc on configuring the read-after-write settings. 
- - Enabling/disable & adding service providers to the allowlist.
- Instructions for local & ephemeral 
- Sample configurations and behaviours 
- Updates to computeReadAfterWrite bool (SP must be in allowlist + optional toggle to use r-a-w)
- - Added testcase for computeReadAfterWrite func

## Ticket reference (if applicable)
Fixes # https://issues.redhat.com/browse/RHCLOUD-38741

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Add documentation for configuring read-after-write settings in the inventory API

New Features:
- Provide detailed guidance on configuring read-after-write settings for local, ephemeral, stage, and production environments

Enhancements:
- Introduce configuration options for read-after-write enablement, including global and service provider-specific settings

Documentation:
- Create comprehensive documentation explaining how to enable, configure, and use read-after-write (r-a-w) settings across different environments