### PR TITLE
RHCLOUD-39386: v1beta2 support

### DIFF
--- a/internal/biz/model/outboxevents.go
+++ b/internal/biz/model/outboxevents.go
@@ -188,6 +188,11 @@ func convertResourceToResourceEvent(resource Resource, operationType EventOperat
 func convertResourceToSetTupleEvent(resource Resource, namespace string) (JsonObject, error) {
 	payload := JsonObject{}
 
+	if resource.ReporterType != "" {
+		// v1beta2 compatibility for namespace override, see common/DefaultSetWorkspace for parity
+		namespace = strings.ToLower(resource.ReporterType)
+	}
+
 	relationship := &kessel.Relationship{
 		Resource: &kessel.ObjectReference{
 			Type: &kessel.ObjectType{

--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -82,14 +82,7 @@ func (uc *Usecase) Upsert(ctx context.Context, m *model.Resource, wait_for_sync 
 	log.Info("upserting resource: ", m)
 	ret := m // Default to returning the input model in case persistence is disabled
 	var subscription pubsub.Subscription
-
-	// Generate txid for data layer
-	// TODO: Replace this when inventory api has proper api-level transaction ids
-	txid, err := uuid.NewV7()
-	if err != nil {
-		return nil, err
-	}
-	txidStr := txid.String()
+	var txidStr string
 
 	if !uc.DisablePersistence {
 		// check if the resource already exists
@@ -101,7 +94,14 @@ func (uc *Usecase) Upsert(ctx context.Context, m *model.Resource, wait_for_sync 
 
 		readAfterWriteEnabled := computeReadAfterWrite(uc, wait_for_sync, m)
 		if readAfterWriteEnabled {
-			subscription = uc.ListenManager.Subscribe(txid.String())
+			// Generate txid for data layer
+			// TODO: Replace this when inventory api has proper api-level transaction ids
+			txid, err := uuid.NewV7()
+			if err != nil {
+				return nil, err
+			}
+			txidStr = txid.String()
+			subscription = uc.ListenManager.Subscribe(txidStr)
 			defer subscription.Unsubscribe()
 		}
 
@@ -285,13 +285,7 @@ func (uc *Usecase) ListResourcesInWorkspace(ctx context.Context, permission, nam
 func (uc *Usecase) Create(ctx context.Context, m *model.Resource, wait_for_sync bool) (*model.Resource, error) {
 	ret := m // Default to returning the input model in case persistence is disabled
 	var subscription pubsub.Subscription
-
-	// Generate txid for data layer
-	// TODO: Replace this when inventory api has proper api-level transaction ids
-	txid, err := uuid.NewV7()
-	if err != nil {
-		return nil, err
-	}
+	var txidStr string
 
 	if !uc.DisablePersistence {
 		// check if the resource already exists
@@ -311,11 +305,18 @@ func (uc *Usecase) Create(ctx context.Context, m *model.Resource, wait_for_sync 
 
 		readAfterWriteEnabled := computeReadAfterWrite(uc, wait_for_sync, m)
 		if readAfterWriteEnabled {
-			subscription = uc.ListenManager.Subscribe(txid.String())
+			// Generate txid for data layer
+			// TODO: Replace this when inventory api has proper api-level transaction ids
+			txid, err := uuid.NewV7()
+			if err != nil {
+				return nil, err
+			}
+			txidStr = txid.String()
+			subscription = uc.ListenManager.Subscribe(txidStr)
 			defer subscription.Unsubscribe()
 		}
 
-		ret, err = uc.reporterResourceRepository.Create(ctx, m, uc.Namespace, txid.String())
+		ret, err = uc.reporterResourceRepository.Create(ctx, m, uc.Namespace, txidStr)
 		if err != nil {
 			return nil, err
 		}
@@ -343,14 +344,7 @@ func (uc *Usecase) Create(ctx context.Context, m *model.Resource, wait_for_sync 
 func (uc *Usecase) Update(ctx context.Context, m *model.Resource, id model.ReporterResourceId, wait_for_sync bool) (*model.Resource, error) {
 	ret := m // Default to returning the input model in case persistence is disabled
 	var subscription pubsub.Subscription
-
-	// Generate txid for data layer
-	// TODO: Replace this when inventory api has proper api-level transaction ids
-	txid, err := uuid.NewV7()
-	if err != nil {
-		return nil, err
-	}
-	txidStr := txid.String()
+	var txidStr string
 
 	if !uc.DisablePersistence {
 		// check if the resource exists
@@ -370,7 +364,14 @@ func (uc *Usecase) Update(ctx context.Context, m *model.Resource, id model.Repor
 
 		readAfterWriteEnabled := computeReadAfterWrite(uc, wait_for_sync, m)
 		if readAfterWriteEnabled {
-			subscription = uc.ListenManager.Subscribe(txid.String())
+			// Generate txid for data layer
+			// TODO: Replace this when inventory api has proper api-level transaction ids
+			txid, err := uuid.NewV7()
+			if err != nil {
+				return nil, err
+			}
+			txidStr = txid.String()
+			subscription = uc.ListenManager.Subscribe(txidStr)
 			defer subscription.Unsubscribe()
 		}
 


### PR DESCRIPTION
- Adds ReporterType mapping to namespace for v1beta2 on outbox events
- Adds test for new ReporterType / Outbox mapping 
- Isolates consistency txids to only generate on readAfterWrite enabled requests

## Summary by Sourcery

Implement v1beta2 support for outbox events and improve transaction ID generation for read-after-write scenarios

New Features:
- Add support for v1beta2 namespace mapping using ReporterType

Enhancements:
- Optimize transaction ID generation to only create when read-after-write is enabled
- Modify outbox event generation to support v1beta2 namespace override

Tests:
- Add test cases for v1beta2 outbox event generation with ReporterType namespace mapping