### PR TITLE
updates timeseries queries to add default value setting

### DIFF
--- a/dashboards/grafana-dashboard-kessel-inventory-api.configmap.yaml
+++ b/dashboards/grafana-dashboard-kessel-inventory-api.configmap.yaml
@@ -1329,7 +1329,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(inventory_consumer_msgs_processed_total[$__interval]))",
+              "expr": "sum(rate(inventory_consumer_msgs_processed_total[$__interval])) or up{job=\"kessel-inventory-api\"} * 0",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -1420,7 +1420,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(inventory_consumer_msg_process_failures_total[$__interval])) / sum(rate(inventory_consumer_msgs_processed_total[$__interval]))",
+              "expr": "sum(rate(inventory_consumer_msg_process_failures_total[$__interval])) / sum(rate(inventory_consumer_msgs_processed_total[$__interval])) or up{job=\"kessel-inventory-api\"} * 0",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -1513,7 +1513,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(inventory_consumer_consumer_errors_total[$__interval])) / sum(rate(inventory_consumer_msgs_processed_total[$__interval]))",
+              "expr": "sum(rate(inventory_consumer_consumer_errors_total[$__interval])) / sum(rate(inventory_consumer_msgs_processed_total[$__interval])) or up{job=\"kessel-inventory-api\"} * 0",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -1542,7 +1542,7 @@ data:
                 "inspect": false
               },
               "mappings": [],
-              "noValue": "No Recent Events",
+              "noValue": "No Recent Kafka Error Events",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -1691,7 +1691,7 @@ data:
       "timezone": "browser",
       "title": "Kessel - Inventory API",
       "uid": "ddxs3i6o0xpmof",
-      "version": 5,
+      "version": 6,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
### PR Template:

## Describe your changes

* updates time series queries to include a secondary query for when there is no data. By leveraging the jobs `up` metric, we can ensure a '0' is plotted when there is no metric value set this way we can properly alert on changes in rate. If the up metric query fails this will also help us differentiate when there is no data due to a scraping problem or just no metric data.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

