### PR TITLE
RHCLOUD-39796 - Add script/runbook for manually replicating missing objects

### DIFF
--- a/docs/manual_migration_to_spicedb.py
+++ b/docs/manual_migration_to_spicedb.py
@@ -7,44 +7,61 @@ import os
 
 def extract_json_payload(line):
     if "operation:" in line:
-        # ignore delete for now.
-        if "operation:deleted" in line:
-            return None
-
         # its tab seperated??
         parts = line.strip().split('\t')
 
         data = json.loads(parts[-1])
-        return data.get("payload")
+        if "operation:deleted" in line: # delete 
+            return data.get("payload"), True
+
+        return data.get("payload"), False
     else:
         match = re.search(r'"payload":"({.+})"', line)
         payload_str = match.group(1).encode().decode("unicode_escape")
-        return json.loads(payload_str)
+        return json.loads(payload_str), False
 
 
-def build_zed_command(payload):
-    resource = payload["resource"]
-    relation = payload["relation"]
-    subject = payload["subject"]["subject"]
+def build_zed_command(payload, delete: bool):
+    if delete:
+        resource_namespace = payload["resource_namespace"]
+        resource_name = payload["resource_type"]
+        resource_id = payload["resource_id"]
+        relation = payload["relation"]
 
-    resource_name = resource["type"]["name"]
-    resource_id = resource["id"]
+        return (
+            f"zed relationship bulk-delete "
+            f"{resource_namespace}/{resource_name}:{resource_id} "
+            f"t_{relation} "
+        )
+    else: # upsert
+    
+        resource = payload["resource"]
+        relation = payload["relation"]
+        subject = payload["subject"]["subject"]
 
-    subject_ns = subject["type"]["namespace"]
-    subject_name = subject["type"]["name"]
-    subject_id = subject["id"]
+        resource_namespace = resource["type"]["namespace"]
+        if resource_namespace == "authz":
+            resource_namespace = "notifications"
 
-    return (
-        f"zed relationship touch "
-        f"notifications/{resource_name}:{resource_id} "
-        f"t_{relation} "
-        f"{subject_ns}/{subject_name}:{subject_id}"
-    )
+        resource_name = resource["type"]["name"]
+        resource_id = resource["id"]
+
+        
+        subject_ns = subject["type"]["namespace"]
+        subject_name = subject["type"]["name"]
+        subject_id = subject["id"]
+
+        return (
+            f"zed relationship touch "
+            f"{resource_namespace}/{resource_name}:{resource_id} "
+            f"t_{relation} "
+            f"{subject_ns}/{subject_name}:{subject_id}"
+        )
 
 
 def main():
     if len(sys.argv) != 2:
-        print("Usage: python3 migrate_to_spicedb.py <input_file>")
+        print("Usage: python3 manual_migration_to_spicedb.py <input_file>")
         sys.exit(1)
 
     input_file = sys.argv[1]
@@ -55,13 +72,17 @@ def main():
 
     with open(input_file, "r") as f:
         for line in f:
-            payload = extract_json_payload(line)
+            payload, delete = extract_json_payload(line)
             if not payload:
                 continue
 
-            cmd = build_zed_command(payload)
+            cmd = build_zed_command(payload, delete)
             print(f"Running: {cmd}")
-            subprocess.run(cmd, shell=True)
+            try:
+                subprocess.run(cmd, shell=True, check=True)
+            except subprocess.CalledProcessError as e:
+                print(f"Command failed with return code {e.returncode}")
+                sys.exit(e.returncode)
 
 if __name__ == "__main__":
     main()

--- a/docs/manual_migration_to_spicedb.py
+++ b/docs/manual_migration_to_spicedb.py
@@ -5,36 +5,82 @@ import sys
 import os
 
 
-def extract_json_payload(line):
+def extract_json_payload(line: str):
     if "operation:" in line:
-        # its tab seperated??
         parts = line.strip().split('\t')
+    
+        # extract the operation
+        op_match = re.search(r'operation:(\w+)', parts[1])
+        if not op_match:
+            return None
+        operation = op_match.group(1)
+        print("operation " + operation)
 
+        # extract inventory_id from payload
+        payload1_json = json.loads(parts[2])
+        inventory_id = payload1_json.get("payload")
+
+        # get the other payload with the permission data.
         data = json.loads(parts[-1])
-        if "operation:deleted" in line: # delete 
-            return data.get("payload"), True
 
-        return data.get("payload"), False
+        return inventory_id, data.get("payload"), operation
     else:
         match = re.search(r'"payload":"({.+})"', line)
         payload_str = match.group(1).encode().decode("unicode_escape")
