### PR TITLE
RHCLOUD-39780: add new metrics

### DIFF
--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -225,17 +225,17 @@ func (i *InventoryConsumer) Consume() error {
 						continue
 					}
 				}
+				Incr(i.MetricsCollector.msgProcessed, operation, nil)
 				i.Logger.Infof("consumed event from topic %s, partition %d at offset %s",
 					*e.TopicPartition.Topic, e.TopicPartition.Partition, e.TopicPartition.Offset)
 				i.Logger.Debugf("consumed event data: key = %-10s value = %s", string(e.Key), string(e.Value))
 
 			case kafka.Error:
+				IncrKafkaError(i.MetricsCollector.kafkaErrors, &e)
 				if e.IsFatal() {
-					IncrKafkaError(i.MetricsCollector.kafkaErrors, &e)
 					run = false
 					i.Errors <- e
 				} else {
-					IncrKafkaError(i.MetricsCollector.kafkaErrors, &e)
 					i.Logger.Errorf("recoverable consumer error: %v: %v -- will retry", e.Code(), e)
 					continue
 				}

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/project-kessel/inventory-api/internal/pubsub"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/go-kratos/kratos/v2/log"
@@ -231,7 +232,9 @@ func (i *InventoryConsumer) Consume() error {
 				i.Logger.Debugf("consumed event data: key = %-10s value = %s", string(e.Key), string(e.Value))
 
 			case kafka.Error:
-				IncrKafkaError(i.MetricsCollector.kafkaErrorEvents, &e)
+				Incr(i.MetricsCollector.kafkaErrorEvents, "kafka", nil,
+					attribute.String("code", e.Code().String()),
+					attribute.String("error", e.Error()))
 				if e.IsFatal() {
 					run = false
 					i.Errors <- e

--- a/internal/consumer/metrics.go
+++ b/internal/consumer/metrics.go
@@ -30,7 +30,7 @@ func (s *StatsData) LabelSet(key string) metric.MeasurementOption {
 	return m
 }
 
-// StatsData defines the key metrics to be monitored provided by a kafka.Stats message. It contains top-level metrics and objets within the message.
+// StatsData defines the key metrics to be monitored provided by a kafka.Stats message. It contains top-level metrics and objects within the message.
 type StatsData struct {
 	Name     string               `json:"name"`
 	ClientID string               `json:"client_id"`
@@ -90,13 +90,13 @@ type MetricsCollector struct {
 	assignmentSize metric.Int64Gauge
 
 	// App Specific Metrics
-	msgProcessed      metric.Int64Counter
-	msgProcessFailure metric.Int64Counter
-	consumerErrors    metric.Int64Counter
-	kafkaErrors       metric.Int64Counter
+	msgsProcessed      metric.Int64Counter
+	msgProcessFailures metric.Int64Counter
+	consumerErrors     metric.Int64Counter
+	kafkaErrorEvents   metric.Int64Counter
 }
 
-// New instsantiates a new MetricsCollector
+// New instantiates a new MetricsCollector
 func (m *MetricsCollector) New(meter metric.Meter) error {
 	var err error
 
@@ -149,16 +149,16 @@ func (m *MetricsCollector) New(meter metric.Meter) error {
 	}
 
 	// create app metrics
-	if m.msgProcessed, err = meter.Int64Counter(prefix + "msgs_processed"); err != nil {
+	if m.msgsProcessed, err = meter.Int64Counter(prefix + "msgs_processed"); err != nil {
 		return err
 	}
-	if m.msgProcessFailure, err = meter.Int64Counter(prefix + "msg_process_failures"); err != nil {
+	if m.msgProcessFailures, err = meter.Int64Counter(prefix + "msg_process_failures"); err != nil {
 		return err
 	}
 	if m.consumerErrors, err = meter.Int64Counter(prefix + "consumer_errors"); err != nil {
 		return err
 	}
-	if m.kafkaErrors, err = meter.Int64Counter(prefix + "kafka_error_events"); err != nil {
+	if m.kafkaErrorEvents, err = meter.Int64Counter(prefix + "kafka_error_events"); err != nil {
 		return err
 	}
 	return nil
@@ -226,7 +226,7 @@ func Incr(counter metric.Int64Counter, operation string, errReason error) {
 
 // IncrKafkaError increments the kakfaError counter when kafka.Error messages are received by the poll loop
 func IncrKafkaError(counter metric.Int64Counter, kerror *kafka.Error) {
-	ctx := context.TODO()
+	ctx := context.Background()
 	counter.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("code", kerror.Code().String()),
 		attribute.String("error", kerror.Error())))


### PR DESCRIPTION
### PR Template:

## Describe your changes

* defines 4 new custom metrics for the inventory consumer
  * `msgsProcessed`: counter to capture processed messages (consumer + processed and stored for commit)
  * `msgProcessFailures`: counter to capure when processing fails unrelated to kafka consumer
  * `consumerErrors`: counter to capture consumer errors related to kafka or replication operations
  * `kafkaErrorEvents`: counter to capture kafka.Error messages received
* adds `Incr` function to increment new counters as they happen outside of stats message processing call (`Collect()`)
* adds calls to increment counters during consume loop where applicable
* updates metrics.go to add comments to all objects for documentation purposes
* removes some of the non-helpful stats metrics as we wont use them

## Ticket reference (if applicable)
For RHCLOUD-39780

## Summary by Sourcery

Add new custom metrics to improve monitoring and error tracking for the inventory consumer

New Features:
- Introduced 4 new custom metrics for tracking message processing and errors

Enhancements:
- Added utility functions to increment custom metrics
- Improved error logging and metrics collection

Chores:
- Removed unused metrics to clean up the metrics collection