### PR TITLE
RHCLOUD-39387: v1beta2 consistency e2e

### DIFF
--- a/test/e2e/inventory_http_test.go
+++ b/test/e2e/inventory_http_test.go
@@ -653,9 +653,7 @@ func TestInventoryAPIHTTP_NotificationsIntegrationLifecycle_WaitForSync(t *testi
 
 	var integration model.Resource
 	err = db.Where("reporter_resource_id = ?", resourceId).First(&integration).Error
-	if err != nil {
-		t.Fatalf("Failed to find Notifications Integration in DB: %v", err)
-	}
+	assert.NoError(t, err, "Failed to find Notifications Integration in DB")
 	assert.NotNil(t, integration, "Notifications Integration not found in DB")
 	assert.NotEmpty(t, integration.ConsistencyToken, "Consistency token is empty")
 
@@ -680,9 +678,7 @@ func TestInventoryAPIHTTP_NotificationsIntegrationLifecycle_WaitForSync(t *testi
 	assert.NoError(t, err, "Failed to update Notifications Integration w/ WaitForSync")
 
 	err = db.Where("reporter_resource_id = ?", resourceId).First(&integration).Error
-	if err != nil {
-		t.Fatalf("Failed to find Notifications Integration in DB: %v", err)
-	}
+	assert.NoError(t, err, "Failed to find Notifications Integration in DB")
 	assert.NotNil(t, integration, "Notifications Integration not found in DB")
 	assert.NotEmpty(t, integration.ConsistencyToken, "Consistency token is empty")
 


### PR DESCRIPTION
- Add e2e test for consistency and v1beta2
- Updates to v1beta1 e2e error handling

## Summary by Sourcery

Add e2e tests for v1beta2 resource consistency and improve error handling in existing tests

New Features:
- Add support for testing WaitForSync parameter in v1beta2 resource reporting
- Introduce a new test case for verifying consistency token generation

Tests:
- Implement a new e2e test for v1beta2 host resource with WaitForSync functionality
- Refactor existing test error handling to use assert methods for more consistent error checking