-        return json.loads(payload_str), False
+        return None, json.loads(payload_str), "updated"
 
 
-def build_zed_command(payload, delete: bool):
-    if delete:
+def build_zed_command(inventory_id: str, payload: any, operation: str):
+    if operation == "deleted":
+        # parse message
         resource_namespace = payload["resource_namespace"]
         resource_name = payload["resource_type"]
         resource_id = payload["resource_id"]
         relation = payload["relation"]
+        # 1
+        # If the resource does not exist in inventory, check if tuple exists, if so delete the tuple
+		# (this is in the case of a delete operation message & no resource in inventory)
+		# (parse message, gabi call, zed relationship read, zed relationship delete) 
+        # call gabi
 
-        return (
-            f"zed relationship bulk-delete "
-            f"{resource_namespace}/{resource_name}:{resource_id} "
-            f"t_{relation} "
+        # res = gabi() # will need to parse some json.
+        print(f"Fetching info on inventory_id: {inventory_id}")
+        res = subprocess.run(
+            f"gabi exec \"select * from resources where inventory_id='{inventory_id}'",
+            shell=True,
+            capture_output=True,
+            text=True
         )
-    else: # upsert
-    
+
+        print("What" + res.stdout)
+
+        # resource doesn't exist in inventory
+        print("Resource doesn't exist in Inventory DB.")
+
+        # zed relationship read fully consistent
+        res = subprocess.run(
+                f"zed relationship read "
+                f"{resource_namespace}/{resource_name}:{resource_id} "
+                f"t_{relation} --consistency-full",
+                shell=True,
+                capture_output=True,
+                text=True
+            )
+        
+        # exists.
+        if len(res.stdout) != 0:
+            print(f"Resource exists in SpiceDB: {res.stdout}")
+
+            return (
+                f"zed relationship bulk-delete "
+                f"{resource_namespace}/{resource_name}:{resource_id} "
+                f"t_{relation} "
+            )
+        else:
+            return None
+        
+    else:
+        # parse message
         resource = payload["resource"]
         relation = payload["relation"]
         subject = payload["subject"]["subject"]
@@ -50,13 +96,119 @@ def build_zed_command(payload, delete: bool):
         subject_ns = subject["type"]["namespace"]
         subject_name = subject["type"]["name"]
         subject_id = subject["id"]
+    
+        if operation == "created":
+            # 	2) If the resource exists in inventory, check if tuple exists, if not create
+            # (in the case of resource in inventory but not in spicedb.)
+            # (parse message, gabi call, zed relationship read, zed relationship create)
 
-        return (
-            f"zed relationship touch "
-            f"{resource_namespace}/{resource_name}:{resource_id} "
-            f"t_{relation} "
-            f"{subject_ns}/{subject_name}:{subject_id}"
-        )
+            # res = gabi()
+
+            print(f"Fetching info on inventory_id: {inventory_id}")
+            res = subprocess.run(
+                f"gabi exec \"select * from resources where inventory_id='{inventory_id}'",
+                shell=True,
+                capture_output=True,
+                text=True
+            )
+
+            print(res.stdout)
+
+            # resource exists
+            print("Resource exists in Inventory DB.")
+
+            # check if tuple already exists!
+
+            # zed relationship read fully consistent
+            res = subprocess.run(
+                    f"zed relationship read "
+                    f"{resource_namespace}/{resource_name}:{resource_id} "
+                    f"t_{relation} "
+                    f"{subject_ns}/{subject_name}:{subject_id} --consistency-full",
+                    shell=True,
+                    capture_output=True,
+                    text=True
+                )
+            
+            # exists.
+            if len(res.stdout) != 0:
+                print(f"Resource exists in SpiceDB: {res.stdout}")
+                return None
+
+            # Only create if exists in inventory & doesn't exist in SpiceDB.
+            return (
+                f"zed relationship create "
+                f"{resource_namespace}/{resource_name}:{resource_id} "
+                f"t_{relation} "
+                f"{subject_ns}/{subject_name}:{subject_id}"
+            )
+    
+        elif operation == "updated":
+            # 4) if the resource exists in inventory, check if the tuple exists, if they do not match, apply the update to the tuple derived from the resource
+			# (so then this is an update okay,)
+			# (what about them needs to match? this is were im a bit confused...)
+			# (parse mesasge, gabi call, zed relatonship read, zed relationship touch)
+
+            # Call gabi to fetch current info on resource.
+            print(f"Fetching info on inventory_id: {inventory_id}")
+            res = subprocess.run(
+                f"gabi exec \"select * from resources where inventory_id='{inventory_id}'\"",
+                shell=True,
+                capture_output=True,
+                text=True
+            )
+            gabi_output = res.stdout
+            if gabi_output == "your query didn't return any results":
+                return None # Don't update anything.
+    
+            # resource exists
+            print("Resource exists in Inventory DB.")
+            parsed_data = json.loads(gabi_output)
+            
+            inventory_resource_id = parsed_data[0]["reporter_resource_id"]
+            inventory_subject_id = parsed_data[0]["workspace_id"]
+
+            print(f"Inventory_resource_id: {inventory_resource_id}")
+            print(f"Inventory_subject_id: {inventory_subject_id}")
+
+            # zed relationship read fully consistent
+            res = subprocess.run(
+                    f"zed relationship read "
+                    f"{resource_namespace}/{resource_name}:{resource_id} "
+                    f"t_{relation} "
+                    f"{subject_ns}/{subject_name}:{subject_id} --consistency-full",
+                    shell=True,
+                    capture_output=True,
+                    text=True
+                )
+            zed_output = res.stdout
+            
+            # exists.
+            if len(zed_output) != 0:
+                print(f"Resource exists in SpiceDB: {zed_output}")
+                # do they match?
+                # If not, apply update from inventory DB.
+                sections = zed_output.split()
+                res_id = sections[0].split(":")[1]
+                sub_id = sections[2].split(":")[1]
+
+                if res_id == inventory_resource_id and sub_id == inventory_subject_id:
+                    return None # They match, no need to update.
+
+                return (
+                    f"zed relationship touch "
+                    f"{resource_namespace}/{resource_name}:{inventory_resource_id} "
+                    f"t_{relation} "
+                    f"{subject_ns}/{subject_name}:{inventory_subject_id}"
+                )
+            
+            # If it doesn't exist in spicedb but does in inventory, we should prob create?
+            return (
+                f"zed relationship touch "
+                f"{resource_namespace}/{resource_name}:{inventory_resource_id} "
+                f"t_{relation} "
+                f"{subject_ns}/{subject_name}:{inventory_subject_id}"
+            )
 
 
 def main():
@@ -72,17 +224,18 @@ def main():
 
     with open(input_file, "r") as f:
         for line in f:
-            payload, delete = extract_json_payload(line)
+            inventory_id, payload, operation = extract_json_payload(line)
             if not payload:
                 continue
 
-            cmd = build_zed_command(payload, delete)
-            print(f"Running: {cmd}")
-            try:
-                subprocess.run(cmd, shell=True, check=True)
-            except subprocess.CalledProcessError as e:
-                print(f"Command failed with return code {e.returncode}")
-                sys.exit(e.returncode)
+            cmd = build_zed_command(inventory_id, payload, operation)
+            if cmd:
+                print(f"Running: {cmd}")
+                try:
+                    subprocess.run(cmd, shell=True, check=True)
+                except subprocess.CalledProcessError as e:
+                    print(f"Command failed with return code {e.returncode}")
+                    sys.exit(e.returncode)
 
 if __name__ == "__main__":
     main()

--- a/docs/manual_migration_to_spicedb.py
+++ b/docs/manual_migration_to_spicedb.py
@@ -1,0 +1,67 @@
+import json
+import re
+import subprocess
+import sys
+import os
+
+
+def extract_json_payload(line):
+    if "operation:" in line:
+        # ignore delete for now.
+        if "operation:deleted" in line:
+            return None
+
+        # its tab seperated??
+        parts = line.strip().split('\t')
+
+        data = json.loads(parts[-1])
+        return data.get("payload")
+    else:
+        match = re.search(r'"payload":"({.+})"', line)
+        payload_str = match.group(1).encode().decode("unicode_escape")
+        return json.loads(payload_str)
+
+
+def build_zed_command(payload):
+    resource = payload["resource"]
+    relation = payload["relation"]
+    subject = payload["subject"]["subject"]
+
+    resource_name = resource["type"]["name"]
+    resource_id = resource["id"]
+
+    subject_ns = subject["type"]["namespace"]
+    subject_name = subject["type"]["name"]
+    subject_id = subject["id"]
+
+    return (
+        f"zed relationship touch "
+        f"notifications/{resource_name}:{resource_id} "
+        f"t_{relation} "
+        f"{subject_ns}/{subject_name}:{subject_id}"
+    )
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python3 migrate_to_spicedb.py <input_file>")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+
+    if not os.path.isfile(input_file):
+        print(f"File not found: {input_file}")
+        return
+
+    with open(input_file, "r") as f:
+        for line in f:
+            payload = extract_json_payload(line)
+            if not payload:
+                continue
+
+            cmd = build_zed_command(payload)
+            print(f"Running: {cmd}")
+            subprocess.run(cmd, shell=True)
+
+if __name__ == "__main__":
+    main()

--- a/docs/manual_migration_to_spicedb.py
+++ b/docs/manual_migration_to_spicedb.py
@@ -36,7 +36,7 @@ def extract_json_payload(line: str):
         inventory_id = match_inventory_id.group(1).encode().decode("unicode_escape")
 
         # We don't really know what operation they are supposed to be doing tbh. 
-        # Update make be safe, but not entirely.
+        # Update might be safe, but not entirely.
         return inventory_id, json.loads(payload_str), "updated"
     
 
@@ -64,7 +64,7 @@ def build_deleted_command(inventory_id, payload):
         print(f"Resource exists in SpiceDB: {res.stdout}. Deleting...")
         return f"zed relationship bulk-delete {resource_namespace}/{resource_name}:{resource_id} t_{relation}"
 
-    print("Resource doesn't exist in SpiceDB. Not deleting")
+    print("Resource doesn't exist in SpiceDB. Nothing to delete...")
     return None
 
 def build_created_command(inventory_id, payload):

--- a/docs/manual_migration_to_spicedb.py
+++ b/docs/manual_migration_to_spicedb.py
@@ -27,7 +27,7 @@ def extract_json_payload(line: str):
     else:
         match = re.search(r'"payload":"({.+})"', line)
         payload_str = match.group(1).encode().decode("unicode_escape")
-        return None, json.loads(payload_str), "updated"
+        return None, json.loads(payload_str), "updated" # we dont really know???
 
 
 def build_zed_command(inventory_id: str, payload: any, operation: str):
@@ -37,11 +37,8 @@ def build_zed_command(inventory_id: str, payload: any, operation: str):
         resource_name = payload["resource_type"]
         resource_id = payload["resource_id"]
         relation = payload["relation"]
-        # 1
         # If the resource does not exist in inventory, check if tuple exists, if so delete the tuple
-		# (this is in the case of a delete operation message & no resource in inventory)
 		# (parse message, gabi call, zed relationship read, zed relationship delete) 
-        # call gabi
 
         # Call gabi to fetch current info on resource.
         inventory_resource_id, inventory_subject_id = fetch_inventory_resource_info(inventory_id)
@@ -71,8 +68,7 @@ def build_zed_command(inventory_id: str, payload: any, operation: str):
                 f"{resource_namespace}/{resource_name}:{resource_id} "
                 f"t_{relation} "
             )
