### PR TITLE
updates default consumer auth enabled setting to true

### DIFF
--- a/internal/consumer/auth/options.go
+++ b/internal/consumer/auth/options.go
@@ -12,7 +12,7 @@ type Options struct {
 
 func NewOptions() *Options {
 	return &Options{
-		Enabled: false,
+		Enabled: true,
 	}
 }
 

--- a/internal/consumer/consumer_test.go
+++ b/internal/consumer/consumer_test.go
@@ -40,6 +40,7 @@ func (t *TestCase) TestSetup() []error {
 	t.options = NewOptions()
 	t.options.BootstrapServers = []string{"localhost:9092"}
 	t.config = NewConfig(t.options)
+	t.config.AuthConfig.Enabled = false
 
 	_, logger := InitLogger("info", LoggerOptions{})
 	t.logger = log.NewHelper(log.With(logger, "subsystem", "inventoryConsumer"))


### PR DESCRIPTION
### PR Template:

## Describe your changes

- updates default enable setting for auth -- this will ensure when clowder injection happens the value is true so that it interpolates settings. This is a bug fix to address later to not rely on those settings for injection

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Bug Fixes:
- Changed default authentication enabled setting from false to true to ensure proper configuration during Clowder injection