### PR TITLE
RHCLOUD-39375: Fixes bug where update calls fail on pre-existing relation 

### DIFF
--- a/internal/authz/allow/allow.go
+++ b/internal/authz/allow/allow.go
@@ -85,6 +85,6 @@ func (a *AllowAllAuthz) UnsetWorkspace(ctx context.Context, local_resource_id, n
 	return &v1beta1.DeleteTuplesResponse{}, nil
 }
 
-func (a *AllowAllAuthz) SetWorkspace(ctx context.Context, local_resource_id, workspace, name, namespace string) (*v1beta1.CreateTuplesResponse, error) {
+func (a *AllowAllAuthz) SetWorkspace(ctx context.Context, local_resource_id, workspace, name, namespace string, upsert bool) (*v1beta1.CreateTuplesResponse, error) {
 	return &v1beta1.CreateTuplesResponse{}, nil
 }

--- a/internal/authz/api/authz-service.go
+++ b/internal/authz/api/authz-service.go
@@ -17,5 +17,5 @@ type Authorizer interface {
 	CreateTuples(context.Context, *kessel.CreateTuplesRequest) (*kessel.CreateTuplesResponse, error)
 	DeleteTuples(context.Context, *kessel.DeleteTuplesRequest) (*kessel.DeleteTuplesResponse, error)
 	UnsetWorkspace(context.Context, string, string, string) (*kessel.DeleteTuplesResponse, error)
-	SetWorkspace(context.Context, string, string, string, string) (*kessel.CreateTuplesResponse, error)
+	SetWorkspace(context.Context, string, string, string, string, bool) (*kessel.CreateTuplesResponse, error)
 }

--- a/internal/authz/kessel/kessel.go
+++ b/internal/authz/kessel/kessel.go
@@ -238,6 +238,7 @@ func (a *KesselAuthz) CheckForUpdate(ctx context.Context, namespace string, upda
 	return resp.GetAllowed(), resp.GetConsistencyToken(), nil
 }
 
+// SetWorkspace upsert inserts the relationship in relations if it doesn't exist and otherwise does nothing
 func (a *KesselAuthz) SetWorkspace(ctx context.Context, local_resource_id, workspace, namespace, name string, upsert bool) (*kessel.CreateTuplesResponse, error) {
 	if workspace == "" {
 		a.incrFailureCounter("SetWorkspace")

--- a/internal/authz/kessel/kessel.go
+++ b/internal/authz/kessel/kessel.go
@@ -238,7 +238,7 @@ func (a *KesselAuthz) CheckForUpdate(ctx context.Context, namespace string, upda
 	return resp.GetAllowed(), resp.GetConsistencyToken(), nil
 }
 
-func (a *KesselAuthz) SetWorkspace(ctx context.Context, local_resource_id, workspace, namespace, name string) (*kessel.CreateTuplesResponse, error) {
+func (a *KesselAuthz) SetWorkspace(ctx context.Context, local_resource_id, workspace, namespace, name string, upsert bool) (*kessel.CreateTuplesResponse, error) {
 	if workspace == "" {
 		a.incrFailureCounter("SetWorkspace")
 		return nil, fmt.Errorf("workspace_id is required")
@@ -266,6 +266,7 @@ func (a *KesselAuthz) SetWorkspace(ctx context.Context, local_resource_id, works
 
 	a.incrSuccessCounter("SetWorkspace")
 	return a.CreateTuples(ctx, &kessel.CreateTuplesRequest{
+		Upsert: upsert,
 		Tuples: rels,
 	})
 }

--- a/internal/biz/common.go
+++ b/internal/biz/common.go
@@ -51,11 +51,11 @@ func DefaultRelationshipSendEvent(ctx context.Context, m *model.Relationship, ev
 	return nil
 }
 
-func DefaultSetWorkspace(ctx context.Context, namespace string, model *model.Resource, authz authzapi.Authorizer) (string, error) {
+func DefaultSetWorkspace(ctx context.Context, namespace string, model *model.Resource, authz authzapi.Authorizer, upsert bool) (string, error) {
 	if model.ReporterType != "" {
 		namespace = strings.ToLower(model.ReporterType)
 	}
-	r, err := authz.SetWorkspace(ctx, model.ReporterResourceId, model.WorkspaceId, namespace, model.ResourceType) //nolint:staticcheck
+	r, err := authz.SetWorkspace(ctx, model.ReporterResourceId, model.WorkspaceId, namespace, model.ResourceType, upsert) //nolint:staticcheck
 	if err != nil {
 		return "", err
 	}

--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -134,7 +134,7 @@ func createNewReporterResource(ctx context.Context, m *model.Resource, uc *Useca
 
 	if uc.Authz != nil {
 		// Send workspace for the created resource
-		ct, err := biz.DefaultSetWorkspace(ctx, uc.Namespace, ret, uc.Authz)
+		ct, err := biz.DefaultSetWorkspace(ctx, uc.Namespace, ret, uc.Authz, false)
 		if err != nil {
 			return nil, err
 		}
@@ -149,7 +149,7 @@ func createNewReporterResource(ctx context.Context, m *model.Resource, uc *Useca
 		}
 		// Send workspace for any updated resources
 		for _, updatedResource := range updatedResources {
-			ct, err := biz.DefaultSetWorkspace(ctx, uc.Namespace, updatedResource, uc.Authz)
+			ct, err := biz.DefaultSetWorkspace(ctx, uc.Namespace, updatedResource, uc.Authz, false)
 			if err != nil {
 				return nil, err
 			}
@@ -202,7 +202,7 @@ func updateExistingReporterResource(ctx context.Context, m *model.Resource, exis
 
 	if uc.Authz != nil {
 		for _, updatedResource := range updatedResources {
-			_, err := biz.DefaultSetWorkspace(ctx, uc.Namespace, updatedResource, uc.Authz)
+			_, err := biz.DefaultSetWorkspace(ctx, uc.Namespace, updatedResource, uc.Authz, true)
 			if err != nil {
 				return nil, err
 			}
@@ -415,7 +415,7 @@ func (uc *Usecase) Create(ctx context.Context, m *model.Resource) (*model.Resour
 
 	if uc.Authz != nil {
 		// Send workspace for the created resource
-		ct, err := biz.DefaultSetWorkspace(ctx, uc.Namespace, ret, uc.Authz)
+		ct, err := biz.DefaultSetWorkspace(ctx, uc.Namespace, ret, uc.Authz, false)
 		if err != nil {
 			return nil, err
 		}
@@ -431,7 +431,7 @@ func (uc *Usecase) Create(ctx context.Context, m *model.Resource) (*model.Resour
 
 		// Send workspace for any updated resources
 		for _, updatedResource := range updatedResources {
-			ct, err := biz.DefaultSetWorkspace(ctx, uc.Namespace, updatedResource, uc.Authz)
+			ct, err := biz.DefaultSetWorkspace(ctx, uc.Namespace, updatedResource, uc.Authz, false)
 			if err != nil {
 				return nil, err
 			}
@@ -490,7 +490,7 @@ func (uc *Usecase) Update(ctx context.Context, m *model.Resource, id model.Repor
 
 	if uc.Authz != nil {
 		for _, updatedResource := range updatedResources {
-			_, err := biz.DefaultSetWorkspace(ctx, uc.Namespace, updatedResource, uc.Authz)
+			_, err := biz.DefaultSetWorkspace(ctx, uc.Namespace, updatedResource, uc.Authz, true)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/biz/resources/resources_test.go
+++ b/internal/biz/resources/resources_test.go
@@ -246,7 +246,7 @@ func (m *MockAuthz) UnsetWorkspace(ctx context.Context, namespace, localResource
 	return args.Get(0).(*v1beta1.DeleteTuplesResponse), args.Error(1)
 }
 
-func (m *MockAuthz) SetWorkspace(ctx context.Context, local_resource_id, workspace, namespace, name string) (*v1beta1.CreateTuplesResponse, error) {
+func (m *MockAuthz) SetWorkspace(ctx context.Context, local_resource_id, workspace, namespace, name string, upsert bool) (*v1beta1.CreateTuplesResponse, error) {
 	args := m.Called(ctx, local_resource_id, workspace, namespace, name)
 	return args.Get(0).(*v1beta1.CreateTuplesResponse), args.Error(1)
 }

--- a/internal/biz/resources/resources_test.go
+++ b/internal/biz/resources/resources_test.go
@@ -247,7 +247,7 @@ func (m *MockAuthz) UnsetWorkspace(ctx context.Context, namespace, localResource
 }
 
 func (m *MockAuthz) SetWorkspace(ctx context.Context, local_resource_id, workspace, namespace, name string, upsert bool) (*v1beta1.CreateTuplesResponse, error) {
-	args := m.Called(ctx, local_resource_id, workspace, namespace, name)
+	args := m.Called(ctx, local_resource_id, workspace, namespace, name, upsert)
 	return args.Get(0).(*v1beta1.CreateTuplesResponse), args.Error(1)
 }
 
@@ -395,7 +395,7 @@ func TestCreateNewResource_ConsistencyToken(t *testing.T) {
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return((*model.Resource)(nil), gorm.ErrRecordNotFound)
 	repo.On("Create", mock.Anything, mock.Anything).Return(&returnedResource, []*model.Resource{}, nil)
 
-	m.On("SetWorkspace", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&v1beta1.CreateTuplesResponse{ConsistencyToken: &v1beta1.ConsistencyToken{Token: "foo-bar-consistency-token"}}, nil)
+	m.On("SetWorkspace", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&v1beta1.CreateTuplesResponse{ConsistencyToken: &v1beta1.ConsistencyToken{Token: "foo-bar-consistency-token"}}, nil)
 	repo.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(&model.Resource{}, []*model.Resource{}, nil)
 
 	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, false)


### PR DESCRIPTION
RHCLOUD-39375: Fixes bug where update calls fail on pre-existing relationship in relations-api/spicedb.
For example, `SetWorkspace` fails if called twice, even in the context of update resource queries. (Relations-api/spicedb requires upsert semantics if the relationship already exists and an error is the wrong response in the context.)

### PR Template:

## Describe your changes

- Relations-api `upsert` semantics exposed to callers of `SetWorkspace` and `DefaultSetWorkspace`.
- Upsert continues to be `false` for creates.
- Upsert is now `true` for updates.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Add upsert semantics to workspace relationship creation to handle pre-existing relationships in the authorization API

Bug Fixes:
- Fix update calls that previously failed when attempting to set a workspace relationship that already exists

Enhancements:
- Modify SetWorkspace method across multiple authorization implementations to support optional upsert behavior
- Add an upsert flag to workspace relationship creation to prevent errors on duplicate relationships