-        else:
-            return None
+        return None
         
     else: # created or updated
         # parse message
@@ -92,8 +88,7 @@ def build_zed_command(inventory_id: str, payload: any, operation: str):
         subject_id = subject["id"]
     
         if operation == "created":
-            # 	2) If the resource exists in inventory, check if tuple exists, if not create
-            # (in the case of resource in inventory but not in spicedb.)
+            # If the resource exists in inventory, check if tuple exists, if not create
             # (parse message, gabi call, zed relationship read, zed relationship create)
 
             # Call gabi to fetch current info on resource.
@@ -119,7 +114,7 @@ def build_zed_command(inventory_id: str, payload: any, operation: str):
             # exists.
             if len(zed_output) != 0:
                 print(f"Resource exists in SpiceDB: {zed_output}")
-                return None
+                return None # Our job here is already done.
 
             # Only create if exists in inventory & doesn't exist in SpiceDB.
             return (
@@ -130,9 +125,8 @@ def build_zed_command(inventory_id: str, payload: any, operation: str):
             )
     
         elif operation == "updated":
-            # 4) if the resource exists in inventory, check if the tuple exists, if they do not match, apply the update to the tuple derived from the resource
-			# (so then this is an update okay,)
-			# (what about them needs to match? this is were im a bit confused...)
+            # if the resource exists in inventory, check if the tuple exists, if they do not match,
+            # apply the update to the tuple derived from the resource
 			# (parse mesasge, gabi call, zed relatonship read, zed relationship touch)
 
             # Call gabi to fetch current info on resource.

