### PR TITLE
Fix network check filter

### DIFF
--- a/scripts/start-inventory.sh
+++ b/scripts/start-inventory.sh
@@ -8,6 +8,6 @@ export SETUP=${CONFIG}
 set -e
 # Function to check if a command is available
 source ./scripts/check_docker_podman.sh
-NETWORK_CHECK=$(${DOCKER} network ls --filter name=kessel --format json)
+NETWORK_CHECK=$(${DOCKER} network ls --filter name='^kessel$' --format json)
 if [[ -z "${NETWORK_CHECK}" || "${NETWORK_CHECK}" == "[]" ]]; then ${DOCKER} network create kessel; fi
 ${DOCKER} compose -f development/docker-compose.yaml up --build -d ${SETUP}


### PR DESCRIPTION
If you have other networks that match "kessel" in some way but are not exactly named "kessel," the docker compose fails. The network check must exactly match "kessel".

## Summary by Sourcery

Update the Docker network check to ensure an exact match for the 'kessel' network and centralize the check logic into a shared script.

Bug Fixes:
- Fix Docker network check to use an exact match ('^kessel$') instead of a substring match ('kessel').

Chores:
- Extract duplicated network check logic from start scripts into a new 'scripts/network-check.sh' script.