### PR TITLE
Update dashboard with kafka lag monitoring panels

### DIFF
--- a/dashboards/grafana-dashboard-kessel-inventory-api.configmap.yaml
+++ b/dashboards/grafana-dashboard-kessel-inventory-api.configmap.yaml
@@ -21,7 +21,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 951500,
+      "id": 765444,
       "links": [],
       "panels": [
         {
@@ -655,6 +655,246 @@ data:
           ],
           "title": "Requests per second",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 16
+          },
+          "id": 8,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.3.8",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "kafka_consumergroup_group_topic_sum_lag{topic=~\"outbox.event.kessel.tuples\"}",
+              "format": "time_series",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "legendFormat": "{topic=\"{{topic}}\", group=\"{{group}}\"}",
+              "range": true,
+              "refId": "outbox.event.kessel.tuples",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "kafka_consumergroup_group_topic_sum_lag{topic=~\"outbox.event.kessel.resources\"}",
+              "format": "time_series",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "legendFormat": "{topic=\"{{topic}}\", group=\"{{group}}\"}",
+              "range": true,
+              "refId": "outbox.event.kessel.resources",
+              "useBackend": false
+            }
+          ],
+          "title": "Kafka Lag (messages)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 16
+          },
+          "id": 9,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.3.8",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "sum by(topic, group) (kafka_consumergroup_group_lag_seconds{topic=~\"outbox.event.kessel.tuples\"})",
+              "format": "time_series",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "legendFormat": "{topic=\"{{topic}}\", group=\"{{group}}\"}",
+              "range": true,
+              "refId": "outbox.event.kessel.tuples",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "sum by(topic, group) (kafka_consumergroup_group_lag_seconds{topic=~\"outbox.event.kessel.resources\"})",
+              "format": "time_series",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "legendFormat": "{topic=\"{{topic}}\", group=\"{{group}}\"}",
+              "range": true,
+              "refId": "outbox.event.kessel.resources",
+              "useBackend": false
+            }
+          ],
+          "title": "Kafka Lag (seconds)",
+          "type": "timeseries"
         }
       ],
       "refresh": "",
@@ -706,6 +946,7 @@ data:
             "name": "datasource",
             "options": [],
             "query": "prometheus",
+            "queryValue": "",
             "refresh": 1,
             "regex": "/(crcp01ue1-prometheus)|(crcfrp01ugw1-prometheus)|(crcs02ue1-prometheus)|(crcfrs01ugw1-prometheus)/",
             "skipUrlSync": false,
@@ -721,7 +962,7 @@ data:
       "timezone": "browser",
       "title": "Kessel - Inventory API",
       "uid": "ddxs3i6o0xpmof",
-      "version": 2,
+      "version": 3,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Adds 2 new visualizations to the existing dashboard to monitor kafka lag
- Monitors lag in number of events and seconds for `outbox.event.kessel.tuples` & `outbox.event.kessel.resources`

## Ticket reference (if applicable)
Fixes # apart of https://issues.redhat.com/browse/RHCLOUD-39132

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Add Kafka lag monitoring panels to the Kessel Inventory API dashboard to track message and time lag for specific Kafka topics

New Features:
- Add two new visualizations to monitor Kafka lag for 'outbox.event.kessel.tuples' and 'outbox.event.kessel.resources' topics
- Implement Kafka lag monitoring in messages and seconds