--- a/docs/manual_migration_to_spicedb.py
+++ b/docs/manual_migration_to_spicedb.py
@@ -45,11 +45,11 @@ def build_zed_command(inventory_id: str, payload: any, operation: str):
 
         # Call gabi to fetch current info on resource.
         inventory_resource_id, inventory_subject_id = fetch_inventory_resource_info(inventory_id)
-        if inventory_resource_id or not inventory_subject_id:
+        if inventory_resource_id or inventory_subject_id:
             return None # Dont delete, as it still exists in inventory DB.
 
         # resource doesn't exist in inventory
-        print("Resource doesn't exist in Inventory DB.")
+        print(f"Inventory ID: {inventory_id} doesn't exist in Inventory DB.")
 
         # zed relationship read fully consistent
         res = subprocess.run(
@@ -60,10 +60,11 @@ def build_zed_command(inventory_id: str, payload: any, operation: str):
                 capture_output=True,
                 text=True
             )
+        zed_output = res.stdout
         
         # exists.
-        if len(res.stdout) != 0:
-            print(f"Resource exists in SpiceDB: {res.stdout}")
+        if len(zed_output) != 0:
+            print(f"Resource exists in SpiceDB: {zed_output}")
 
             return (
                 f"zed relationship bulk-delete "
@@ -101,8 +102,6 @@ def build_zed_command(inventory_id: str, payload: any, operation: str):
                 return None # No resource in inventory DB.
             
             # resource exists
-            print("Resource exists in Inventory DB.")
-
             # check if tuple already exists!
 
             # zed relationship read fully consistent
@@ -115,10 +114,11 @@ def build_zed_command(inventory_id: str, payload: any, operation: str):
                     capture_output=True,
                     text=True
                 )
