### PR TITLE
Add workaround for authz namespace

### DIFF
--- a/internal/biz/model/outboxevents.go
+++ b/internal/biz/model/outboxevents.go
@@ -194,6 +194,11 @@ func convertResourceToSetTupleEvent(resource Resource, namespace string) (JsonOb
 		namespace = strings.ToLower(resource.ReporterType)
 	}
 
+	// This is a temporary workaround for check/lookup
+	if namespace == "authz" {
+		namespace = "notifications"
+	}
+
 	relationship := &kessel.Relationship{
 		Resource: &kessel.ObjectReference{
 			Type: &kessel.ObjectType{
@@ -232,6 +237,11 @@ func convertResourceToUnsetTupleEvent(resource Resource, namespace string) (Json
 	if resource.ReporterType != "" {
 		// v1beta2 compatibility for namespace override, see common/DefaultSetWorkspace for parity
 		namespace = strings.ToLower(resource.ReporterType)
+	}
+
+	// This is a temporary workaround for check/lookup
+	if namespace == "authz" {
+		namespace = "notifications"
 	}
 
 	tuple := &kessel.RelationTupleFilter{


### PR DESCRIPTION
- Adds temporary workaround for authz namespaced requests

## Summary by Sourcery

Add a temporary workaround to handle authz namespace by mapping it to notifications namespace in tuple conversion functions

Bug Fixes:
- Fixed namespace handling for authz-related requests by redirecting to notifications namespace

Chores:
- Added temporary workaround for namespace mapping in outbox events processing