### PR TITLE
RHCLOUD- 39617: add rebalance callback

### DIFF
--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -414,7 +414,7 @@ func (i *InventoryConsumer) commitStoredOffsets() error {
 		return err
 	}
 
-	i.Logger.Infof("offsets commited ([partition:offset]): %s", formatOffsets(committed))
+	i.Logger.Infof("offsets committed ([partition:offset]): %s", formatOffsets(committed))
 	i.OffsetStorage = nil
 	return nil
 }
@@ -550,7 +550,7 @@ func (i *InventoryConsumer) RebalanceCallback(consumer *kafka.Consumer, event ka
 		}
 
 	default:
-		i.Logger.Error("Unxpected event type: %v", event)
+		i.Logger.Error("Unexpected event type: %v", event)
 	}
 	return nil
 }

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -41,9 +41,17 @@ var requiredHeaders = []string{"operation", "txid"}
 var ErrClosed = errors.New("consumer closed")
 var ErrMaxRetries = errors.New("max retries reached")
 
-// InventoryConsumer defines a Kafka Consumer with required clients and configs to call Relations API and update the Inventory DB with consistency tokens
+type Consumer interface {
+	CommitOffsets(offsets []kafka.TopicPartition) ([]kafka.TopicPartition, error)
+	SubscribeTopics(topics []string, rebalanceCb kafka.RebalanceCb) (err error)
+	Poll(timeoutMs int) (event kafka.Event)
+	IsClosed() bool
+	Close() error
+}
+
+// InventoryConsumer defines a Consumer with required clients and configs to call Relations API and update the Inventory DB with consistency tokens
 type InventoryConsumer struct {
-	Consumer         *kafka.Consumer
+	Consumer         Consumer
 	OffsetStorage    []kafka.TopicPartition
 	Config           CompletedConfig
 	DB               *gorm.DB

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -48,6 +48,7 @@ type Consumer interface {
 	Poll(timeoutMs int) (event kafka.Event)
 	IsClosed() bool
 	Close() error
+	AssignmentLost() bool
 }
 
 // InventoryConsumer defines a Consumer with required clients and configs to call Relations API and update the Inventory DB with consistency tokens
@@ -524,7 +525,8 @@ func (i *InventoryConsumer) Retry(operation func() (string, error)) (string, err
 	return "", ErrMaxRetries
 }
 
-// RebalanceCallback logs when rebalance events occur and ensures any stored offsets are committed before losing the partition assignment. It is registered to the kafka subscription and is invoked  automatically whenever rebalances occur.
+// RebalanceCallback logs when rebalance events occur and ensures any stored offsets are committed before losing the partition assignment. It is registered to the kafka 'SubscribeTopics' call and is invoked  automatically whenever rebalances occurs.
+// Note, the RebalanceCb function must satisfy the function type func(*Consumer, Event). This function does so, but the consumer embedded in the InventoryConsumer called versus the passed on which is the same consumer in either case.
 func (i *InventoryConsumer) RebalanceCallback(consumer *kafka.Consumer, event kafka.Event) error {
 	switch ev := event.(type) {
 	case kafka.AssignedPartitions:

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"slices"
+	"strings"
 	"syscall"
 	"time"
 
@@ -129,10 +130,7 @@ type MessagePayload struct {
 
 // Consume begins the consumption loop for the Consumer
 func (i *InventoryConsumer) Consume() error {
-	// TODO -- potentially leverage rebalanceCallback here to run something when rebalance occurs
-	// more specifically, if we start commiting after X number of messages, when consumer loses partition
-	// we can ensure to commit any offsets not yet commit. This is more futureproofing than critical for now
-	err := i.Consumer.SubscribeTopics([]string{i.Config.Topic}, nil)
+	err := i.Consumer.SubscribeTopics([]string{i.Config.Topic}, i.RebalanceCallback)
 	if err != nil {
 		i.Logger.Errorf("failed to subscribe to topic: %v", err)
 		i.Errors <- err
@@ -219,7 +217,7 @@ func (i *InventoryConsumer) Consume() error {
 						i.Logger.Errorf("failed to commit offsets: %v", err)
 						continue
 					}
-					i.Logger.Infof("offsets %s to %s committed", committedOffsets[0].Offset, committedOffsets[len(committedOffsets)-1].Offset)
+					i.Logger.Infof("offsets commited ([partition:offset]): %v", strings.Join(committedOffsets, ","))
 					i.OffsetStorage = nil
 				}
 				i.Logger.Infof("consumed event from topic %s, partition %d at offset %s",
@@ -402,12 +400,17 @@ func checkIfCommit(partition kafka.TopicPartition) bool {
 }
 
 // commitStoredOffsets commits offsets for all processed messages since last offset commit
-func (i *InventoryConsumer) commitStoredOffsets() ([]kafka.TopicPartition, error) {
-	commitedOffsets, err := i.Consumer.CommitOffsets(i.OffsetStorage)
+func (i *InventoryConsumer) commitStoredOffsets() ([]string, error) {
+	var committedOffsets []string
+	committed, err := i.Consumer.CommitOffsets(i.OffsetStorage)
 	if err != nil {
 		return nil, err
 	}
-	return commitedOffsets, nil
+
+	for _, partition := range committed {
+		committedOffsets = append(committedOffsets, fmt.Sprintf("[%d:%s]", partition.Partition, partition.Offset.String()))
+	}
+	return committedOffsets, nil
 }
 
 // CreateTuple calls the Relations API to create a tuple from the message payload received and returns the consistency token
@@ -484,7 +487,7 @@ func (i *InventoryConsumer) Shutdown() error {
 			if err != nil {
 				i.Logger.Errorf("failed to commit offsets before shutting down: %v", err)
 			} else {
-				i.Logger.Infof("offsets %s to %s committed", committedOffsets[0].Offset, committedOffsets[len(committedOffsets)-1].Offset)
+				i.Logger.Infof("offsets committed ([partition:offset]): %v", strings.Join(committedOffsets, ","))
 			}
 		}
 		err := i.Consumer.Close()
@@ -519,4 +522,32 @@ func (i *InventoryConsumer) Retry(operation func() (string, error)) (string, err
 	}
 	i.Logger.Errorf("Error processing request (max attempts reached: %v): %v", attempts, err)
 	return "", ErrMaxRetries
+}
+
+// RebalanceCallback logs when rebalance events occur and ensures any stored offsets are committed before losing the partition assignment. It is registered to the kafka subscription and is invoked  automatically whenever rebalances occur.
+func (i *InventoryConsumer) RebalanceCallback(consumer *kafka.Consumer, event kafka.Event) error {
+	switch ev := event.(type) {
+	case kafka.AssignedPartitions:
+		i.Logger.Warnf("consumer rebalance event type: %d new partition(s) assigned: %v\n",
+			len(ev.Partitions), ev.Partitions)
+
+	case kafka.RevokedPartitions:
+		i.Logger.Warnf("consumer rebalance event: %d partition(s) revoked: %v\n",
+			len(ev.Partitions), ev.Partitions)
+
+		if i.Consumer.AssignmentLost() {
+			i.Logger.Warn("Assignment lost involuntarily, commit may fail")
+		}
+		committedOffsets, err := i.commitStoredOffsets()
+		if err != nil {
+			i.Logger.Errorf("failed to commit offsets: %v", err)
+			return err
+		}
+		i.Logger.Infof("offsets committed ([partition:offset]): %v", strings.Join(committedOffsets, ","))
+		i.OffsetStorage = nil
+
+	default:
+		i.Logger.Error("Unxpected event type: %v", event)
+	}
+	return nil
 }

--- a/internal/consumer/consumer_test.go
+++ b/internal/consumer/consumer_test.go
@@ -433,15 +433,45 @@ func TestCommitStoredOffsets(t *testing.T) {
 	tests := []struct {
 		name          string
 		storedOffsets []kafka.TopicPartition
-		expected      []kafka.TopicPartition
+		response      []kafka.TopicPartition
+		expected      []string
 	}{
 		{
-			name: "ensures all stored offsets are returned from offset commit",
+			name: "single stored offset is returned from offset commit",
 			storedOffsets: []kafka.TopicPartition{
-				{Offset: kafka.Offset(10), Partition: kafka.PartitionAny},
+				{Offset: kafka.Offset(10), Partition: 0},
 			},
-			expected: []kafka.TopicPartition{
-				{Offset: kafka.Offset(10), Partition: kafka.PartitionAny},
+			response: []kafka.TopicPartition{
+				{Offset: kafka.Offset(10), Partition: 0},
+			},
+			expected: []string{
+				"[0:10]",
+			},
+		},
+		{
+			name: "all stored offsets are returned from offset commit",
+			storedOffsets: []kafka.TopicPartition{
+				{Offset: kafka.Offset(10), Partition: 0},
+				{Offset: kafka.Offset(11), Partition: 0},
+				{Offset: kafka.Offset(1), Partition: 1},
+				{Offset: kafka.Offset(2), Partition: 1},
+				{Offset: kafka.Offset(12), Partition: 0},
+				{Offset: kafka.Offset(13), Partition: 0},
+				{Offset: kafka.Offset(3), Partition: 1},
+				{Offset: kafka.Offset(4), Partition: 1},
+			},
+			response: []kafka.TopicPartition{
+				{Offset: kafka.Offset(10), Partition: 0},
+				{Offset: kafka.Offset(11), Partition: 0},
+				{Offset: kafka.Offset(12), Partition: 0},
+				{Offset: kafka.Offset(13), Partition: 0},
+				{Offset: kafka.Offset(1), Partition: 1},
+				{Offset: kafka.Offset(2), Partition: 1},
+				{Offset: kafka.Offset(3), Partition: 1},
+				{Offset: kafka.Offset(4), Partition: 1},
+			},
+			expected: []string{
+				"[0:10]", "[0:11]", "[0:12]", "[0:13]", "[1:1]", "[1:2]", "[1:3]", "[1:4]",
 			},
 		},
 	}
@@ -452,7 +482,7 @@ func TestCommitStoredOffsets(t *testing.T) {
 			assert.Nil(t, errs)
 
 			c := &mocks.MockConsumer{}
-			c.On("CommitOffsets", mock.Anything).Return(test.expected, nil)
+			c.On("CommitOffsets", mock.Anything).Return(test.response, nil)
 			tester.inv.Consumer = c
 
 			committedOffsets, err := tester.inv.commitStoredOffsets()

--- a/internal/consumer/consumer_test.go
+++ b/internal/consumer/consumer_test.go
@@ -62,7 +62,13 @@ func (t *TestCase) TestSetup() []error {
 
 	notifier := &pubsub.NotifierMock{}
 
-	t.inv, err = New(t.completedConfig, &gorm.DB{}, authz.CompletedConfig{}, nil, notifier, t.logger)
+	authorizer := &mocks.MockAuthz{}
+	createTupleResponse := &v1beta1.CreateTuplesResponse{ConsistencyToken: &v1beta1.ConsistencyToken{Token: "test-token"}}
+	deleteTupleResponse := &v1beta1.DeleteTuplesResponse{ConsistencyToken: &v1beta1.ConsistencyToken{Token: "test-token"}}
+	authorizer.On("CreateTuples", mock.Anything, mock.Anything).Return(createTupleResponse, nil)
+	authorizer.On("DeleteTuples", mock.Anything, mock.Anything).Return(deleteTupleResponse, nil)
+
+	t.inv, err = New(t.completedConfig, &gorm.DB{}, authz.CompletedConfig{}, authorizer, notifier, t.logger)
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -72,13 +78,6 @@ func (t *TestCase) TestSetup() []error {
 		errs = append(errs, err)
 	}
 
-	createTupleResponse := &v1beta1.CreateTuplesResponse{ConsistencyToken: &v1beta1.ConsistencyToken{Token: "test-token"}}
-	deleteTupleResponse := &v1beta1.DeleteTuplesResponse{ConsistencyToken: &v1beta1.ConsistencyToken{Token: "test-token"}}
-
-	m := &mocks.MockAuthz{}
-	m.On("CreateTuples", mock.Anything, mock.Anything).Return(createTupleResponse, nil)
-	m.On("DeleteTuples", mock.Anything, mock.Anything).Return(deleteTupleResponse, nil)
-	t.inv.Authorizer = m
 	return errs
 }
 
@@ -426,6 +425,39 @@ func TestCheckIfCommit(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			actual := checkIfCommit(test.partition)
 			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestCommitStoredOffsets(t *testing.T) {
+	tests := []struct {
+		name          string
+		storedOffsets []kafka.TopicPartition
+		expected      []kafka.TopicPartition
+	}{
+		{
+			name: "ensures all stored offsets are returned from offset commit",
+			storedOffsets: []kafka.TopicPartition{
+				{Offset: kafka.Offset(10), Partition: kafka.PartitionAny},
+			},
+			expected: []kafka.TopicPartition{
+				{Offset: kafka.Offset(10), Partition: kafka.PartitionAny},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tester := TestCase{}
+			errs := tester.TestSetup()
+			assert.Nil(t, errs)
+
+			c := &mocks.MockConsumer{}
+			c.On("CommitOffsets", mock.Anything).Return(test.expected, nil)
+			tester.inv.Consumer = c
+
+			committedOffsets, err := tester.inv.commitStoredOffsets()
+			assert.Nil(t, err)
+			assert.Equal(t, test.expected, committedOffsets)
 		})
 	}
 }

--- a/internal/consumer/consumer_test.go
+++ b/internal/consumer/consumer_test.go
@@ -434,22 +434,18 @@ func TestCommitStoredOffsets(t *testing.T) {
 		name          string
 		storedOffsets []kafka.TopicPartition
 		response      []kafka.TopicPartition
-		expected      []string
 	}{
 		{
-			name: "single stored offset is returned from offset commit",
+			name: "single stored offset is committed without error",
 			storedOffsets: []kafka.TopicPartition{
 				{Offset: kafka.Offset(10), Partition: 0},
 			},
 			response: []kafka.TopicPartition{
 				{Offset: kafka.Offset(10), Partition: 0},
-			},
-			expected: []string{
-				"[0:10]",
 			},
 		},
 		{
-			name: "all stored offsets are returned from offset commit",
+			name: "all stored offsets are committed without error",
 			storedOffsets: []kafka.TopicPartition{
 				{Offset: kafka.Offset(10), Partition: 0},
 				{Offset: kafka.Offset(11), Partition: 0},
@@ -469,9 +465,6 @@ func TestCommitStoredOffsets(t *testing.T) {
 				{Offset: kafka.Offset(2), Partition: 1},
 				{Offset: kafka.Offset(3), Partition: 1},
 				{Offset: kafka.Offset(4), Partition: 1},
-			},
-			expected: []string{
-				"[0:10]", "[0:11]", "[0:12]", "[0:13]", "[1:1]", "[1:2]", "[1:3]", "[1:4]",
 			},
 		},
 	}
@@ -485,9 +478,9 @@ func TestCommitStoredOffsets(t *testing.T) {
 			c.On("CommitOffsets", mock.Anything).Return(test.response, nil)
 			tester.inv.Consumer = c
 
-			committedOffsets, err := tester.inv.commitStoredOffsets()
+			err := tester.inv.commitStoredOffsets()
 			assert.Nil(t, err)
-			assert.Equal(t, test.expected, committedOffsets)
+			assert.Nil(t, tester.inv.OffsetStorage)
 		})
 	}
 }

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"context"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 
 	"github.com/project-kessel/inventory-api/internal/biz/model"
 	kesselv1 "github.com/project-kessel/relations-api/api/kessel/relations/v1"
@@ -11,6 +12,10 @@ import (
 )
 
 type MockAuthz struct {
+	mock.Mock
+}
+
+type MockConsumer struct {
 	mock.Mock
 }
 
@@ -54,3 +59,18 @@ func (m *MockAuthz) LookupResources(ctx context.Context, request *v1beta1.Lookup
 	args := m.Called(ctx, request)
 	return args.Get(0).(grpc.ServerStreamingClient[v1beta1.LookupResourcesResponse]), args.Error(1)
 }
+
+func (m *MockConsumer) CommitOffsets(offsets []kafka.TopicPartition) ([]kafka.TopicPartition, error) {
+	args := m.Called(offsets)
+	return args.Get(0).([]kafka.TopicPartition), args.Error(1)
+}
+
+func (m *MockConsumer) SubscribeTopics(topics []string, rebalanceCb kafka.RebalanceCb) (err error) {
+	return nil
+}
+
+func (m *MockConsumer) Poll(timeoutMs int) (event kafka.Event) { return nil }
+
+func (m *MockConsumer) IsClosed() bool { return true }
+
+func (m *MockConsumer) Close() error { return nil }

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -74,3 +74,5 @@ func (m *MockConsumer) Poll(timeoutMs int) (event kafka.Event) { return nil }
 func (m *MockConsumer) IsClosed() bool { return true }
 
 func (m *MockConsumer) Close() error { return nil }
+
+func (m *MockConsumer) AssignmentLost() bool { return true }

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"context"
+
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 
 	"github.com/project-kessel/inventory-api/internal/biz/model"
@@ -66,13 +67,26 @@ func (m *MockConsumer) CommitOffsets(offsets []kafka.TopicPartition) ([]kafka.To
 }
 
 func (m *MockConsumer) SubscribeTopics(topics []string, rebalanceCb kafka.RebalanceCb) (err error) {
-	return nil
+	args := m.Called(topics, rebalanceCb)
+	return args.Error(0)
 }
 
-func (m *MockConsumer) Poll(timeoutMs int) (event kafka.Event) { return nil }
+func (m *MockConsumer) Poll(timeoutMs int) (event kafka.Event) {
+	args := m.Called(timeoutMs)
+	return args.Get(0).(kafka.Event)
+}
 
-func (m *MockConsumer) IsClosed() bool { return true }
+func (m *MockConsumer) IsClosed() bool {
+	args := m.Called()
+	return args.Get(0).(bool)
+}
 
-func (m *MockConsumer) Close() error { return nil }
+func (m *MockConsumer) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
 
-func (m *MockConsumer) AssignmentLost() bool { return true }
+func (m *MockConsumer) AssignmentLost() bool {
+	args := m.Called()
+	return args.Get(0).(bool)
+}


### PR DESCRIPTION
### PR Template:

## Describe your changes
* adds consumer interface for mocking
  * updates inventory consumer to take consumer interface over kafka consumer
  * ensures all used kafka consumer methods are added to satisfy interface
  * adds new tests that uses mock to confirm it works
* adds rebalance callback function and configures SubscribeTopics with it
  * This will ensure offsets are committed when partitions are revoked
* updates the commitStoredOffsets function to return a structured string with partitions and offsets committed (more useful when there are multiple partitions


## Ticket reference (if applicable)
For # RHCLOUD-39617

## Summary by Sourcery

Enhance Kafka consumer with improved offset management, rebalance handling, and mockability

New Features:
- Add consumer interface for easier mocking and testing
- Implement rebalance callback to ensure offsets are committed during partition rebalancing

Enhancements:
- Update offset commit logging to provide more detailed partition and offset information
- Refactor consumer to use an interface for better abstraction

Tests:
- Add new tests for offset commitment
- Create mock consumer for testing