+            zed_output = res.stdout
             
             # exists.
-            if len(res.stdout) != 0:
-                print(f"Resource exists in SpiceDB: {res.stdout}")
+            if len(zed_output) != 0:
+                print(f"Resource exists in SpiceDB: {zed_output}")
                 return None
 
             # Only create if exists in inventory & doesn't exist in SpiceDB.
@@ -139,7 +139,7 @@ def build_zed_command(inventory_id: str, payload: any, operation: str):
             inventory_resource_id, inventory_subject_id = fetch_inventory_resource_info(inventory_id)
             if not inventory_resource_id or not inventory_subject_id:
                 return None # No resource in inventory DB.
-
+            
             # zed relationship read fully consistent
             res = subprocess.run(
                     f"zed relationship read "
@@ -193,7 +193,7 @@ def fetch_inventory_resource_info(inventory_id):
         return None, None # Don't update anything.
 
     # resource exists
-    print("Resource exists in Inventory DB.")
+    print(f"Inventory ID: {inventory_id} exists in Inventory DB.")
     parsed_data = json.loads(gabi_output)
     
     inventory_resource_id = parsed_data[0]["reporter_resource_id"]

--- a/docs/manual_migration_to_spicedb.py
+++ b/docs/manual_migration_to_spicedb.py
@@ -45,6 +45,8 @@ def build_zed_command(inventory_id: str, payload: any, operation: str):
 
         # Call gabi to fetch current info on resource.
         inventory_resource_id, inventory_subject_id = fetch_inventory_resource_info(inventory_id)
+        if inventory_resource_id or not inventory_subject_id:
+            return None # Dont delete, as it still exists in inventory DB.
 
         # resource doesn't exist in inventory
         print("Resource doesn't exist in Inventory DB.")
@@ -95,7 +97,9 @@ def build_zed_command(inventory_id: str, payload: any, operation: str):
 
             # Call gabi to fetch current info on resource.
             inventory_resource_id, inventory_subject_id = fetch_inventory_resource_info(inventory_id)
-
+            if not inventory_resource_id or not inventory_subject_id:
+                return None # No resource in inventory DB.
+            
             # resource exists
             print("Resource exists in Inventory DB.")
 
@@ -133,6 +137,8 @@ def build_zed_command(inventory_id: str, payload: any, operation: str):
 
             # Call gabi to fetch current info on resource.
             inventory_resource_id, inventory_subject_id = fetch_inventory_resource_info(inventory_id)
+            if not inventory_resource_id or not inventory_subject_id:
+                return None # No resource in inventory DB.
 
             # zed relationship read fully consistent
             res = subprocess.run(
@@ -184,7 +190,7 @@ def fetch_inventory_resource_info(inventory_id):
     )
     gabi_output = res.stdout
     if gabi_output == "your query didn't return any results":
-        return None # Don't update anything.
+        return None, None # Don't update anything.
 
     # resource exists
     print("Resource exists in Inventory DB.")

--- a/docs/runbooks/stage/replicate-inventory-messages-spicedb.md
+++ b/docs/runbooks/stage/replicate-inventory-messages-spicedb.md
@@ -112,7 +112,17 @@ EOF
 
 Save these messages to some file like `kafkadump.txt`.
 
-With our zed context and gabi config set up to stage and port-forwarding into the SpiceDB service, we can execute our [migration script](/docs/manual_migration_to_spicedb.py). Move the migration script to the same level as your `kafkadump.txt` file.
+**WARNING:**
+Before executing our script we must ensure the consumer is disabled such that no messages are processed at the same time
+we are trying to manually replicate resources to SpiceDB. If you do not disable the consumer before running the migration script, data between inventory and SpiceDB may not be consistent. 
+
+Disable the consumer in the inventory api config yaml. You may need to roll the pods for the change to take effect.
+```shell
+  consumer:
+    enabled: false
+```
+
+With our zed context and gabi config set up to stage and port-forwarding into the SpiceDB service, we can execute our [migration script](/scripts/manual_migration_to_spicedb.py). Move the migration script to the same location as your `kafkadump.txt` file.
 
 Run 
 ```shell
@@ -120,3 +130,10 @@ python3 manual_migration_to_spicedb.py kafkadump.txt
 ```
 
 Voila! Your inventory DB data should now be consistent with SpiceDB after reprocessing the failing messages!
+
+You can now reenable the consumer so messages can begin processing. You may need to roll the pods for the change to take effect.
+
+```shell
+  consumer:
+    enabled: true
+```

--- a/docs/runbooks/stage/replicate-inventory-messages-spicedb.md
+++ b/docs/runbooks/stage/replicate-inventory-messages-spicedb.md
@@ -43,7 +43,7 @@ The read command should dump out the entire SpiceDB schema. An error is provided
 
 To install the `gabi` CLI, refer to [gabi's README](https://github.com/app-sre/gabi-cli) for specific instructions based on your OS
 
-In order to access Inventory's DB using the `gabi` cli, you'll need to configure a profile for the stage gabi instance. This will access to the gabi instance via its route and a token used to login to the cluster.
+In order to access Inventory's DB using the `gabi` cli, you'll need to configure a profile for the stage gabi instance. Accessing the Gabi instance requires its route and a token used to log into the cluster.
 
 If you don't already have a gabi config initialized, execute the `init` command: 
 ```shell

--- a/docs/runbooks/stage/replicate-inventory-messages-spicedb.md
+++ b/docs/runbooks/stage/replicate-inventory-messages-spicedb.md
@@ -1,0 +1,52 @@
+# Manual Inventory DB replication to SpiceDB
+
+## Prerequisites
+
+Remediations covered in this guide will require the following:
+1) [zed cli](https://github.com/authzed/zed?tab=readme-ov-file#getting-started)
+2) Some python3 version installed.
+3) Access to the portforwarding into the running cluster. 
+
+### Configuring Zed CLI
+
+To install the `zed` CLI, refer to [Authzed's README](https://github.com/authzed/zed?tab=readme-ov-file#getting-started) for specific instructions based on your OS
+
+In order to access SpiceDB using the `zed` cli, you'll need to configure a context for the SpiceDB endpoint. This will require a preshared token available in a Kubernetes secret on cluster.
+
+To configure the context:
+
+```shell
+# capture the preshared key from spicedb-config secret
+PSTK=$(oc get secret spicedb-config -o jsonpath='{.data.preshared_key}' | base64 -d)
+
+# create the context with zed cli -- change ENV to the ENV you are targeting (stage, prod)
+zed context set <ENV>-spicedb localhost:50051 $PSTK --insecure
+
+# verify the context was created and is the current context
+zed context list
+```
+
+To confirm the context is working:
+
+```shell
+# port-forward the spicedb service to your system
+oc port-forward svc/kessel-relations-spicedb 50051:50051
+
+# check the schema
+zed schema read
+```
+
+The read command should dump out the entire SpiceDB schema. An error is provided if there are any connection issues or if no schema exists.
+
+## Running the migration script.
+
+We will need a dump of the offset messages that need to be reprocessed.
+
+Save these messages as some file like `kafkadump.txt`.
+
+With our zed context setup to stage and portforwarding into the spicedb service, we can execute our [migration script](/docs/manual_migration_to_spicedb.py). Move the migration script to the same level as your `kafkadump.txt` file.
+
+Run 
+```shell
+python3 manual_migration_to_spicedb.py kafkadump.txt
+```

--- a/docs/runbooks/stage/replicate-inventory-messages-spicedb.md
+++ b/docs/runbooks/stage/replicate-inventory-messages-spicedb.md
@@ -49,7 +49,7 @@ If you don't already have a gabi config initialized, execute the `init` command:
 ```shell
 gabi config init
 ```
-There are two settings we need to setup, the `URL` and `TOKEN`. You can grab the `URL` from
+There are two settings we need to set up, the `URL` and `TOKEN`. You can grab the `URL` from
 the `gabi-kessel` route and the `TOKEN` from the token used to log into the cluster.
 Execute the following to set your url and token.
 ```shell

--- a/docs/runbooks/stage/replicate-inventory-messages-spicedb.md
+++ b/docs/runbooks/stage/replicate-inventory-messages-spicedb.md
@@ -4,8 +4,9 @@
 
 Remediations covered in this guide will require the following:
 1) [zed cli](https://github.com/authzed/zed?tab=readme-ov-file#getting-started)
-2) Some python3 version installed.
-3) Access to the portforwarding into the running cluster. 
+2) [gabi cli](https://github.com/app-sre/gabi-cli) installed & gabi access on cluster
+3) Some python3 version installed.
+4) Access to the portforwarding into the running cluster. 
 
 ### Configuring Zed CLI
 
