### PR TITLE
RHCLOUD-39617: updates to add rebalance callback and improve testing

### DIFF
--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -36,9 +36,17 @@ const commitModulo = 10
 var ErrClosed = errors.New("consumer closed")
 var ErrMaxRetries = errors.New("max retries reached")
 
-// InventoryConsumer defines a Kafka Consumer with required clients and configs to call Relations API and update the Inventory DB with consistency tokens
+type Consumer interface {
+	CommitOffsets(offsets []kafka.TopicPartition) ([]kafka.TopicPartition, error)
+	SubscribeTopics(topics []string, rebalanceCb kafka.RebalanceCb) (err error)
+	Poll(timeoutMs int) (event kafka.Event)
+	IsClosed() bool
+	Close() error
+}
+
+// InventoryConsumer defines a Consumer with required clients and configs to call Relations API and update the Inventory DB with consistency tokens
 type InventoryConsumer struct {
-	Consumer         *kafka.Consumer
+	Consumer         Consumer
 	OffsetStorage    []kafka.TopicPartition
 	Config           CompletedConfig
 	DB               *gorm.DB

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -43,6 +43,7 @@ type Consumer interface {
 	Poll(timeoutMs int) (event kafka.Event)
 	IsClosed() bool
 	Close() error
+	AssignmentLost() bool
 }
 
 // InventoryConsumer defines a Consumer with required clients and configs to call Relations API and update the Inventory DB with consistency tokens
@@ -506,7 +507,8 @@ func (i *InventoryConsumer) Retry(operation func() (string, error)) (string, err
 	return "", ErrMaxRetries
 }
 
-// RebalanceCallback logs when rebalance events occur and ensures any stored offsets are committed before losing the partition assignment. It is registered to the kafka subscription and is invoked  automatically whenever rebalances occur.
+// RebalanceCallback logs when rebalance events occur and ensures any stored offsets are committed before losing the partition assignment. It is registered to the kafka 'SubscribeTopics' call and is invoked  automatically whenever rebalances occurs.
+// Note, the RebalanceCb function must satisfy the function type func(*Consumer, Event). This function does so, but the consumer embedded in the InventoryConsumer called versus the passed on which is the same consumer in either case.
 func (i *InventoryConsumer) RebalanceCallback(consumer *kafka.Consumer, event kafka.Event) error {
 	switch ev := event.(type) {
 	case kafka.AssignedPartitions:

--- a/internal/consumer/consumer_test.go
+++ b/internal/consumer/consumer_test.go
@@ -367,15 +367,45 @@ func TestCommitStoredOffsets(t *testing.T) {
 	tests := []struct {
 		name          string
 		storedOffsets []kafka.TopicPartition
-		expected      []kafka.TopicPartition
+		response      []kafka.TopicPartition
+		expected      []string
 	}{
 		{
-			name: "ensures all stored offsets are returned from offset commit",
+			name: "single stored offset is returned from offset commit",
 			storedOffsets: []kafka.TopicPartition{
-				{Offset: kafka.Offset(10), Partition: kafka.PartitionAny},
+				{Offset: kafka.Offset(10), Partition: 0},
 			},
-			expected: []kafka.TopicPartition{
-				{Offset: kafka.Offset(10), Partition: kafka.PartitionAny},
+			response: []kafka.TopicPartition{
+				{Offset: kafka.Offset(10), Partition: 0},
+			},
+			expected: []string{
+				"[0:10]",
+			},
+		},
+		{
+			name: "all stored offsets are returned from offset commit",
+			storedOffsets: []kafka.TopicPartition{
+				{Offset: kafka.Offset(10), Partition: 0},
+				{Offset: kafka.Offset(11), Partition: 0},
+				{Offset: kafka.Offset(1), Partition: 1},
+				{Offset: kafka.Offset(2), Partition: 1},
+				{Offset: kafka.Offset(12), Partition: 0},
+				{Offset: kafka.Offset(13), Partition: 0},
+				{Offset: kafka.Offset(3), Partition: 1},
+				{Offset: kafka.Offset(4), Partition: 1},
+			},
+			response: []kafka.TopicPartition{
+				{Offset: kafka.Offset(10), Partition: 0},
+				{Offset: kafka.Offset(11), Partition: 0},
+				{Offset: kafka.Offset(12), Partition: 0},
+				{Offset: kafka.Offset(13), Partition: 0},
+				{Offset: kafka.Offset(1), Partition: 1},
+				{Offset: kafka.Offset(2), Partition: 1},
+				{Offset: kafka.Offset(3), Partition: 1},
+				{Offset: kafka.Offset(4), Partition: 1},
+			},
+			expected: []string{
+				"[0:10]", "[0:11]", "[0:12]", "[0:13]", "[1:1]", "[1:2]", "[1:3]", "[1:4]",
 			},
 		},
 	}
@@ -386,7 +416,7 @@ func TestCommitStoredOffsets(t *testing.T) {
 			assert.Nil(t, errs)
 
 			c := &mocks.MockConsumer{}
-			c.On("CommitOffsets", mock.Anything).Return(test.expected, nil)
+			c.On("CommitOffsets", mock.Anything).Return(test.response, nil)
 			tester.inv.Consumer = c
 
 			committedOffsets, err := tester.inv.commitStoredOffsets()

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"context"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 
 	"github.com/project-kessel/inventory-api/internal/biz/model"
 	kesselv1 "github.com/project-kessel/relations-api/api/kessel/relations/v1"
@@ -11,6 +12,10 @@ import (
 )
 
 type MockAuthz struct {
+	mock.Mock
+}
+
+type MockConsumer struct {
 	mock.Mock
 }
 
@@ -54,3 +59,18 @@ func (m *MockAuthz) LookupResources(ctx context.Context, request *v1beta1.Lookup
 	args := m.Called(ctx, request)
 	return args.Get(0).(grpc.ServerStreamingClient[v1beta1.LookupResourcesResponse]), args.Error(1)
 }
+
+func (m *MockConsumer) CommitOffsets(offsets []kafka.TopicPartition) ([]kafka.TopicPartition, error) {
+	args := m.Called(offsets)
+	return args.Get(0).([]kafka.TopicPartition), args.Error(1)
+}
+
+func (m *MockConsumer) SubscribeTopics(topics []string, rebalanceCb kafka.RebalanceCb) (err error) {
+	return nil
+}
+
+func (m *MockConsumer) Poll(timeoutMs int) (event kafka.Event) { return nil }
+
+func (m *MockConsumer) IsClosed() bool { return true }
+
+func (m *MockConsumer) Close() error { return nil }

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -74,3 +74,5 @@ func (m *MockConsumer) Poll(timeoutMs int) (event kafka.Event) { return nil }
 func (m *MockConsumer) IsClosed() bool { return true }
 
 func (m *MockConsumer) Close() error { return nil }
+
+func (m *MockConsumer) AssignmentLost() bool { return true }


### PR DESCRIPTION
### PR Template:

## Describe your changes

* adds consumer interface for mocking
  * updates inventory consumer to take consumer interface over kafka consumer
  * ensures all used kafka consumer methods are added to satisfy interface
  * adds new tests that uses mock to confirm it works
* adds rebalance callback function and configures SubscribeTopics with it
  * This will ensure offsets are committed when partitions are revoked
* updates the commitStoredOffsets function to return a structured string with partitions and offsets committed (more useful when there are multiple partitions

