### PR TITLE
Docs cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ To stop:
 make inventory-down
 ```
 
-### Alternatives way of running this service
+### Alternative ways of running this service
 
 There are numerous ways to run Inventory API using Docker Compose for various testing and debugging needs. For more options, see our [guide](./docs/dev-guides/docker-compose-options.md)
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ This repository implements a common inventory system with eventing.
 ## Development Setup
 
 ### Prerequisites
-- Go 1.23.1+
+- Go 1.23.6
 - Make
+
+### Debugging
+
+See [DEBUG](./DEBUG.md) for instructions on how to debug
 
 ### Running locally
 
@@ -88,36 +92,13 @@ export DOCKER=docker
 make api
 ```
 
+> [!IMPORTANT]
 > Note: The `podman-compose` provider struggles with compose files that leverage `depends_on` as it can't properly handle the dependency graphs. You can fix this issue on Linux by installing the `docker-compose-plugin` or also having `docker-compose` installed. When installed, podman uses the `docker-compose` provider by default instead. The benefit of the `docker-compose-plugin` is that it doesn't require the full Docker setup or Docker daemon!
 
-### Debugging
 
-See [DEBUG](./DEBUG.md) for instructions on how to debug
+### Running Locally using Docker Compose
 
-## Alternatives way of running this service
-
-### Local Kessel Inventory + Kessel Relations using built binaries
-
-Inventory and Relations can also be run locally using built binaries, but the default config for Inventory will conflict with Relations.
-
-To run Relations locally, see the [Relations README](https://github.com/project-kessel/relations-api?tab=readme-ov-file#prerequisites)
-
-Relations will also require SpiceDB, this can be run using Podman/Docker (See relevant section also in the [Relations README](https://github.com/project-kessel/relations-api?tab=readme-ov-file#spicedb-using-dockerpodman))
-
-For Inventory, an alternate config is available, pre-configured to expect a local running Relations API
-```shell
-# Setup
-make local-build
-make migrate
-
-# run with the relations friendly config file
-./bin/inventory-api serve --config development/configs/local-w-relations.yaml
-```
-> NOTE: The below setups all involve spinning up Kafka infrastrcture with configuration jobs that run after. It can take about to a minute before the full Kafka stack is ready to go.
-
-### Kessel Inventory Full Setup using Docker Compose
-
-Testing locally is fine for simple changes but in order to test the full application, it requires all the dependent baking services.
+Testing locally is fine for simple changes but in order to test the full application, it requires all the dependent backing services.
 
 The Full Setup option for Docker Compose:
 - Exposes the inventory API in `localhost` and using port `8000` for http and port `9000` for grpc.
@@ -139,133 +120,11 @@ To stop:
 make inventory-down
 ```
 
-### Kessel Inventory + Kessel Relations using Docker Compose
+### Alternatives way of running this service
 
-An Relations-ready version of the Full Setup configuration exists that can be easily used with Relations API.
+There are numerous ways to run Inventory API using Docker Compose for various testing and debugging needs. For more options, see our [guide](./docs/dev-guides/docker-compose-options.md)
 
-The only notable differences being:
-- Inventory is configured to use ports `8081`, and `9081` to not conflict with Relations API
-- Configures Inventory API using the [Full-Setup-Relations-Ready](development/configs/full-setup-relations-ready.yaml) config file
-
-To start the Relations-ready version of Inventory:
-```shell
-make inventory-up-relations-ready
-```
-
-To deploy Relations API, it's recommended to clone the Relations API repo locally and leverage their existing [Docker Compose process](https://github.com/project-kessel/relations-api/tree/main?tab=readme-ov-file#spicedb-using-dockerpodman) to spin up the Relations API.
-
-Both Inventory and Relations compose files are configured to use the same Docker network (`kessel`) to ensure network connectivity between all containers.
-
-To stop Inventory:
-```shell
-make inventory-down
-```
-
-### Kessel Inventory + Kessel Relations w Monitoring Stack using Docker Compose
-
-Useful for testing metrics, alerts, and dashboards locally where you can generate enough data and see it reflected in our Monitoring stack outside of Stage
-
-This setup uses the same setup as the previous one but includes Prometheus, Grafana, and Alertmanager. It will require Relations API to be running to ensure consumer metrics are captured.
-
-To start Inventory and the monitoring stack:
-```shell
-make inventory-up-w-monitoring
-```
-
-To deploy Relations API, it's recommended to clone the Relations API repo locally and leverage their existing [Docker Compose process](https://github.com/project-kessel/relations-api/tree/main?tab=readme-ov-file#spicedb-using-dockerpodman) to spin up the Relations API.
-
-Both Inventory and Relations compose files are configured to use the same Docker network (`kessel`) to ensure network connectivity between all containers.
-
-To stop Inventory and the monitoring stack:
-```shell
-make inventory-down
-```
-
-> Note: If it's your first time spinning up Grafana, there is an initial login configured that you'll need to reset.
-> username: `admin`
-> password: `admin`.
-> You will be prompted to reset it afterwards.
-> The local running Prometheus is configured by default as a datasource so no other work is needed other than adding your own dashboards
-
-Grafana URL: http://localhost:3000
-
-Prometheus URL: http://localhost:9050
-
-Alertmanager URL: http://localhost:9093
-
-
-### Local Kessel Inventory + Docker Compose Infra (Split Setup)
-
-The Split Setup involves using a locally running Inventory API, but all other infra (Postgres, Kafka, etc) are deployed via Docker. This setup is great for debugging the local running binary but still have all the dependent services to test the full application.
-
-To start the Split Setup:
-```shell
-make inventory-up-split
-```
-
-Then to run Inventory:
-```shell
-# Setup
-make local-build
-
-# run with the split config file (postgres host flag overwrites config locally which is set for Docker internal address)
-./bin/inventory-api serve --config development/configs/split-setup.yaml --storage.postgres.host localhost
-```
-
-### Split Setup + Kessel Relations
-
-Same as Split Setup which leverages a local Inventory API and Docker for the dependent infra, but updates the Inventory API server ports to not conflict with a running Relations API
-
-To deploy Relations API, it's recommended to clone the Relations API repo locally and leverage their existing [Docker Compose process](https://github.com/project-kessel/relations-api/tree/main?tab=readme-ov-file#spicedb-using-dockerpodman) to spin up the Relations API.
-
-To start the Relations-ready Split Setup:
-```shell
-make inventory-up-split-relations-ready
-```
-
-Then to run Inventory:
-```shell
-# Setup
-make local-build
-
-# run with the split config file (postgres host flag overwrites config locally which is set for Docker internal address)
-./bin/inventory-api serve --config development/configs/split-setup-relations-ready.yaml --storage.postgres.host localhost
-```
-
-### Kessel Inventory + Kessel Relations + SSO (Keycloak) using Docker Compose
-
-This setup expands on the Relations-ready Full Setup by:
-- Setting up a Keycloak instance running at port 8084 with [myrealm](development/configs/myrealm.json) config file.
-- Setting up a default service account with clientId: `test-svc`. Refer to [get-token](scripts/get-token.sh) to learn how to fetch a token.
-- Configures Inventory API using the [Full-Setup-w-SSO](development/configs/full-setup-w-sso.yaml) config file
-
-As before you'll need to run the Relations Compose steps available in the [Relations API repo](https://github.com/project-kessel/relations-api/tree/main?tab=readme-ov-file#spicedb-using-dockerpodman)
-
-To start use:
-```shell
-make inventory-up-sso
-```
-
-Once it has started, you will need to fetch a token and use it when making calls to the service.
-
-To get a token use:
-```shell
-make get-token
-```
-
-You can then export an ENV with that value and use in calls such as:
-
-```shell
-curl -H "Authorization: bearer ${TOKEN}" # ...
-```
-
-To stop use:
-
-```shell
-make inventory-down
-```
-
-## Running in Ephemeral Cluster with Relations API using Bonfire
+### Running in Ephemeral Cluster with Relations API using Bonfire
 
 See [Testing Inventory in Ephemeral](./docs/ephemeral-testing.md) for instructions on how to deploy Kessel Inventory in the ephemeral cluster.
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ make api
 
 See [DEBUG](./DEBUG.md) for instructions on how to debug
 
-### Alternatives way of running this service
+## Alternatives way of running this service
 
-#### Local Kessel Inventory + Kessel Relations using built binaries
+### Local Kessel Inventory + Kessel Relations using built binaries
 
 Inventory and Relations can also be run locally using built binaries, but the default config for Inventory will conflict with Relations.
 
@@ -115,7 +115,7 @@ make migrate
 ```
 > NOTE: The below setups all involve spinning up Kafka infrastrcture with configuration jobs that run after. It can take about to a minute before the full Kafka stack is ready to go.
 
-#### Kessel Inventory Full Setup using Docker Compose
+### Kessel Inventory Full Setup using Docker Compose
 
 Testing locally is fine for simple changes but in order to test the full application, it requires all the dependent baking services.
 
@@ -139,7 +139,7 @@ To stop:
 make inventory-down
 ```
 
-#### Kessel Inventory + Kessel Relations using Docker Compose
+### Kessel Inventory + Kessel Relations using Docker Compose
 
 An Relations-ready version of the Full Setup configuration exists that can be easily used with Relations API.
 
@@ -161,7 +161,7 @@ To stop Inventory:
 make inventory-down
 ```
 
-#### Kessel Inventory + Kessel Relations w Monitoring Stack using Docker Compose
+### Kessel Inventory + Kessel Relations w Monitoring Stack using Docker Compose
 
 Useful for testing metrics, alerts, and dashboards locally where you can generate enough data and see it reflected in our Monitoring stack outside of Stage
 
@@ -194,7 +194,7 @@ Prometheus URL: http://localhost:9050
 Alertmanager URL: http://localhost:9093
 
 
-#### Local Kessel Inventory + Docker Compose Infra (Split Setup)
+### Local Kessel Inventory + Docker Compose Infra (Split Setup)
 
 The Split Setup involves using a locally running Inventory API, but all other infra (Postgres, Kafka, etc) are deployed via Docker. This setup is great for debugging the local running binary but still have all the dependent services to test the full application.
 
@@ -212,7 +212,7 @@ make local-build
 ./bin/inventory-api serve --config development/configs/split-setup.yaml --storage.postgres.host localhost
 ```
 
-#### Split Setup + Kessel Relations
+### Split Setup + Kessel Relations
 
 Same as Split Setup which leverages a local Inventory API and Docker for the dependent infra, but updates the Inventory API server ports to not conflict with a running Relations API
 
@@ -232,7 +232,7 @@ make local-build
 ./bin/inventory-api serve --config development/configs/split-setup-relations-ready.yaml --storage.postgres.host localhost
 ```
 
-#### Kessel Inventory + Kessel Relations + SSO (Keycloak) using Docker Compose
+### Kessel Inventory + Kessel Relations + SSO (Keycloak) using Docker Compose
 
 This setup expands on the Relations-ready Full Setup by:
 - Setting up a Keycloak instance running at port 8084 with [myrealm](development/configs/myrealm.json) config file.
@@ -265,7 +265,7 @@ To stop use:
 make inventory-down
 ```
 
-#### Running in Ephemeral Cluster with Relations API using Bonfire
+## Running in Ephemeral Cluster with Relations API using Bonfire
 
 See [Testing Inventory in Ephemeral](./docs/ephemeral-testing.md) for instructions on how to deploy Kessel Inventory in the ephemeral cluster.
 

--- a/docs/dev-guides/docker-compose-options.md
+++ b/docs/dev-guides/docker-compose-options.md
@@ -1,4 +1,4 @@
-# Alternatives way of running this service
+# Alternative ways of running this service
 
 ## Local Kessel Inventory + Kessel Relations using built binaries
 
@@ -17,11 +17,11 @@ make migrate
 # run with the relations friendly config file
 ./bin/inventory-api serve --config development/configs/local-w-relations.yaml
 ```
-> NOTE: The below setups all involve spinning up Kafka infrastrcture with configuration jobs that run after. It can take about to a minute before the full Kafka stack is ready to go.
+> NOTE: The below setups all involve spinning up Kafka infrastructure with configuration jobs that run after. It can take about to a minute before the full Kafka stack is ready to go.
 
 ## Kessel Inventory + Kessel Relations using Docker Compose
 
-An Relations-ready version of the Full Setup configuration exists that can be easily used with Relations API.
+A Relations-ready version of the Full Setup configuration exists that can be easily used with Relations API.
 
 The only notable differences being:
 - Inventory is configured to use ports `8081`, and `9081` to not conflict with Relations API

--- a/docs/dev-guides/docker-compose-options.md
+++ b/docs/dev-guides/docker-compose-options.md
@@ -1,0 +1,146 @@
+# Alternatives way of running this service
+
+## Local Kessel Inventory + Kessel Relations using built binaries
+
+Inventory and Relations can also be run locally using built binaries, but the default config for Inventory will conflict with Relations.
+
+To run Relations locally, see the [Relations README](https://github.com/project-kessel/relations-api?tab=readme-ov-file#prerequisites)
+
+Relations will also require SpiceDB, this can be run using Podman/Docker (See relevant section also in the [Relations README](https://github.com/project-kessel/relations-api?tab=readme-ov-file#spicedb-using-dockerpodman))
+
+For Inventory, an alternate config is available, pre-configured to expect a local running Relations API
+```shell
+# Setup
+make local-build
+make migrate
+
+# run with the relations friendly config file
+./bin/inventory-api serve --config development/configs/local-w-relations.yaml
+```
+> NOTE: The below setups all involve spinning up Kafka infrastrcture with configuration jobs that run after. It can take about to a minute before the full Kafka stack is ready to go.
+
+## Kessel Inventory + Kessel Relations using Docker Compose
+
+An Relations-ready version of the Full Setup configuration exists that can be easily used with Relations API.
+
+The only notable differences being:
+- Inventory is configured to use ports `8081`, and `9081` to not conflict with Relations API
+- Configures Inventory API using the [Full-Setup-Relations-Ready](development/configs/full-setup-relations-ready.yaml) config file
+
+To start the Relations-ready version of Inventory:
+```shell
+make inventory-up-relations-ready
+```
+
+To deploy Relations API, it's recommended to clone the Relations API repo locally and leverage their existing [Docker Compose process](https://github.com/project-kessel/relations-api/tree/main?tab=readme-ov-file#spicedb-using-dockerpodman) to spin up the Relations API.
+
+Both Inventory and Relations compose files are configured to use the same Docker network (`kessel`) to ensure network connectivity between all containers.
+
+To stop Inventory:
+```shell
+make inventory-down
+```
+
+## Kessel Inventory + Kessel Relations w Monitoring Stack using Docker Compose
+
+Useful for testing metrics, alerts, and dashboards locally where you can generate enough data and see it reflected in our Monitoring stack outside of Stage
+
+This setup uses the same setup as the previous one but includes Prometheus, Grafana, and Alertmanager. It will require Relations API to be running to ensure consumer metrics are captured.
+
+To start Inventory and the monitoring stack:
+```shell
+make inventory-up-w-monitoring
+```
+
+To deploy Relations API, it's recommended to clone the Relations API repo locally and leverage their existing [Docker Compose process](https://github.com/project-kessel/relations-api/tree/main?tab=readme-ov-file#spicedb-using-dockerpodman) to spin up the Relations API.
+
+Both Inventory and Relations compose files are configured to use the same Docker network (`kessel`) to ensure network connectivity between all containers.
+
+To stop Inventory and the monitoring stack:
+```shell
+make inventory-down
+```
+
+> Note: If it's your first time spinning up Grafana, there is an initial login configured that you'll need to reset.
+> username: `admin`
+> password: `admin`.
+> You will be prompted to reset it afterwards.
+> The local running Prometheus is configured by default as a datasource so no other work is needed other than adding your own dashboards
+
+Grafana URL: http://localhost:3000
+
+Prometheus URL: http://localhost:9050
+
+Alertmanager URL: http://localhost:9093
+
+
+## Local Kessel Inventory + Docker Compose Infra (Split Setup)
+
+The Split Setup involves using a locally running Inventory API, but all other infra (Postgres, Kafka, etc) are deployed via Docker. This setup is great for debugging the local running binary but still have all the dependent services to test the full application.
+
+To start the Split Setup:
+```shell
+make inventory-up-split
+```
+
+Then to run Inventory:
+```shell
+# Setup
+make local-build
+
+# run with the split config file (postgres host flag overwrites config locally which is set for Docker internal address)
+./bin/inventory-api serve --config development/configs/split-setup.yaml --storage.postgres.host localhost
+```
+
+## Split Setup + Kessel Relations
+
+Same as Split Setup which leverages a local Inventory API and Docker for the dependent infra, but updates the Inventory API server ports to not conflict with a running Relations API
+
+To deploy Relations API, it's recommended to clone the Relations API repo locally and leverage their existing [Docker Compose process](https://github.com/project-kessel/relations-api/tree/main?tab=readme-ov-file#spicedb-using-dockerpodman) to spin up the Relations API.
+
+To start the Relations-ready Split Setup:
+```shell
+make inventory-up-split-relations-ready
+```
+
+Then to run Inventory:
+```shell
+# Setup
+make local-build
+
+# run with the split config file (postgres host flag overwrites config locally which is set for Docker internal address)
+./bin/inventory-api serve --config development/configs/split-setup-relations-ready.yaml --storage.postgres.host localhost
+```
+
+## Kessel Inventory + Kessel Relations + SSO (Keycloak) using Docker Compose
+
+This setup expands on the Relations-ready Full Setup by:
+- Setting up a Keycloak instance running at port 8084 with [myrealm](development/configs/myrealm.json) config file.
+- Setting up a default service account with clientId: `test-svc`. Refer to [get-token](scripts/get-token.sh) to learn how to fetch a token.
+- Configures Inventory API using the [Full-Setup-w-SSO](development/configs/full-setup-w-sso.yaml) config file
+
+As before you'll need to run the Relations Compose steps available in the [Relations API repo](https://github.com/project-kessel/relations-api/tree/main?tab=readme-ov-file#spicedb-using-dockerpodman)
+
+To start use:
+```shell
+make inventory-up-sso
+```
+
+Once it has started, you will need to fetch a token and use it when making calls to the service.
+
+To get a token use:
+```shell
+make get-token
+```
+
+You can then export an ENV with that value and use in calls such as:
+
+```shell
+curl -H "Authorization: bearer ${TOKEN}" # ...
+```
+
+To stop use:
+
+```shell
+make inventory-down
+```


### PR DESCRIPTION
### PR Template:

## Describe your changes

* updates some of the headings in readme for legibiltiy
* moves all the extra docker compose options to a new doc file to declutter the readme, leaving the main docker compose setup only
* updates formatting of note about podman-compose

## Summary by Sourcery

Clean up and reorganize project documentation by improving README readability, updating prerequisites, extracting detailed Docker Compose options to a dedicated guide, and enhancing formatting of debugging and deployment notes.

Documentation:
- Bump Go prerequisite to 1.23.6 and refine README section headings
- Add a Debugging section with a link to DEBUG.md
- Reformat the podman-compose compatibility note into an Important callout
- Extract all alternative Docker Compose configurations into docs/dev-guides/docker-compose-options.md
- Simplify README by referencing the new Docker Compose guide and the ephemeral cluster testing instructions