@@ -38,15 +39,84 @@ zed schema read
 
 The read command should dump out the entire SpiceDB schema. An error is provided if there are any connection issues or if no schema exists.
 
+### Configuring gabi CLI
+
+To install the `gabi` CLI, refer to [gabi's README](https://github.com/app-sre/gabi-cli) for specific instructions based on your OS
+
+In order to access Inventory's DB using the `gabi` cli, you'll need to configure a profile for the stage gabi instance. This will access to the gabi instance via its route and a token used to login to the cluster.
+
+If you don't already have a gabi config initialized, execute the `init` command: 
+```shell
+gabi config init
+```
+There are two settings we need to setup, the `URL` and `TOKEN`. You can grab the `URL` from
+the `gabi-kessel` route and the `TOKEN` from the token used to log into the cluster.
+Execute the following to set your url and token.
+```shell
+gabi config seturl <gabi-kessel-route>
+gabi config settoken <sha256-login-token> 
+```
+You can check your current profile with `gabi config currentprofile`.
+```shell
+{
+  "name": "default",
+  "alias": "default",
+  "url": "https://gabi-kessel.apps.cluster.example.com",
+  "token": "sha256~xkXXX...",
+  "current": true,
+  "enable_history": true
+}
+```
+
+To confirm `gabi` is working we can execute a basic query against the DB.
+```shell
+gabi exec "select id, created_at, reporter from resources limit 1"
+[
+  {
+    "created_at": "2024-11-13T14:29:57.061157Z",
+    "id": "X-X-X-X",
+    "reporter": "{}"
+  }
+]
+```
+
 ## Running the migration script.
 
-We will need a dump of the offset messages that need to be reprocessed.
+We will need a dump of the offset messages that need to be reprocessed. To get a dump of processed messages,
+we can spin up a kafka debug pod to read every message.
 
-Save these messages as some file like `kafkadump.txt`.
+**Process**
 
-With our zed context setup to stage and portforwarding into the spicedb service, we can execute our [migration script](/docs/manual_migration_to_spicedb.py). Move the migration script to the same level as your `kafkadump.txt` file.
+```shell
+# capture Kafka connection details for Kafka CLI commands later
+BOOTSTRAP_SERVERS=$(oc get secret kessel-inventory -o json | jq -r '.data."cdappconfig.json"' | base64 -d | jq -r '.kafka.brokers[] | "\(.hostname):\(.port)"')
+KAFKA_USER=$(oc get secret kessel-inventory -o json | jq -r '.data."cdappconfig.json"' | base64 -d | jq -r '.kafka.brokers[0].sasl.username')
+KAFKA_PW=$(oc get secret kessel-inventory -o json | jq -r '.data."cdappconfig.json"' | base64 -d | jq -r '.kafka.brokers[0].sasl.password')
+
+# run and exec into kafka pod
+oc run kafka-debug --rm -i --tty --image quay.io/strimzi/kafka:0.45.0-kafka-3.9.0 --env BOOTSTRAP_SERVERS="$BOOTSTRAP_SERVERS" --env KAFKA_USER="$KAFKA_USER" --env KAFKA_PW="$KAFKA_PW" -- bash
+
+# setup the config file with credentials information
+cat <<EOF > /tmp/config.props
+sasl.mechanism=SCRAM-SHA-512
+security.protocol=SASL_SSL
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="$KAFKA_USER" password="$KAFKA_PW";
+EOF
+
+# confirm current offset and lag
+./bin/kafka-consumer-groups.sh --bootstrap-server $BOOTSTRAP_SERVERS --command-config /tmp/config.props --group inventory-consumer --describe
+
+# print all processed messages
+./bin/kafka-console-consumer.sh --topic outbox.event.kessel.tuples --from-beginning  --consumer.config /tmp/config.props --bootstrap-server $BOOTSTRAP_SERVERS --property print.offset=true --property print.key=true --property print.headers=true
+```
+
+Save these messages to some file like `kafkadump.txt`.
+
+With our zed context and gabi config setup to stage and port-forwarding into the SpiceDB service, we can execute our [migration script](/docs/manual_migration_to_spicedb.py). Move the migration script to the same level as your `kafkadump.txt` file.
 
 Run 
 ```shell
 python3 manual_migration_to_spicedb.py kafkadump.txt
 ```
+
+Voila! Your inventory DB data should now be consistent with SpiceDB after reprocessing the failing messages!

--- a/docs/runbooks/stage/replicate-inventory-messages-spicedb.md
+++ b/docs/runbooks/stage/replicate-inventory-messages-spicedb.md
@@ -112,7 +112,7 @@ EOF
 
 Save these messages to some file like `kafkadump.txt`.
 
-With our zed context and gabi config setup to stage and port-forwarding into the SpiceDB service, we can execute our [migration script](/docs/manual_migration_to_spicedb.py). Move the migration script to the same level as your `kafkadump.txt` file.
+With our zed context and gabi config set up to stage and port-forwarding into the SpiceDB service, we can execute our [migration script](/docs/manual_migration_to_spicedb.py). Move the migration script to the same level as your `kafkadump.txt` file.
 
 Run 
 ```shell

--- a/scripts/manual_migration_to_spicedb.py
+++ b/scripts/manual_migration_to_spicedb.py
@@ -116,6 +116,9 @@ def build_updated_command(inventory_id, payload):
     if len(res.stdout) != 0:
         print(f"Resource exists in SpiceDB: {res.stdout}")
         sections = res.stdout.split()
+        if len(sections) < 3:
+            print(f"Unexpected output format from zed relationship read: {res.stdout}")
+            return None
         current_res_id = sections[0].split(":")[1]
         current_sub_id = sections[2].split(":")[1]
         if current_res_id == inv_res_id and current_sub_id == inv_sub_id:
@@ -168,7 +171,7 @@ def fetch_inventory_resource_info(inventory_id):
     parse_reporter = json.loads(parsed_data[0]["reporter"])
     inv_reporter_reporter_type = parse_reporter["reporter_type"].lower()
 
-    inv_reporter_type = inv_reporter_type if inv_reporter_type else inv_reporter_reporter_type
+    inv_reporter_type = inv_reporter_type or inv_reporter_reporter_type
 
     print(f"Inventory_resource_id: {inv_resource_id}")
     print(f"Inventory_subject_id: {inv_subject_id}")

--- a/scripts/manual_migration_to_spicedb.py
+++ b/scripts/manual_migration_to_spicedb.py
@@ -49,7 +49,7 @@ def build_deleted_command(inventory_id, payload):
 
     # Call gabi to fetch current info on resource.
     inv_res_id, inv_sub_id, inv_res_type, inv_report_id = fetch_inventory_resource_info(inventory_id)
-    if inv_res_id or inv_sub_id:
+    if not all([inv_res_id, inv_sub_id, inv_res_type, inv_report_id]):
         return None # Dont delete, as it still exists in inventory DB.
 
     # zed relationship read fully consistent (drift check)
@@ -77,7 +77,7 @@ def build_created_command(inventory_id, payload):
 
     # Call gabi to fetch current info on resource.
     inv_res_id, inv_sub_id, inv_res_type, inv_report_id = fetch_inventory_resource_info(inventory_id)
-    if not inv_res_id or not inv_sub_id:
+    if not all([inv_res_id, inv_sub_id, inv_res_type, inv_report_id]):
         return None # No resource in inventory DB.
 
     # zed relationship read fully consistent (drift check)
@@ -105,7 +105,7 @@ def build_updated_command(inventory_id, payload):
 
     # Call gabi to fetch current info on resource.
     inv_res_id, inv_sub_id, inv_res_type, inv_report_id = fetch_inventory_resource_info(inventory_id)
-    if not inv_res_id or not inv_sub_id:
+    if not all([inv_res_id, inv_sub_id, inv_res_type, inv_report_id]):
         return None # No resource in inventory DB.
 
     # zed relationship read fully consistent (drift check)


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Adds a script to be used to replicate missing data from inventory DB to SpiceDB 
- Runbook for replicating inventory db data to spicedb, with setup instructions with usage with zed and gabi

## Ticket reference (if applicable)
Fixes # https://issues.redhat.com/browse/RHCLOUD-39796

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Add a script and runbook for manually replicating inventory database messages to SpiceDB

New Features:
- Created a Python script to migrate inventory database messages to SpiceDB
- Added a runbook with detailed instructions for manual migration process

Documentation:
- Documented step-by-step process for configuring Zed CLI
- Provided instructions for running the migration script

Chores:
- Created documentation for manual data replication workflow

## Summary by Sourcery

Add a script and runbook for manually replicating inventory database messages to SpiceDB, providing a tool to reconcile data discrepancies between the inventory database and SpiceDB

New Features:
- Created a Python script to migrate inventory database messages to SpiceDB
- Developed a comprehensive migration process for replicating missing or inconsistent data

Documentation:
- Added detailed runbook with step-by-step instructions for configuring Zed and Gabi CLIs
- Provided comprehensive guide for manual data replication workflow

Chores:
- Created documentation for manual data synchronization process
- Implemented error handling and logging for migration script