### PR TITLE
Lint internal eventual consistency code.

### DIFF
--- a/internal/biz/model/outboxevents.go
+++ b/internal/biz/model/outboxevents.go
@@ -114,10 +114,7 @@ func newResourceEvent(operationType EventOperationType, resource *Resource) (*Re
 
 	var labels []EventResourceLabel
 	for _, val := range resource.Labels {
-		labels = append(labels, EventResourceLabel{
-			Key:   val.Key,
-			Value: val.Value,
-		})
+		labels = append(labels, EventResourceLabel(val))
 	}
 
 	var reportedTime time.Time
@@ -177,11 +174,15 @@ func convertResourceToResourceEvent(resource Resource, operationType EventOperat
 		return nil, fmt.Errorf("failed to create resource event: %w", err)
 	}
 
-	marshalledJson, error := json.Marshal(resourceEvent)
-	if error != nil {
-		return nil, fmt.Errorf("failed to marshal resource to json: %w", error)
+	marshalledJson, err := json.Marshal(resourceEvent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal resource to json: %w", err)
 	}
-	json.Unmarshal(marshalledJson, &payload)
+
+	err = json.Unmarshal(marshalledJson, &payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json to payload: %w", err)
+	}
 
 	return payload, nil
 }

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -30,8 +30,8 @@ import (
 	"gorm.io/gorm"
 )
 
-var ClosedError = errors.New("consumer closed")
-var MaxRetriesError = errors.New("max retries reached")
+var ErrClosed = errors.New("consumer closed")
+var ErrMaxRetries = errors.New("max retries reached")
 
 type Consumer interface {
 	Consume() error
@@ -231,7 +231,7 @@ func (i *InventoryConsumer) Consume() error {
 		}
 	}
 	err = i.Shutdown()
-	if !errors.Is(err, ClosedError) {
+	if !errors.Is(err, ErrClosed) {
 		return fmt.Errorf("error in consumer shutdown: %v", err)
 	}
 	return err
@@ -444,9 +444,9 @@ func (i *InventoryConsumer) Shutdown() error {
 			i.Logger.Errorf("Error closing kafka consumer: %v", err)
 			return err
 		}
-		return ClosedError
+		return ErrClosed
 	}
-	return ClosedError
+	return ErrClosed
 }
 
 // Retry executes the given function and will retry on failure with backoff until max retries is reached
@@ -470,5 +470,5 @@ func (i *InventoryConsumer) Retry(operation func() (string, error)) (string, err
 		return fmt.Sprintf("%s", resp), nil
 	}
 	i.Logger.Errorf("Error processing request (max attempts reached: %v): %v", attempts, err)
-	return "", MaxRetriesError
+	return "", ErrMaxRetries
 }

--- a/internal/consumer/consumer_test.go
+++ b/internal/consumer/consumer_test.go
@@ -47,9 +47,17 @@ func (t *TestCase) TestSetup() []error {
 	var errs []error
 	var err error
 
-	errs = t.options.Complete()
-	errs = t.options.Validate()
-	t.completedConfig, errs = NewConfig(t.options).Complete()
+	if errList := t.options.Complete(); err != nil {
+		errs = append(errs, errList...)
+	}
+	if errList := t.options.Validate(); err != nil {
+		errs = append(errs, errList...)
+	}
+	cfg, errList := NewConfig(t.options).Complete()
+	t.completedConfig = cfg
+	if errList != nil {
+		errs = append(errs, errList...)
+	}
 
 	notifier := &pubsub.NotifierMock{}
 
@@ -223,9 +231,9 @@ func TestInventoryConsumer_Retry(t *testing.T) {
 		},
 		{
 			description:   "retry fails and returns MaxRetriesError",
-			funcToExecute: func() (string, error) { return "fail", MaxRetriesError },
+			funcToExecute: func() (string, error) { return "fail", ErrMaxRetries },
 			exectedResult: "",
-			expectedErr:   MaxRetriesError,
+			expectedErr:   ErrMaxRetries,
 		},
 	}
 

--- a/internal/consumer/metrics.go
+++ b/internal/consumer/metrics.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"context"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -155,7 +156,7 @@ func (m *MetricsCollector) Collect(stats StatsData) {
 	m.replyq.Record(ctx, stats.Replyq, stats.LabelSet(""))
 
 	// topics.partitions
-	for partitionKey, _ := range stats.Topics[outboxTopic].Partitions {
+	for partitionKey := range stats.Topics[outboxTopic].Partitions {
 		if partitionKey != "-1" {
 			m.fetchqCnt.Record(ctx, stats.Topics[outboxTopic].Partitions[partitionKey].FetchqCnt, stats.LabelSet(partitionKey))
 			m.fetchqSize.Record(ctx, stats.Topics[outboxTopic].Partitions[partitionKey].FetchqSize, stats.LabelSet(partitionKey))

--- a/internal/consumer/metrics_test.go
+++ b/internal/consumer/metrics_test.go
@@ -1,9 +1,10 @@
 package consumer
 
 import (
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMetrics_New(t *testing.T) {
@@ -11,8 +12,7 @@ func TestMetrics_New(t *testing.T) {
 		name:        "TestMetricsNew_DefaultMeters",
 		description: "ensures a metrics collector is configured with all default meters",
 	}
-	var errs []error
-	errs = test.TestSetup()
+	errs := test.TestSetup()
 	assert.Nil(t, errs)
 
 	structValues := reflect.ValueOf(test.metrics)

--- a/internal/pubsub/listenmanager.go
+++ b/internal/pubsub/listenmanager.go
@@ -41,12 +41,6 @@ func NewListenManager(logger *log.Helper, driver Driver) *ListenManager {
 	}
 }
 
-type channelChange struct {
-	channel   string
-	close     func()
-	operation string
-}
-
 func (l *ListenManager) Subscribe(txId string) Subscription {
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/internal/pubsub/listenmanager_test.go
+++ b/internal/pubsub/listenmanager_test.go
@@ -58,7 +58,7 @@ func TestWaitTimeout(t *testing.T) {
 
 		err := subscription.BlockForNotification(timeoutCtx)
 		assert.Error(t, err)
-		assert.Equal(t, "Context cancelled while waiting for notification", err.Error())
+		assert.Equal(t, "context cancelled while waiting for notification", err.Error())
 	}()
 
 	wg.Wait()

--- a/internal/pubsub/subscription.go
+++ b/internal/pubsub/subscription.go
@@ -39,7 +39,7 @@ func (s *subscription) BlockForNotification(ctx context.Context) error {
 				return nil
 			}
 		case <-ctx.Done():
-			return fmt.Errorf("Context cancelled while waiting for notification")
+			return fmt.Errorf("context cancelled while waiting for notification")
 		}
 	}
 }


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Lint merged in main code to pass linter.
- Change errors to go naming convention with `Err` to start. ie `MaxRetriesError` to `ErrMaxRetries`
- Some missed error checking
- Removed the unused `type channelChange struct {`

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Lint and refactor internal eventual consistency code to adhere to Go naming conventions, improve error handling, and remove unused code.

Bug Fixes:
- Fix error handling in TestSetup by correctly appending error lists.

Enhancements:
- Rename error variables to follow Go naming conventions, changing 'MaxRetriesError' to 'ErrMaxRetries' and 'ClosedError' to 'ErrClosed'.
- Remove unused type 'channelChange' from the codebase.
- Improve error handling in NewCommand by capturing and returning errors from goroutines.