### PR TITLE
 RHCLOUD-39780: adds another docker compose option with monitoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,10 @@ inventory-up:
 inventory-up-relations-ready:
 	./scripts/start-inventory.sh full-setup-relations-ready 8081 9081
 
+.PHONY: inventory-up-w-monitoring
+inventory-up-w-monitoring:
+	./scripts/start-inventory.sh full-kessel-w-monitoring 8081 9081
+
 .PHONY: inventory-up-split
 inventory-up-split:
 	./scripts/start-inventory.sh split-setup 8000 9000

--- a/README.md
+++ b/README.md
@@ -160,6 +160,37 @@ To stop Inventory:
 ```shell
 make inventory-down
 ```
+
+#### Kessel Inventory + Kessel Relations w Monitoring Stack using Docker Compose
+
+Useful for testing metrics, alerts, and dashboards locally where you can generate enough data and see it reflected in our Monitoring stack outside of Stage
+
+This setup uses the same setup as the previous one but includes Prometheus, Grafana, and Alertmanager. It will require Relations API to be running to ensure consumer metrics are captured.
+
+To start Inventory and the monitoring stack:
+```shell
+make inventory-up-w-monitoring
+```
+
+To deploy Relations API, it's recommended to clone the Relations API repo locally and leverage their existing [Docker Compose process](https://github.com/project-kessel/relations-api/tree/main?tab=readme-ov-file#spicedb-using-dockerpodman) to spin up the Relations API.
+
+Both Inventory and Relations compose files are configured to use the same docker network (`kessel`) to ensure network connectivity between all containers.
+
+To stop Inventory:
+```shell
+make inventory-down
+```
+
+> Note: If its your first time spinning up Grafana, there is an initial login configured that you'll need to reset.
+> username: `admin`
+> password: `admin`.
+> You will be prompted to reset it afterwards.
+> The local running prometheus is configured by default as a datasource so no other work is needed other than adding your own dashboards
+
+Grafana URL: http://localhost:3000
+Prometheus URL: http://localhost:9050
+Alertmanager URL: http://localhost:9093
+
 #### Local Kessel Inventory + Docker Compose Infra (Split Setup)
 
 The Split Setup involves using a locally running Inventory API, but all other infra (Postgres, Kafka, etc) are deployed via Docker. This setup is great for debugging the local running binary but still have all the dependent services to test the full application.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ export DOCKER=docker
 make api
 ```
 
-> Note: The `podman-compose` provider struggles with compose files that leverage `depends_on` as it can't properly handle the dependency graphs. You can fix this issue on Linux by installing the `docker-compose-plugin` or also having `docker-compose` installed. When installed, podman uses the `docker-compose` provider by default instead. The benefit of the `docker-compose-plugin` is that it doesn't require the full Docker setup or docker daemon!
+> Note: The `podman-compose` provider struggles with compose files that leverage `depends_on` as it can't properly handle the dependency graphs. You can fix this issue on Linux by installing the `docker-compose-plugin` or also having `docker-compose` installed. When installed, podman uses the `docker-compose` provider by default instead. The benefit of the `docker-compose-plugin` is that it doesn't require the full Docker setup or Docker daemon!
 
 ### Debugging
 
@@ -154,7 +154,7 @@ make inventory-up-relations-ready
 
 To deploy Relations API, it's recommended to clone the Relations API repo locally and leverage their existing [Docker Compose process](https://github.com/project-kessel/relations-api/tree/main?tab=readme-ov-file#spicedb-using-dockerpodman) to spin up the Relations API.
 
-Both Inventory and Relations compose files are configured to use the same docker network (`kessel`) to ensure network connectivity between all containers.
+Both Inventory and Relations compose files are configured to use the same Docker network (`kessel`) to ensure network connectivity between all containers.
 
 To stop Inventory:
 ```shell
@@ -174,22 +174,25 @@ make inventory-up-w-monitoring
 
 To deploy Relations API, it's recommended to clone the Relations API repo locally and leverage their existing [Docker Compose process](https://github.com/project-kessel/relations-api/tree/main?tab=readme-ov-file#spicedb-using-dockerpodman) to spin up the Relations API.
 
-Both Inventory and Relations compose files are configured to use the same docker network (`kessel`) to ensure network connectivity between all containers.
+Both Inventory and Relations compose files are configured to use the same Docker network (`kessel`) to ensure network connectivity between all containers.
 
-To stop Inventory:
+To stop Inventory and the monitoring stack:
 ```shell
 make inventory-down
 ```
 
-> Note: If its your first time spinning up Grafana, there is an initial login configured that you'll need to reset.
+> Note: If it's your first time spinning up Grafana, there is an initial login configured that you'll need to reset.
 > username: `admin`
 > password: `admin`.
 > You will be prompted to reset it afterwards.
