### PR TITLE
RHCLOUD-39799: Derive namespace from resource/request for outbox event tuples

### DIFF
--- a/internal/biz/model/outboxevents.go
+++ b/internal/biz/model/outboxevents.go
@@ -189,14 +189,11 @@ func convertResourceToResourceEvent(resource Resource, operationType EventOperat
 func convertResourceToSetTupleEvent(resource Resource, namespace string) (JsonObject, error) {
 	payload := JsonObject{}
 
+	// Derive namespace from the resource when possible
 	if resource.ReporterType != "" {
-		// v1beta2 compatibility for namespace override, see common/DefaultSetWorkspace for parity
 		namespace = strings.ToLower(resource.ReporterType)
-	}
-
-	// This is a temporary workaround for check/lookup
-	if namespace == "authz" {
-		namespace = "notifications"
+	} else if resource.Reporter.ReporterType != "" { //nolint:staticcheck
+		namespace = strings.ToLower(resource.Reporter.ReporterType)
 	}
 
 	relationship := &kessel.Relationship{
@@ -234,14 +231,11 @@ func convertResourceToSetTupleEvent(resource Resource, namespace string) (JsonOb
 func convertResourceToUnsetTupleEvent(resource Resource, namespace string) (JsonObject, error) {
 	payload := JsonObject{}
 
+	// Derive namespace from the resource when possible
 	if resource.ReporterType != "" {
-		// v1beta2 compatibility for namespace override, see common/DefaultSetWorkspace for parity
 		namespace = strings.ToLower(resource.ReporterType)
-	}
-
-	// This is a temporary workaround for check/lookup
-	if namespace == "authz" {
-		namespace = "notifications"
+	} else if resource.Reporter.ReporterType != "" { //nolint:staticcheck
+		namespace = strings.ToLower(resource.Reporter.ReporterType)
 	}
 
 	tuple := &kessel.RelationTupleFilter{

--- a/internal/biz/model/outboxevents_test.go
+++ b/internal/biz/model/outboxevents_test.go
@@ -78,7 +78,7 @@ func TestNewOutboxEventsFromResourceCreated(t *testing.T) {
 	assert.NotNil(t, resourceEvent)
 	assert.NotNil(t, tupleEvent)
 	assertResourceEvent(t, OperationTypeCreated, resource, resourceEvent)
-	assertSetTupleEvent(t, resource, tupleEvent, namespace)
+	assertSetTupleEvent(t, resource, tupleEvent, resource.Reporter.ReporterType)
 }
 
 func TestNewOutboxEventsFromResourceUpdated(t *testing.T) {
@@ -89,7 +89,7 @@ func TestNewOutboxEventsFromResourceUpdated(t *testing.T) {
 	assert.NotNil(t, resourceEvent)
 	assert.NotNil(t, tupleEvent)
 	assertResourceEvent(t, OperationTypeUpdated, resource, resourceEvent)
-	assertSetTupleEvent(t, resource, tupleEvent, namespace)
+	assertSetTupleEvent(t, resource, tupleEvent, resource.Reporter.ReporterType)
 }
 
 func TestNewOutboxEventsFromResourceDeleted(t *testing.T) {
@@ -100,7 +100,7 @@ func TestNewOutboxEventsFromResourceDeleted(t *testing.T) {
 	assert.NotNil(t, resourceEvent)
 	assert.NotNil(t, tupleEvent)
 	assertResourceEvent(t, OperationTypeDeleted, resource, resourceEvent)
-	assertUnsetTupleEvent(t, resource, tupleEvent, namespace)
+	assertUnsetTupleEvent(t, resource, tupleEvent, resource.Reporter.ReporterType)
 }
 
 func TestNewOutboxEventsFromResourceCreated_v1beta2(t *testing.T) {


### PR DESCRIPTION
- Support deriving tuple namespace from resources rather than request handlers when possible
- Will still fallback to the handler namespace if the resource does not contain complete data

## Summary by Sourcery

Improve namespace derivation for outbox events by prioritizing resource-level namespace information

Bug Fixes:
- Remove hardcoded namespace workaround for 'authz' to 'notifications' mapping

Enhancements:
- Modify namespace derivation logic to first check resource-level reporter type before falling back to handler namespace

Tests:
- Update test cases to use resource reporter type for namespace validation