### PR TITLE
RHCLOUD-39150 : Remove persistence flag from v1beta2

### DIFF
--- a/.inventory-api.yaml
+++ b/.inventory-api.yaml
@@ -17,7 +17,6 @@ eventing:
   eventer: stdout
   kafka:
 storage:
-  disable-persistence: false
   database: sqlite3
   sqlite3:
     dsn: inventory.db

--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -70,7 +70,6 @@ func New(reporterResourceRepository ReporterResourceRepository, inventoryResourc
 
 func (uc *Usecase) Upsert(ctx context.Context, m *model.Resource) (*model.Resource, error) {
 	log.Info("upserting resource: ", m)
-	ret := m // Default to returning the input model in case persistence is disabled
 
 	existingResource, err := uc.reporterResourceRepository.FindByReporterResourceIdv1beta2(ctx, model.ReporterResourceIdv1beta2FromResource(m))
 

--- a/internal/biz/resources/resources_test.go
+++ b/internal/biz/resources/resources_test.go
@@ -531,7 +531,7 @@ func TestDeleteReturnsDbError(t *testing.T) {
 	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, false)
 	ctx := context.TODO()
 
-	err := useCase.Delete(ctx, model.ReporterResourceId{})
+	err := useCase.Deletev1beta1(ctx, model.ReporterResourceId{})
 	assert.ErrorIs(t, err, ErrDatabaseError)
 	repo.AssertExpectations(t)
 }
@@ -547,7 +547,7 @@ func TestDeleteReturnsDbErrorBackwardsCompatible(t *testing.T) {
 	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, false)
 	ctx := context.TODO()
 
-	err := useCase.Delete(ctx, model.ReporterResourceId{})
+	err := useCase.Deletev1beta1(ctx, model.ReporterResourceId{})
 	assert.ErrorIs(t, err, ErrDatabaseError)
 	repo.AssertExpectations(t)
 }
@@ -563,7 +563,7 @@ func TestDeleteNonexistentResource(t *testing.T) {
 	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, false)
 	ctx := context.TODO()
 
-	err := useCase.Delete(ctx, model.ReporterResourceId{})
+	err := useCase.Deletev1beta1(ctx, model.ReporterResourceId{})
 	assert.ErrorIs(t, err, ErrResourceNotFound)
 	repo.AssertExpectations(t)
 }
@@ -583,7 +583,7 @@ func TestDeleteResource(t *testing.T) {
 
 	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, false)
 
-	err = useCase.Delete(ctx, model.ReporterResourceId{})
+	err = useCase.Deletev1beta1(ctx, model.ReporterResourceId{})
 	assert.Nil(t, err)
 
 	repo.AssertExpectations(t)
@@ -606,7 +606,7 @@ func TestDeleteResourceBackwardsCompatible(t *testing.T) {
 
 	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, false)
 
-	err = useCase.Delete(ctx, model.ReporterResourceId{})
+	err = useCase.Deletev1beta1(ctx, model.ReporterResourceId{})
 	assert.Nil(t, err)
 
 	repo.AssertExpectations(t)

--- a/internal/biz/resources/resources_test.go
+++ b/internal/biz/resources/resources_test.go
@@ -668,31 +668,31 @@ func TestUpdateResource_PersistenceDisabled(t *testing.T) {
 	repo.AssertNotCalled(t, "Create")
 }
 
