### PR TITLE
adds parameter for defining the secret name to blue/green api configs

### DIFF
--- a/deploy/kessel-inventory.yaml
+++ b/deploy/kessel-inventory.yaml
@@ -54,7 +54,7 @@ objects:
             volumes:
               - name: config-volume
                 secret:
-                  secretName: inventory-api-config
+                  secretName: ${INVENTORY_API_CONFIG_SECRET}
           webServices:
             public:
               enabled: true
@@ -86,3 +86,6 @@ parameters:
   - description: Number of replicas
     name: REPLICAS
     value: "1"
+  - description: Name of the Inventory API Config K8s secret
+    name: INVENTORY_API_CONFIG_SECRET
+    value: inventory-api-config


### PR DESCRIPTION
### PR Template:

## Describe your changes

When we look to deploy all the v1beta2 and consistency changes to stage prod, we'll need to roll out a new inventory api config secret. The new secret has been created in clusters, this new parameter allows us to define the name of the secret to target for the inventory API config. When we are ready to switch over to the new secret, we can set this variable in app interface to point to the new secret (`inventory-api-config-v1beta2`)

The default value is set to the current secret name which means its a no-op for current setup

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Add a configurable parameter to specify the Kubernetes secret name for inventory API configuration

New Features:
- Enable flexible secret naming for inventory API configuration with a default value that maintains existing behavior

Enhancements:
- Introduce a new parameter INVENTORY_API_CONFIG_SECRET to allow dynamic specification of the Kubernetes secret used for inventory API configuration