### PR TITLE
RHCLOUD-39803: Skip blocking read after write if the consumer is disabled

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -222,11 +222,18 @@ func NewCommand(
 
 			inventoryresources_repo := inventoryResourcesRepo.New(db)
 
+			usecaseConfig := &resourcesctl.UsecaseConfig{
+				DisablePersistence:      storageConfig.Options.DisablePersistence,
+				ReadAfterWriteEnabled:   consistencyConfig.ReadAfterWriteEnabled,
+				ReadAfterWriteAllowlist: consistencyConfig.ReadAfterWriteAllowlist,
+				ConsumerEnabled:         consumerOptions.Enabled,
+			}
+
 			//v1beta2
 
 			// wire together inventory service handling
 			resource_repo := resourcerepo.New(db)
-			inventory_controller := resourcesctl.New(resource_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), storageConfig.Options.DisablePersistence, listenManager, consistencyConfig.ReadAfterWriteEnabled, consistencyConfig.ReadAfterWriteAllowlist)
+			inventory_controller := resourcesctl.New(resource_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), listenManager, usecaseConfig)
 			inventory_service := resourcesvc.NewKesselInventoryServiceV1beta2(inventory_controller)
 			pbv1beta2.RegisterKesselInventoryServiceServer(server.GrpcServer, inventory_service)
 			pbv1beta2.RegisterKesselInventoryServiceHTTPServer(server.HttpServer, inventory_service)
@@ -234,35 +241,35 @@ func NewCommand(
 			//v1beta1
 			// wire together notificationsintegrations handling
 			notifs_repo := resourcerepo.New(db)
-			notifs_controller := resourcesctl.New(notifs_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), storageConfig.Options.DisablePersistence, listenManager, consistencyConfig.ReadAfterWriteEnabled, consistencyConfig.ReadAfterWriteAllowlist)
+			notifs_controller := resourcesctl.New(notifs_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), listenManager, usecaseConfig)
 			notifs_service := notifssvc.NewKesselNotificationsIntegrationsServiceV1beta1(notifs_controller)
 			pb.RegisterKesselNotificationsIntegrationServiceServer(server.GrpcServer, notifs_service)
 			pb.RegisterKesselNotificationsIntegrationServiceHTTPServer(server.HttpServer, notifs_service)
 
 			// wire together authz handling
 			authz_repo := resourcerepo.New(db)
-			authz_controller := resourcesctl.New(authz_repo, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), storageConfig.Options.DisablePersistence, listenManager, consistencyConfig.ReadAfterWriteEnabled, consistencyConfig.ReadAfterWriteAllowlist)
+			authz_controller := resourcesctl.New(authz_repo, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), listenManager, usecaseConfig)
 			authz_service := resourcesvc.NewKesselCheckServiceV1beta1(authz_controller)
 			authzv1beta1.RegisterKesselCheckServiceServer(server.GrpcServer, authz_service)
 			authzv1beta1.RegisterKesselCheckServiceHTTPServer(server.HttpServer, authz_service)
 
 			// wire together hosts handling
 			hosts_repo := resourcerepo.New(db)
-			hosts_controller := resourcesctl.New(hosts_repo, inventoryresources_repo, authorizer, eventingManager, "hbi", log.With(logger, "subsystem", "hosts_controller"), storageConfig.Options.DisablePersistence, listenManager, consistencyConfig.ReadAfterWriteEnabled, consistencyConfig.ReadAfterWriteAllowlist)
+			hosts_controller := resourcesctl.New(hosts_repo, inventoryresources_repo, authorizer, eventingManager, "hbi", log.With(logger, "subsystem", "hosts_controller"), listenManager, usecaseConfig)
 			hosts_service := hostssvc.NewKesselRhelHostServiceV1beta1(hosts_controller)
 			pb.RegisterKesselRhelHostServiceServer(server.GrpcServer, hosts_service)
 			pb.RegisterKesselRhelHostServiceHTTPServer(server.HttpServer, hosts_service)
 
 			// wire together k8sclusters handling
 			k8sclusters_repo := resourcerepo.New(db)
-			k8sclusters_controller := resourcesctl.New(k8sclusters_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8sclusters_controller"), storageConfig.Options.DisablePersistence, listenManager, consistencyConfig.ReadAfterWriteEnabled, consistencyConfig.ReadAfterWriteAllowlist)
+			k8sclusters_controller := resourcesctl.New(k8sclusters_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8sclusters_controller"), listenManager, usecaseConfig)
 			k8sclusters_service := k8sclusterssvc.NewKesselK8SClusterServiceV1beta1(k8sclusters_controller)
 			pb.RegisterKesselK8SClusterServiceServer(server.GrpcServer, k8sclusters_service)
 			pb.RegisterKesselK8SClusterServiceHTTPServer(server.HttpServer, k8sclusters_service)
 
 			// wire together k8spolicies handling
 			k8spolicies_repo := resourcerepo.New(db)
-			k8spolicies_controller := resourcesctl.New(k8spolicies_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8spolicies_controller"), storageConfig.Options.DisablePersistence, listenManager, consistencyConfig.ReadAfterWriteEnabled, consistencyConfig.ReadAfterWriteAllowlist)
+			k8spolicies_controller := resourcesctl.New(k8spolicies_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8spolicies_controller"), listenManager, usecaseConfig)
 			k8spolicies_service := k8spoliciessvc.NewKesselK8SPolicyServiceV1beta1(k8spolicies_controller)
 			pb.RegisterKesselK8SPolicyServiceServer(server.GrpcServer, k8spolicies_service)
 			pb.RegisterKesselK8SPolicyServiceHTTPServer(server.HttpServer, k8spolicies_service)


### PR DESCRIPTION
- Consolidates usecase configuration to avoid handler params from continuing to grow
- Adds consumer enabled attribute to usecase config to allow read after write blocks to be skipped when disabled
- Adds create/update/upsert tests

## Summary by Sourcery

Consolidate usecase configuration by introducing a UsecaseConfig struct to manage various configuration flags, with a specific focus on adding a consumer enabled attribute to skip read after write blocks when disabled

New Features:
- Added ConsumerEnabled flag to control consumer-related operations

Enhancements:
- Refactored usecase configuration to use a centralized configuration struct
- Simplified parameter management in usecase initialization

Tests:
- Added tests to verify behavior when consumer is disabled
- Added test cases for create, update, and upsert operations with consumer disabled

Chores:
- Updated multiple function signatures to use new UsecaseConfig struct
- Removed redundant individual configuration parameters