### PR TITLE
RHCLOUD-39866 -- add code-cov reporting

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -34,23 +36,6 @@ jobs:
         with:
           name: code-coverage
           path: coverage.txt
-
-
-  # XXX this will fail if main does not already have a coverage.out report uploaded by the previous job
-  code-coverage:
-    name: Code coverage report
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    steps:
-      - name: Download coverage report
-        uses: actions/download-artifact@v4
-        with:
-          name: code-coverage
-          path: . 
-      - name: verify
-        run: ls -l coverage.txt && cat coverage.txt
-
       - name: code-cov report
         id: code-cov-report
         uses: codecov/codecov-action@v5
@@ -59,3 +44,4 @@ jobs:
           disable_search: true
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage
-          path: coverage.out
+          path: coverage.txt
 
 
   # XXX this will fail if main does not already have a coverage.out report uploaded by the previous job
@@ -43,14 +43,19 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     steps:
-      - name: coverage report
-        id: coverage-report
-        uses: fgrosse/go-coverage-report@v1.2.0
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
         with:
-          coverage-file-name: coverage.out
-          skip-comment: true # requires write permission on pull requests
-          # below options help track coverage across forks
-          trim: github.com/project-kessel/inventory-api
-          root-package: ""
-      - name: coverage summary
-        run: echo "${{ steps.coverage-report.outputs.coverage_report }}" >> "$GITHUB_STEP_SUMMARY"
+          name: code-coverage
+          path: . 
+      - name: verify
+        run: ls -l coverage.txt && cat coverage.txt
+
+      - name: code-cov report
+        id: code-cov-report
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.txt
+          disable_search: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -106,9 +106,9 @@ test:
 	@echo ""
 	@echo "Running tests."
 	# TODO: e2e tests are taking too long to be enabled by default. They need to be sped up.
-	@$(GO) test ./... -count=1 -coverprofile=coverage.out -skip 'TestInventoryAPIGRPC_*|TestInventoryAPIHTTP_*|Test_ACMKafkaConsumer'
+	@$(GO) test ./... -count=1 -race -covermode=atomic -coverprofile=coverage.txt -skip 'TestInventoryAPIGRPC_*|TestInventoryAPIHTTP_*|Test_ACMKafkaConsumer'
 	@echo "Overall test coverage:"
-	@$(GO) tool cover -func=coverage.out | grep total: | awk '{print $$3}'
+	@$(GO) tool cover -func=coverage.txt | grep total: | awk '{print $$3}'
 
 .PHONY: check-e2e-tests
 # check result of kind e2e tests
@@ -116,7 +116,7 @@ check-e2e-tests:
 	./scripts/check-e2e-tests.sh
 
 test-coverage: test
-	@$(GO) tool cover -html=coverage.out -o coverage.html
+	@$(GO) tool cover -html=coverage.txt -o coverage.html
 	@echo "coverage report written to coverage.html"
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Common Inventory 
+# Common Inventory
 
 This repository implements a common inventory system with eventing.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Common Inventory
+# Common Inventory 
 
 This repository implements a common inventory system with eventing.
 


### PR DESCRIPTION
### PR Template:

## Describe your changes
Produce and upload code-coverage reporting to code-cov.
For ex: https://app.codecov.io/github/project-kessel/inventory-api/commit/a9abd5f96f583b2c424534a3ad326896d5f3ef75/tree 
- ...

## [RHCLOUD-39866](https://issues.redhat.com/browse/RHCLOUD-39866) 

## Checklist

* [ X ] Are the agreed upon acceptance criteria fulfilled?
Code-cov results are available here: https://app.codecov.io/github/project-kessel/inventory-api/commit/a9abd5f96f583b2c424534a3ad326896d5f3ef75/tree 

* [X  ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)
Requirements were discusesed in chat.

* [X  ] Do your changes have passing automated tests and sufficient observability?
Yes 
* [X ] Are the work steps you introduced repeatable by others, either through automation or documentation?

* [ X ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ X ] Are the agreed upon coding/architectural practices applied?

* [X ] Are security needs fullfilled? (e.g. no internal URL)

* [ X] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ X] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Add Codecov reporting to the project's CI workflow

CI:
- Updated GitHub Actions workflow to integrate Codecov for code coverage reporting
- Modified test command to generate coverage report with race detection

Chores:
- Updated Makefile to change coverage report file extension and generation parameters