-func TestDeleteResource_PersistenceDisabled(t *testing.T) {
-	ctx := context.TODO()
-
-	id, err := uuid.NewV7()
-	assert.Nil(t, err)
-
-	repo := &MockedReporterResourceRepository{}
-	inventoryRepo := &MockedInventoryResourceRepository{}
-
-	// Mock as if persistence is not disabled, for assurance
-	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return(&model.Resource{
-		ID: id,
-	}, nil)
-	repo.On("Delete", mock.Anything, (uint64)(33)).Return(&model.Resource{}, nil)
-
-	disablePersistence := true
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, disablePersistence)
-
-	err = useCase.Delete(ctx, model.ReporterResourceId{})
-	assert.Nil(t, err)
-
-	// Assert that the repository methods were not called since persistence is disabled
-	repo.AssertNotCalled(t, "FindByReporterResourceId")
-	repo.AssertNotCalled(t, "Delete")
-}
+//func TestDeleteResource_PersistenceDisabled(t *testing.T) {
+//	ctx := context.TODO()
+//
+//	id, err := uuid.NewV7()
+//	assert.Nil(t, err)
+//
+//	repo := &MockedReporterResourceRepository{}
+//	inventoryRepo := &MockedInventoryResourceRepository{}
+//
+//	// Mock as if persistence is not disabled, for assurance
+//	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return(&model.Resource{
+//		ID: id,
+//	}, nil)
+//	repo.On("Delete", mock.Anything, (uint64)(33)).Return(&model.Resource{}, nil)
+//
+//	disablePersistence := true
+//	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, disablePersistence)
+//
+//	err = useCase.Delete(ctx, model.ReporterResourceId{})
+//	assert.Nil(t, err)
+//
+//	// Assert that the repository methods were not called since persistence is disabled
+//	repo.AssertNotCalled(t, "FindByReporterResourceId")
+//	repo.AssertNotCalled(t, "Delete")
+//}
 
 func TestCheck_MissingResource(t *testing.T) {
 	ctx := context.TODO()

--- a/internal/service/resources/hosts/hosts.go
+++ b/internal/service/resources/hosts/hosts.go
@@ -70,7 +70,7 @@ func (c *HostsService) DeleteRhelHost(ctx context.Context, r *pb.DeleteRhelHostR
 	}
 
 	if resourceId, err := fromDeleteRequest(r, identity); err == nil {
-		if err := c.Ctl.Delete(ctx, resourceId); err == nil {
+		if err := c.Ctl.Deletev1beta1(ctx, resourceId); err == nil {
 			return toDeleteResponse(), nil
 		} else {
 			return nil, err

--- a/internal/service/resources/k8sclusters/k8scluster.go
+++ b/internal/service/resources/k8sclusters/k8scluster.go
@@ -72,7 +72,7 @@ func (c *K8sClustersService) DeleteK8SCluster(ctx context.Context, r *pb.DeleteK
 	}
 
 	if resourceId, err := fromDeleteRequest(r, identity); err == nil {
-		if err := c.Ctl.Delete(ctx, resourceId); err == nil {
+		if err := c.Ctl.Deletev1beta1(ctx, resourceId); err == nil {
 			return toDeleteResponse(), nil
 		} else {
 			return nil, err

--- a/internal/service/resources/k8spolicies/k8spolicies.go
+++ b/internal/service/resources/k8spolicies/k8spolicies.go
@@ -74,7 +74,7 @@ func (c *K8sPolicyService) DeleteK8SPolicy(ctx context.Context, r *pb.DeleteK8SP
 	}
 
 	if resourceId, err := fromDeleteRequest(r, identity); err == nil {
-		if err := c.Ctl.Delete(ctx, resourceId); err == nil {
+		if err := c.Ctl.Deletev1beta1(ctx, resourceId); err == nil {
 			return toDeleteResponse(), nil
 		} else {
 			return nil, err

--- a/internal/service/resources/kesselresourceservice.go
+++ b/internal/service/resources/kesselresourceservice.go
@@ -57,7 +57,7 @@ func (c *ResourceService) DeleteResource(ctx context.Context, r *pb.DeleteResour
 		return nil, fmt.Errorf("failed to build reporter resource ID: %w", err)
 	}
 
-	err = c.Ctl.Delete(ctx, reporterResource)
+	err = c.Ctl.DeleteV1beta2(ctx, reporterResource)
 	if err != nil {
 		log.Error("Failed to delete resource: ", err)
 		return nil, fmt.Errorf("failed to delete resource: %w", err)

--- a/internal/service/resources/notificationsintegrations/notificationsintegrations.go
+++ b/internal/service/resources/notificationsintegrations/notificationsintegrations.go
@@ -109,7 +109,7 @@ func (c *NotificationsIntegrationsService) DeleteNotificationsIntegration(ctx co
 	}
 
 	if resourceId, err := fromDeleteRequest(r, identity); err == nil {
-		if err := c.Ctl.Delete(ctx, resourceId); err == nil {
+		if err := c.Ctl.Deletev1beta1(ctx, resourceId); err == nil {
 			return toDeleteResponse(), nil
 		} else {
 			return nil, err


### PR DESCRIPTION
### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #
https://issues.redhat.com/browse/RHCLOUD-39150
## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Remove persistence flag and update delete methods to support v1beta2 resource deletion

New Features:
- Introduced DeleteV1beta2 method for more robust resource deletion

Enhancements:
- Refactored resource deletion methods to support v1beta2 approach
- Removed persistence-related conditional logic from resource upsert method

Chores:
- Removed `DisablePersistence` flag from configuration
- Updated test cases to reflect new deletion method signatures