### PR TITLE
RHCLOUD-39404: Remove TODO for HTTP lookup streaming endpoint

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -170,7 +170,6 @@ func NewCommand(
 			lookup_controller := resourcesctl.New(resource_repo, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), storageConfig.Options.DisablePersistence)
 			lookup_service := authzsvc.NewKesselLookupService(lookup_controller)
 			authzv1beta2.RegisterKesselLookupServiceServer(server.GrpcServer, lookup_service)
-			//TODO: http service not getting generated
 
 			//v1beta1
 			// wire together notificationsintegrations handling


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Remove TODO from serve.go because HTTP does not support streaming only GRPC

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Chores:
- Remove an outdated TODO comment in serve.go that was no longer relevant