### PR TITLE
adds no auth config option to consumer to specify CA cert path

### DIFF
--- a/internal/consumer/auth/options.go
+++ b/internal/consumer/auth/options.go
@@ -8,11 +8,13 @@ type Options struct {
 	SASLMechanism    string `mapstructure:"sasl-mechanism"`
 	SASLUsername     string `mapstructure:"sasl-username"`
 	SASLPassword     string `mapstructure:"sasl-password"`
+	CACert           string `mapstructure:"ca-cert"`
 }
 
 func NewOptions() *Options {
 	return &Options{
 		Enabled: false,
+		CACert:  "/etc/pki/tls/cert.pem",
 	}
 }
 
@@ -25,4 +27,5 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 	fs.StringVar(&o.SASLMechanism, prefix+"sasl-mechanism", o.SASLMechanism, "sets the SASL mechanism")
 	fs.StringVar(&o.SASLUsername, prefix+"sasl-username", o.SASLUsername, "sets the username to use for authentication")
 	fs.StringVar(&o.SASLPassword, prefix+"sasl-password", o.SASLPassword, "sets the password to use for authentication")
+	fs.StringVar(&o.CACert, prefix+"ca-cert", o.CACert, "sets the file or directory path to CA certificate(s) for verifying the broker's key (default: /etc/pki/tls/cert.pem)")
 }

--- a/internal/consumer/config.go
+++ b/internal/consumer/config.go
@@ -3,9 +3,10 @@ package consumer
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/project-kessel/inventory-api/internal/consumer/auth"
 	"github.com/project-kessel/inventory-api/internal/consumer/retry"
-	"strings"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
@@ -62,6 +63,7 @@ func (c *Config) Complete() (CompletedConfig, []error) {
 				"sasl.mechanism":    c.AuthConfig.SASLMechanism,
 				"sasl.username":     c.AuthConfig.SASLUsername,
 				"sasl.password":     c.AuthConfig.SASLPassword,
+				"ssl.ca.location":   c.AuthConfig.CACert,
 			}
 			for key, value := range authSettings {
 				if err := config.SetKey(key, value); err != nil {


### PR DESCRIPTION
### PR Template:

## Describe your changes

* adds ca cert config option to consumer to configure `ssl.ca.location` with the client to address potential TLS failures in stage

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Add a configuration option to specify the CA certificate path for broker TLS verification.

New Features:
- Allow users to configure the path to the CA certificate file or directory used for verifying the broker's key via the `ca-cert` flag/setting.
- Set `/etc/pki/tls/cert.pem` as the default CA certificate path.