### PR TITLE
RHCLOUD-39559: Fix update relations create logic

### DIFF
--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -468,15 +468,18 @@ func (uc *Usecase) Update(ctx context.Context, m *model.Resource, id model.Repor
 
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return uc.Create(ctx, m)
+				ret, updatedResources, err = uc.reporterResourceRepository.Create(ctx, m)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				return nil, ErrDatabaseError
 			}
-
-			return nil, ErrDatabaseError
-		}
-
-		ret, updatedResources, err = uc.reporterResourceRepository.Update(ctx, m, existingResource.ID)
-		if err != nil {
-			return nil, err
+		} else {
+			ret, updatedResources, err = uc.reporterResourceRepository.Update(ctx, m, existingResource.ID)
+			if err != nil {
+				return nil, err
+			}
 		}
 	} else {
 		// mock the updated at time for eventing

--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -468,18 +468,15 @@ func (uc *Usecase) Update(ctx context.Context, m *model.Resource, id model.Repor
 
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				ret, updatedResources, err = uc.reporterResourceRepository.Create(ctx, m)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				return nil, ErrDatabaseError
+				return uc.Create(ctx, m)
 			}
-		} else {
-			ret, updatedResources, err = uc.reporterResourceRepository.Update(ctx, m, existingResource.ID)
-			if err != nil {
-				return nil, err
-			}
+
+			return nil, ErrDatabaseError
+		}
+
+		ret, updatedResources, err = uc.reporterResourceRepository.Update(ctx, m, existingResource.ID)
+		if err != nil {
+			return nil, err
 		}
 	} else {
 		// mock the updated at time for eventing

--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -422,7 +422,7 @@ func (uc *Usecase) Create(ctx context.Context, m *model.Resource) (*model.Resour
 
 	if uc.Authz != nil {
 		// Send workspace for the created resource
-		ct, err := biz.DefaultSetWorkspace(ctx, uc.Namespace, ret, uc.Authz, false)
+		ct, err := biz.DefaultSetWorkspace(ctx, uc.Namespace, ret, uc.Authz, true)
 		if err != nil {
 			return nil, err
 		}
@@ -438,7 +438,7 @@ func (uc *Usecase) Create(ctx context.Context, m *model.Resource) (*model.Resour
 
 		// Send workspace for any updated resources
 		for _, updatedResource := range updatedResources {
-			ct, err := biz.DefaultSetWorkspace(ctx, uc.Namespace, updatedResource, uc.Authz, false)
+			ct, err := biz.DefaultSetWorkspace(ctx, uc.Namespace, updatedResource, uc.Authz, true)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Make relations write upsert `true` for "Create" to ensure that writes do not fail on existing resource*. 

* Create itself doesn't require this, but there is a case where "update" calls "create" where upsert would be expected. This change is the lightest touch change -- no refactoring/method signature changes -- to a deprecated method to fix the bug.

## Ticket reference (if applicable)
Fixes #RHCLOUD-39559.

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

