### PR TITLE
RHCLOUD-39613: Do workspace list post checks in parallel rather than in series

### DIFF
--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -297,7 +297,7 @@ func (uc *Usecase) ListResourcesInWorkspace(ctx context.Context, permission, nam
 	var wg sync.WaitGroup
 	for _, resource := range resources {
 		wg.Add(1)
-		log.Infof("ListResourcesInWorkspace: checkforview on %+v", resource)
+		log.Debugf("ListResourcesInWorkspace: checkforview on %+v", resource)
 
 		go func() {
 			defer wg.Done()
@@ -307,7 +307,7 @@ func (uc *Usecase) ListResourcesInWorkspace(ctx context.Context, permission, nam
 			} else if err != nil {
 				error_chan <- err
 			} else if allowed != kessel.CheckResponse_ALLOWED_TRUE {
-				log.Infof("Response was not allowed: %v", allowed)
+				log.Debugf("ListResourcesInWorkspace: response was not allowed: %v", allowed)
 			}
 		}()
 	}

--- a/internal/biz/resources/resources_test.go
+++ b/internal/biz/resources/resources_test.go
@@ -6,6 +6,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"io"
+	"sort"
 	"testing"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -278,6 +279,78 @@ func resource1() *model.Resource {
 			{
 				Key:   "label-1",
 				Value: "value-2",
+			},
+			{
+				Key:   "label-xyz",
+				Value: "value-xyz",
+			},
+		},
+	}
+}
+
+func resource2() *model.Resource {
+	return &model.Resource{
+		ID:    uuid.UUID{},
+		OrgId: "my-org2",
+		ResourceData: map[string]any{
+			"foo2": "bar2",
+		},
+		ResourceType: "my-resource2",
+		WorkspaceId:  "my-workspace",
+		Reporter: model.ResourceReporter{
+			Reporter: model.Reporter{
+				ReporterId:      "reporter_id",
+				ReporterType:    "reporter_type",
+				ReporterVersion: "1.0.2",
+			},
+			LocalResourceId: "foo-resource",
+		},
+		ConsoleHref: "/etc/console",
+		ApiHref:     "/etc/api",
+		Labels: model.Labels{
+			{
+				Key:   "label-2",
+				Value: "value-2",
+			},
+			{
+				Key:   "label-2",
+				Value: "value-3",
+			},
+			{
+				Key:   "label-xyz",
+				Value: "value-xyz",
+			},
+		},
+	}
+}
+
+func resource3() *model.Resource {
+	return &model.Resource{
+		ID:    uuid.UUID{},
+		OrgId: "my-org3",
+		ResourceData: map[string]any{
+			"foo3": "bar3",
+		},
+		ResourceType: "my-resource33",
+		WorkspaceId:  "my-workspace",
+		Reporter: model.ResourceReporter{
+			Reporter: model.Reporter{
+				ReporterId:      "reporter_id",
+				ReporterType:    "reporter_type",
+				ReporterVersion: "1.0.2",
+			},
+			LocalResourceId: "foo-resource",
+		},
+		ConsoleHref: "/etc/console",
+		ApiHref:     "/etc/api",
+		Labels: model.Labels{
+			{
+				Key:   "label-3",
+				Value: "value-3",
+			},
+			{
+				Key:   "label-2",
+				Value: "value-3",
 			},
 			{
 				Key:   "label-xyz",
@@ -954,6 +1027,11 @@ func TestListResourcesInWorkspace_ResourcesAllowedTrue(t *testing.T) {
 	res := <-resource_chan
 	assert.Equal(t, resource, res) // expecting to get back resource1
 
+	_, ok := <-resource_chan
+	if ok {
+		t.Error("resource_chan should have been closed")
+	}
+
 	assert.Empty(t, err_chan) // dont want any errors.
 
 	// check negative case (not allowed)
@@ -968,6 +1046,83 @@ func TestListResourcesInWorkspace_ResourcesAllowedTrue(t *testing.T) {
 	assert.Empty(t, err_chan) // dont want any errors.
 
 	repo.AssertExpectations(t)
+}
+
+func TestListResourcesInWorkspace_MultipleResourcesAllowedTrue(t *testing.T) {
+	ctx := context.TODO()
+
+	inventoryRepo := &MockedInventoryResourceRepository{}
+	repo := &MockedReporterResourceRepository{}
+	m := &MockAuthz{}
+
+	resource := resource1()
+	resource2 := resource2()
+	resource3 := resource3()
+
+	repo.On("FindByWorkspaceId", mock.Anything, mock.Anything).Return([]*model.Resource{resource, resource2, resource3}, nil)
+	m.On("Check", mock.Anything, mock.Anything, "notifications_integration_write", mock.Anything, mock.Anything).Return(v1beta1.CheckResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
+
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, false)
+	resource_chan, err_chan, err := useCase.ListResourcesInWorkspace(ctx, "notifications_integration_write", "rbac", &v1beta1.SubjectReference{}, "foo-id")
+
+	assert.Nil(t, err)
+
+	out := make([]*model.Resource, 3)
+	out[0] = <-resource_chan
+	out[1] = <-resource_chan
+	out[2] = <-resource_chan
+
+	in := []*model.Resource{resource, resource2, resource3}
+	sort.Slice(in, func(i, j int) bool { return len(in[i].ResourceType) < len(in[j].ResourceType) })
+	sort.Slice(out, func(i, j int) bool { return len(out[i].ResourceType) < len(out[j].ResourceType) })
+	assert.Equal(t, in, out) // all 3 are there in any order
+
+	_, ok := <-resource_chan
+	if ok {
+		t.Error("resource_chan should have been closed") // and there was no other resource
+	}
+
+	assert.Empty(t, err_chan) // dont want any errors.
+}
+
+// not authorized for the middle one and error on the third should just pass first
+func TestListResourcesInWorkspace_MultipleResourcesOneFalseTwoTrueLastError(t *testing.T) {
+	ctx := context.TODO()
+
+	inventoryRepo := &MockedInventoryResourceRepository{}
+	repo := &MockedReporterResourceRepository{}
+	m := &MockAuthz{}
+
+	resource := resource1()
+	resource2 := resource2()
+	resource3 := resource3()
+	theError := errors.New("failed calling relations")
+
+	repo.On("FindByWorkspaceId", mock.Anything, mock.Anything).Return([]*model.Resource{resource, resource2, resource3}, nil)
+	m.On("Check", mock.Anything, mock.Anything, "notifications_integration_write", resource, mock.Anything).Return(v1beta1.CheckResponse_ALLOWED_FALSE, &v1beta1.ConsistencyToken{}, nil)
+	m.On("Check", mock.Anything, mock.Anything, "notifications_integration_write", resource2, mock.Anything).Return(v1beta1.CheckResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
+	m.On("Check", mock.Anything, mock.Anything, "notifications_integration_write", resource3, mock.Anything).Return(v1beta1.CheckResponse_ALLOWED_UNSPECIFIED, &v1beta1.ConsistencyToken{}, theError)
+
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, false)
+	resource_chan, err_chan, err := useCase.ListResourcesInWorkspace(ctx, "notifications_integration_write", "rbac", &v1beta1.SubjectReference{}, "foo-id")
+
+	assert.Nil(t, err)
+
+	out_allowed := make([]*model.Resource, 1)
+	out_allowed[0] = <-resource_chan
+
+	in_allowed := []*model.Resource{resource2}
+	sort.Slice(in_allowed, func(i, j int) bool { return len(in_allowed[i].ResourceType) < len(in_allowed[j].ResourceType) })
+	sort.Slice(out_allowed, func(i, j int) bool { return len(out_allowed[i].ResourceType) < len(out_allowed[j].ResourceType) })
+	assert.Equal(t, in_allowed, out_allowed) // all 3 are there in any order
+
+	_, ok := <-resource_chan
+	if ok {
+		t.Error("resource_chan should have been closed") // and there was no other resource
+	}
+
+	backError := <-err_chan
+	assert.Equal(t, theError, backError) // dont want any errors.
 }
 
 func TestListResourcesInWorkspace_ResourcesAllowedError(t *testing.T) {


### PR DESCRIPTION
### PR Template:

## Describe your changes

- A performance improvement for `ListResourcesInWorkspace` where multiple checks are performed in parallel rather than in series.
- This may or not may not resolve RHCLOUD-39613, which has not been fully investigated.

## Ticket reference (if applicable)
Fixes #RHCLOUD-39613

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Improve performance of workspace resource listing by performing authorization checks in parallel instead of sequentially

New Features:
- Add support for concurrent authorization checks when listing resources in a workspace

Enhancements:
- Modify ListResourcesInWorkspace method to use goroutines and sync.WaitGroup for parallel processing of resource authorization checks

Tests:
- Add multiple test cases to verify parallel resource listing with different scenarios including all allowed, partially allowed, and error cases