-> The local running prometheus is configured by default as a datasource so no other work is needed other than adding your own dashboards
+> The local running Prometheus is configured by default as a datasource so no other work is needed other than adding your own dashboards
 
 Grafana URL: http://localhost:3000
+
 Prometheus URL: http://localhost:9050
+
 Alertmanager URL: http://localhost:9093
+
 
 #### Local Kessel Inventory + Docker Compose Infra (Split Setup)
 

--- a/development/configs/full-kessel-w-monitoring.yaml
+++ b/development/configs/full-kessel-w-monitoring.yaml
@@ -1,0 +1,43 @@
+server:
+  http:
+    address: 0.0.0.0:8081
+  grpc:
+    address: 0.0.0.0:9081
+authn:
+  allow-unauthenticated: true
+authz:
+  impl: kessel
+  kessel:
+    insecure-client: true
+    url: relations-api:9000
+    enable-oidc-auth: false
+    principal-user-domain: 0.0.0.0:8084
+eventing:
+  eventer: stdout
+  kafka:
+storage:
+  disable-persistence: false
+  database: postgres
+  postgres:
+    host: "invdatabase"
+    port: "5433"
+    user: "postgres"
+    password: "yPsw5e6ab4bvAGe5H"
+    dbname: "spicedb"
+resources:
+  schemaPath: "data/schema/resources"
+  use_cache: true
+consumer:
+  enabled: true
+  bootstrap-servers: kafka:9093
+  retry-options:
+    consumer-max-retries: 3
+    operation-max-retries: 4
+    backoff-factor: 5
+  auth:
+    enabled: false
+log:
+  level: "info"
+  livez: true
+  readyz: true
+

--- a/development/configs/monitoring/grafana-datasource.yml
+++ b/development/configs/monitoring/grafana-datasource.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: prometheus
+    type: prometheus
+    orgId: 1
+    url: http://development-prometheus-1:9090
+    isDefault: true

--- a/development/configs/monitoring/prometheus.yml
+++ b/development/configs/monitoring/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 10s
+scrape_configs:
+ - job_name: inventory-api
+   static_configs:
+    - targets:
+       - development-inventory-api-1:8081

--- a/development/docker-compose.yaml
+++ b/development/docker-compose.yaml
@@ -23,6 +23,20 @@ services:
       - kessel
     restart: on-failure
 
+  full-kessel-w-monitoring:
+    image: bash:3.1-alpine3.21
+    command: ["echo", "starting full-kessel-w-monitoring"]
+    depends_on:
+    - inventory-api
+    - kafka-setup
+    - connect-setup
+    - prometheus
+    - grafana
+    - alertmanager
+    networks:
+      - kessel
+    restart: on-failure
+
   full-setup-w-sso:
     image: bash:3.1-alpine3.21
     command: ["echo", "starting full-setup-w-sso"]
@@ -216,6 +230,37 @@ services:
       - 8084:8084
     networks:
       - kessel
+
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - "./configs/monitoring/prometheus.yml:/etc/prometheus/prometheus.yml"
+    # - "./configs/monitoring/rules.yml:/etc/prometheus/rules.yml"
+    networks:
+      - kessel
+    ports:
+      - 9050:9090
+  alertmanager:
+    image: prom/alertmanager
+    # volumes:
+    #   - "./configs/monitoring/alertmanager.yml:/alertmanager/alertmanager.yml"
+    networks:
+      - kessel
+    ports:
+      - 9093:9093
+  grafana:
+    image: grafana/grafana-enterprise
+    container_name: grafana
+    restart: unless-stopped
+    ports:
+      - '3000:3000'
+    volumes:
+      - grafana-storage:/var/lib/grafana
+      - ./configs/monitoring/grafana-datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
+    networks:
+      - kessel
+volumes:
+  grafana-storage: {}
 
 networks:
   kessel:


### PR DESCRIPTION
### PR Template:

## Describe your changes

* adds another docker compose option to spin up monitoring for local testing of alerts and metrics generation
  * updates README with details
  * updates Makefile to add new target
  * updates compose file to add new services and shortcut target
  * adds new configs for monitoring stack

## Ticket reference (if applicable)
For  RHCLOUD-39780

## Summary by Sourcery

Add a new Docker Compose configuration with monitoring stack for local testing of metrics, alerts, and dashboards

New Features:
- Introduce a new Docker Compose setup with Prometheus, Grafana, and Alertmanager for local monitoring

Enhancements:
- Add configuration files for Prometheus, Grafana, and Alertmanager
- Create a new Makefile target for spinning up the monitoring stack

Documentation:
- Update README with instructions for using the new monitoring-enabled Docker Compose setup

Chores:
- Configure monitoring services to work with the existing Kessel infrastructure