### PR TITLE
Set debezium poll.interval.ms to 250ms

### DIFF
--- a/deploy/debezium/debezium-connector.yaml
+++ b/deploy/debezium/debezium-connector.yaml
@@ -27,6 +27,7 @@ objects:
       heartbeat.interval.ms: ${DEBEZIUM_HEARTBEAT_INTERVAL_MS}
       heartbeat.action.query: ${DEBEZIUM_ACTION_QUERY}
       topic.heartbeat.prefix: ${TOPIC_HEARTBEAT_PREFIX}
+      poll.interval.ms: ${DEBEZIUM_POLL_INTERVAL_MS}
 parameters:
 - name: KAFKA_CONNECT_INSTANCE
   value: platform-kafka-connect
@@ -43,3 +44,6 @@ parameters:
 - name: DEBEZIUM_HEARTBEAT_INTERVAL_MS
   value: "300000"
   description: The interval for the Debezium heartbeat in ms
+- name: DEBEZIUM_POLL_INTERVAL_MS
+  value: "250"
+  description: The interval for the Debezium batch processing

--- a/deploy/kessel-inventory-ephem.yaml
+++ b/deploy/kessel-inventory-ephem.yaml
@@ -257,6 +257,7 @@ objects:
         heartbeat.interval.ms: ${DEBEZIUM_HEARTBEAT_INTERVAL_MS}
         heartbeat.action.query: ${DEBEZIUM_ACTION_QUERY}
         topic.heartbeat.prefix: ${TOPIC_HEARTBEAT_PREFIX}
+        poll.interval.ms: ${DEBEZIUM_POLL_INTERVAL_MS}
 
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
@@ -368,3 +369,6 @@ parameters:
   - name: DEBEZIUM_HEARTBEAT_INTERVAL_MS
     value: "300000"
     description: The interval for the Debezium heartbeat in ms
+  - name: DEBEZIUM_POLL_INTERVAL_MS
+    value: "250"
+    description: The interval for the Debezium batch processing

--- a/deploy/kind/inventory/strimzi.yaml
+++ b/deploy/kind/inventory/strimzi.yaml
@@ -84,3 +84,4 @@ spec:
     transforms.outbox.table.expand.json.payload: true
     value.converter: org.apache.kafka.connect.json.JsonConverter
     plugin.name: pgoutput
+    poll.interval.ms: 250

--- a/development/configs/debezium-connector.json
+++ b/development/configs/debezium-connector.json
@@ -15,6 +15,7 @@
     "transforms.outbox.table.fields.additional.placement": "operation:header,txid:header",
     "transforms.outbox.table.expand.json.payload": true,
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
-    "plugin.name": "pgoutput"
+    "plugin.name": "pgoutput",
+    "poll.interval.ms": 250
   }
 }


### PR DESCRIPTION
- Sets debezium poll interval to 250ms
  - defines a happy medium between performance and resource utilization until we can get some practical use data

<img width="1778" alt="image" src="https://github.com/user-attachments/assets/dc256ec9-bf74-4c7d-abf6-6ffd63849031" />
Benchmarks:

- 1 pod
- 8 min runs

## Summary by Sourcery

Deployment:
- Update the `poll.interval.ms` setting to 250 across Debezium connector configurations for various environments (production, ephemeral, kind, development).