### PR TITLE
RHCLOUD-39804 - Add an indefinite retry mechanism to the consumer

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -288,7 +288,6 @@ func NewCommand(
 			shutdown := shutdown(db, server, eventingManager, &inventoryConsumer, log.NewHelper(logger))
 
 			if !storageOptions.DisablePersistence && consumerOptions.Enabled {
-				const maxBackoff = 30 * time.Second
 				go func() {
 					retries := 0
 					for consumerOptions.RetryOptions.ConsumerMaxRetries == -1 || retries < consumerOptions.RetryOptions.ConsumerMaxRetries {
@@ -304,7 +303,7 @@ func NewCommand(
 							inventoryConsumer.Logger.Errorf("consumer unable to process current message -- restarting consumer")
 							retries++
 							if consumerOptions.RetryOptions.ConsumerMaxRetries == -1 || retries < consumerOptions.RetryOptions.ConsumerMaxRetries {
-								backoff := min(time.Duration(inventoryConsumer.RetryOptions.BackoffFactor*retries*300)*time.Millisecond, maxBackoff)
+								backoff := min(time.Duration(inventoryConsumer.RetryOptions.BackoffFactor*retries*300)*time.Millisecond, time.Duration(consumerOptions.RetryOptions.MaxBackoffSeconds)*time.Second)
 								inventoryConsumer.Logger.Errorf("retrying in %v", backoff)
 								time.Sleep(backoff)
 							}

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -290,7 +290,7 @@ func NewCommand(
 			if !storageOptions.DisablePersistence && consumerOptions.Enabled {
 				go func() {
 					retries := 0
-					for retries < consumerOptions.RetryOptions.ConsumerMaxRetries {
+					for consumerOptions.RetryOptions.ConsumerMaxRetries == -1 || retries < consumerOptions.RetryOptions.ConsumerMaxRetries {
 						// If the consumer cannot process a message, the consumer loop is restarted
 						// This is to ensure we re-read the message and prevent it being dropped and moving to next message.
 						// To re-read the current message, we have to recreate the consumer connection so that the earliest offset is used
@@ -302,7 +302,7 @@ func NewCommand(
 						if e.Is(err, consumer.ErrClosed) {
 							inventoryConsumer.Logger.Errorf("consumer unable to process current message -- restarting consumer")
 							retries++
-							if retries < consumerOptions.RetryOptions.ConsumerMaxRetries {
+							if consumerOptions.RetryOptions.ConsumerMaxRetries == -1 || retries < consumerOptions.RetryOptions.ConsumerMaxRetries {
 								backoff := time.Duration(inventoryConsumer.RetryOptions.BackoffFactor*retries*300) * time.Millisecond
 								inventoryConsumer.Logger.Errorf("retrying in %v", backoff)
 								time.Sleep(backoff)

--- a/deploy/kessel-inventory-ephem.yaml
+++ b/deploy/kessel-inventory-ephem.yaml
@@ -25,6 +25,7 @@ objects:
             consumer-max-retries: -1
             operation-max-retries: -1
             backoff-factor: 5
+            max-backoff-seconds: 30
           auth:
             enabled: false
             security-protocol: sasl_plaintext

--- a/deploy/kessel-inventory-ephem.yaml
+++ b/deploy/kessel-inventory-ephem.yaml
@@ -21,6 +21,10 @@ objects:
           enabled: true
           bootstrap-servers: inventory-kafka-kafka-bootstrap:9092
           topic: outbox.event.kessel.tuples
+          retry-options:
+            consumer-max-retries: -1
+            operation-max-retries: -1
+            backoff-factor: 5
           auth:
             enabled: false
             security-protocol: sasl_plaintext

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,12 +72,13 @@ func LogConfigurationInfo(options *OptionsConfig) {
 		)
 	}
 
-	log.Debugf("Consumer Configuration: Bootstrap Server: %s, Topic: %s, Consumer Max Retries: %d, Operation Max Retries: %d, Backoff Factor: %d",
+	log.Debugf("Consumer Configuration: Bootstrap Server: %s, Topic: %s, Consumer Max Retries: %d, Operation Max Retries: %d, Backoff Factor: %d, Max Backoff Seconds: %d",
 		options.Consumer.BootstrapServers,
 		options.Consumer.Topic,
 		options.Consumer.RetryOptions.ConsumerMaxRetries,
 		options.Consumer.RetryOptions.OperationMaxRetries,
 		options.Consumer.RetryOptions.BackoffFactor,
+		options.Consumer.RetryOptions.MaxBackoffSeconds,
 	)
 
 	log.Debugf("Consumer Auth Settings: Enabled: %v, Security Protocol: %s, Mechanism: %s, Username: %s",

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -183,6 +183,7 @@ func (i *InventoryConsumer) Consume() error {
 
 				resp, err = i.ProcessMessage(headers, relationsEnabled, e)
 				if err != nil {
+					Incr(i.MetricsCollector.msgProcessFailures, "ProcessMessage", err)
 					i.Logger.Errorf(
 						"error processing message: topic=%s partition=%d offset=%s",
 						*e.TopicPartition.Topic, e.TopicPartition.Partition, e.TopicPartition.Offset)
@@ -528,16 +529,18 @@ func (i *InventoryConsumer) Shutdown() error {
 // Retry executes the given function and will retry on failure with backoff until max retries is reached
 func (i *InventoryConsumer) Retry(operation func() (string, error)) (string, error) {
 	attempts := 0
+	const maxBackoff = 30 * time.Second
 	var resp interface{}
 	var err error
 
-	for attempts < i.RetryOptions.OperationMaxRetries {
+	for i.RetryOptions.OperationMaxRetries == -1 || attempts < i.RetryOptions.OperationMaxRetries {
 		resp, err = operation()
 		if err != nil {
+			Incr(i.MetricsCollector.msgProcessFailures, "Retry", err)
 			i.Logger.Errorf("request failed: %v", err)
 			attempts++
-			if attempts < i.RetryOptions.OperationMaxRetries {
-				backoff := time.Duration(i.RetryOptions.BackoffFactor*attempts*300) * time.Millisecond
+			if i.RetryOptions.OperationMaxRetries == -1 || attempts < i.RetryOptions.OperationMaxRetries {
+				backoff := min(time.Duration(i.RetryOptions.BackoffFactor*attempts*300)*time.Millisecond, maxBackoff)
 				i.Logger.Errorf("retrying in %v", backoff)
 				time.Sleep(backoff)
 			}

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -100,6 +100,7 @@ func New(config CompletedConfig, db *gorm.DB, authz authz.CompletedConfig, autho
 		ConsumerMaxRetries:  config.RetryConfig.ConsumerMaxRetries,
 		OperationMaxRetries: config.RetryConfig.OperationMaxRetries,
 		BackoffFactor:       config.RetryConfig.BackoffFactor,
+		MaxBackoffSeconds:   config.RetryConfig.MaxBackoffSeconds,
 	}
 
 	var errChan chan error

--- a/internal/consumer/retry/options.go
+++ b/internal/consumer/retry/options.go
@@ -1,11 +1,14 @@
 package retry
 
-import "github.com/spf13/pflag"
+import (
+	"github.com/spf13/pflag"
+)
 
 type Options struct {
 	ConsumerMaxRetries  int `mapstructure:"consumer-max-retries"`
 	OperationMaxRetries int `mapstructure:"operation-max-retries"`
 	BackoffFactor       int `mapstructure:"backoff-factor"`
+	MaxBackoffSeconds   int `mapstructure:"max-backoff-seconds"`
 }
 
 func NewOptions() *Options {
@@ -13,6 +16,7 @@ func NewOptions() *Options {
 		ConsumerMaxRetries:  2,
 		OperationMaxRetries: 3,
 		BackoffFactor:       5,
+		MaxBackoffSeconds:   30,
 	}
 }
 
@@ -20,7 +24,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 	if prefix != "" {
 		prefix = prefix + "."
 	}
-	fs.IntVar(&o.ConsumerMaxRetries, prefix+"consumer-max-retries", o.ConsumerMaxRetries, "sets the max number of retries to process a message before killing consumer (default: 3)")
-	fs.IntVar(&o.OperationMaxRetries, prefix+"operation-max-retries", o.OperationMaxRetries, "sets the max number of retries to execute a request before failing out (default: 4)")
-	fs.IntVar(&o.BackoffFactor, prefix+"backoff-factor", o.BackoffFactor, "value used to calculate backoff between requests/restarts (default: 4)")
+	fs.IntVar(&o.ConsumerMaxRetries, prefix+"consumer-max-retries", o.ConsumerMaxRetries, "sets the max number of retries to process a message before killing consumer (default: 2)")
+	fs.IntVar(&o.OperationMaxRetries, prefix+"operation-max-retries", o.OperationMaxRetries, "sets the max number of retries to execute a request before failing out (default: 3)")
+	fs.IntVar(&o.BackoffFactor, prefix+"backoff-factor", o.BackoffFactor, "value used to calculate backoff between requests/restarts (default: 5)")
+	fs.IntVar(&o.MaxBackoffSeconds, prefix+"max-backoff-seconds", o.MaxBackoffSeconds, "maximum amount of time between retries for the consumer in seconds (default: 30)")
 }


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Add a mechanism to indefinitely retry the consumer itself 
- Add a mechanism to indefinitely retry processing a failing message
- Add a configurable maximum amount of backoff time between retries
```
retry-options:
    consumer-max-retries: -1
    operation-max-retries: -1
    max-backoff-seconds: 30
```
- Updates ephemeral deployment with indefinite retries & backoff setting
- Adds some metrics counters to the Retry().


## Ticket reference (if applicable)
Fixes # https://issues.redhat.com/browse/RHCLOUD-39804

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Implement an indefinite retry mechanism for the Kafka consumer to improve resilience and error handling

New Features:
- Add support for indefinite retries for both consumer and message processing by using -1 as a retry count

Enhancements:
- Implement a maximum backoff time of 30 seconds to prevent excessive wait times
- Add metrics tracking for retry failures

Deployment:
- Update ephemeral deployment configuration to enable indefinite retries

## Summary by Sourcery

Implement an indefinite retry mechanism for the Kafka consumer to improve system resilience and error handling

New Features:
- Add support for indefinite retries for both consumer and message processing by using -1 as a retry count

Bug Fixes:
- Prevent message dropping by restarting consumer on processing failures

Enhancements:
- Implement a maximum backoff time of 30 seconds to prevent excessive wait times
- Add metrics tracking for retry failures

Deployment:
- Update ephemeral deployment configuration to enable indefinite retries