### PR TITLE
RHCLOUD-39803: Notification circuit breaker for consumer health

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-kratos/kratos/v2/log"
+	"github.com/sony/gobreaker"
 	"github.com/spf13/cobra"
 	"gorm.io/gorm"
 
@@ -229,11 +230,26 @@ func NewCommand(
 				ConsumerEnabled:         consumerOptions.Enabled,
 			}
 
-			//v1beta2
+			// This circuit breaker is used to prevent request handlers from being blocked
+			// indefinitely if the consumer is not responding via notifications.
+			// This is a naive solution until we can implement a more robust
+			// solution for navigating consumer health.
+			waitForNotifCircuitBreaker := gobreaker.NewCircuitBreaker(gobreaker.Settings{
+				Name:    "wait-for-notif-breaker",
+				Timeout: 60 * time.Second, // Reset after 60s if tripped
+				ReadyToTrip: func(counts gobreaker.Counts) bool {
+					// Trip after 3 consecutive failures
+					return counts.ConsecutiveFailures > 2
+				},
+				OnStateChange: func(name string, from gobreaker.State, to gobreaker.State) {
+					log.Debugf("Circuit breaker %s changed from %s to %s", name, from, to)
+				},
+			})
 
+			//v1beta2
 			// wire together inventory service handling
 			resource_repo := resourcerepo.New(db)
-			inventory_controller := resourcesctl.New(resource_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), listenManager, usecaseConfig)
+			inventory_controller := resourcesctl.New(resource_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			inventory_service := resourcesvc.NewKesselInventoryServiceV1beta2(inventory_controller)
 			pbv1beta2.RegisterKesselInventoryServiceServer(server.GrpcServer, inventory_service)
 			pbv1beta2.RegisterKesselInventoryServiceHTTPServer(server.HttpServer, inventory_service)
@@ -241,35 +257,35 @@ func NewCommand(
 			//v1beta1
 			// wire together notificationsintegrations handling
 			notifs_repo := resourcerepo.New(db)
-			notifs_controller := resourcesctl.New(notifs_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), listenManager, usecaseConfig)
+			notifs_controller := resourcesctl.New(notifs_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			notifs_service := notifssvc.NewKesselNotificationsIntegrationsServiceV1beta1(notifs_controller)
 			pb.RegisterKesselNotificationsIntegrationServiceServer(server.GrpcServer, notifs_service)
 			pb.RegisterKesselNotificationsIntegrationServiceHTTPServer(server.HttpServer, notifs_service)
 
 			// wire together authz handling
 			authz_repo := resourcerepo.New(db)
-			authz_controller := resourcesctl.New(authz_repo, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), listenManager, usecaseConfig)
+			authz_controller := resourcesctl.New(authz_repo, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			authz_service := resourcesvc.NewKesselCheckServiceV1beta1(authz_controller)
 			authzv1beta1.RegisterKesselCheckServiceServer(server.GrpcServer, authz_service)
 			authzv1beta1.RegisterKesselCheckServiceHTTPServer(server.HttpServer, authz_service)
 
 			// wire together hosts handling
 			hosts_repo := resourcerepo.New(db)
-			hosts_controller := resourcesctl.New(hosts_repo, inventoryresources_repo, authorizer, eventingManager, "hbi", log.With(logger, "subsystem", "hosts_controller"), listenManager, usecaseConfig)
+			hosts_controller := resourcesctl.New(hosts_repo, inventoryresources_repo, authorizer, eventingManager, "hbi", log.With(logger, "subsystem", "hosts_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			hosts_service := hostssvc.NewKesselRhelHostServiceV1beta1(hosts_controller)
 			pb.RegisterKesselRhelHostServiceServer(server.GrpcServer, hosts_service)
 			pb.RegisterKesselRhelHostServiceHTTPServer(server.HttpServer, hosts_service)
 
 			// wire together k8sclusters handling
 			k8sclusters_repo := resourcerepo.New(db)
-			k8sclusters_controller := resourcesctl.New(k8sclusters_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8sclusters_controller"), listenManager, usecaseConfig)
+			k8sclusters_controller := resourcesctl.New(k8sclusters_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8sclusters_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			k8sclusters_service := k8sclusterssvc.NewKesselK8SClusterServiceV1beta1(k8sclusters_controller)
 			pb.RegisterKesselK8SClusterServiceServer(server.GrpcServer, k8sclusters_service)
 			pb.RegisterKesselK8SClusterServiceHTTPServer(server.HttpServer, k8sclusters_service)
 
 			// wire together k8spolicies handling
 			k8spolicies_repo := resourcerepo.New(db)
-			k8spolicies_controller := resourcesctl.New(k8spolicies_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8spolicies_controller"), listenManager, usecaseConfig)
+			k8spolicies_controller := resourcesctl.New(k8spolicies_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8spolicies_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			k8spolicies_service := k8spoliciessvc.NewKesselK8SPolicyServiceV1beta1(k8spolicies_controller)
 			pb.RegisterKesselK8SPolicyServiceServer(server.GrpcServer, k8spolicies_service)
 			pb.RegisterKesselK8SPolicyServiceHTTPServer(server.HttpServer, k8spolicies_service)

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/project-kessel/relations-api v0.0.0-20250408111129-d8b61a77bd9a
 	github.com/prometheus/client_golang v1.22.0
 	github.com/redhatinsights/app-common-go v1.6.8
+	github.com/sony/gobreaker v1.0.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.1

--- a/go.sum
+++ b/go.sum
@@ -384,6 +384,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
+github.com/sony/gobreaker v1.0.0 h1:feX5fGGXSl3dYd4aHZItw+FpHLvvoaqkawKjVNiFMNQ=
+github.com/sony/gobreaker v1.0.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=

--- a/internal/biz/usecase/resources/resources.go
+++ b/internal/biz/usecase/resources/resources.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
 	"github.com/project-kessel/inventory-api/internal/pubsub"
+	"github.com/sony/gobreaker"
 
 	"github.com/google/uuid"
 
@@ -64,6 +65,7 @@ type UsecaseConfig struct {
 type Usecase struct {
 	reporterResourceRepository  ReporterResourceRepository
 	inventoryResourceRepository InventoryResourceRepository
+	waitForNotifBreaker         *gobreaker.CircuitBreaker
 	Authz                       authzapi.Authorizer
 	Eventer                     eventingapi.Manager
 	Namespace                   string
@@ -75,10 +77,11 @@ type Usecase struct {
 
 func New(reporterResourceRepository ReporterResourceRepository, inventoryResourceRepository InventoryResourceRepository,
 	authz authzapi.Authorizer, eventer eventingapi.Manager, namespace string, logger log.Logger,
-	listenManager pubsub.ListenManagerImpl, usecaseConfig *UsecaseConfig) *Usecase {
+	listenManager pubsub.ListenManagerImpl, waitForNotifBreaker *gobreaker.CircuitBreaker, usecaseConfig *UsecaseConfig) *Usecase {
 	return &Usecase{
 		reporterResourceRepository:  reporterResourceRepository,
 		inventoryResourceRepository: inventoryResourceRepository,
+		waitForNotifBreaker:         waitForNotifBreaker,
 		Authz:                       authz,
 		Eventer:                     eventer,
 		Namespace:                   namespace,
@@ -138,12 +141,25 @@ func (uc *Usecase) Upsert(ctx context.Context, m *model.Resource, write_visibili
 			timeoutCtx, cancel := context.WithTimeout(ctx, listenTimeout)
 			defer cancel()
 
-			err = subscription.BlockForNotification(timeoutCtx)
-			if err != nil {
-				if errors.Is(err, pubsub.ErrWaitContextCancelled) {
-					return ret, nil
+			_, err := uc.waitForNotifBreaker.Execute(func() (interface{}, error) {
+				err = subscription.BlockForNotification(timeoutCtx)
+				if err != nil {
+					// Return error for circuit breaker
+					return nil, err
 				}
-				return nil, err
+				return nil, nil
+			})
+
+			if err != nil {
+				switch {
+				case errors.Is(err, pubsub.ErrWaitContextCancelled):
+					return ret, nil
+				case errors.Is(err, gobreaker.ErrOpenState):
+					uc.log.WithContext(ctx).Debugf("Circuit breaker is open, skipped waiting for notification from consumer")
+					return ret, nil
+				default:
+					return nil, err
+				}
 			}
 		}
 	}

--- a/internal/biz/usecase/resources/resources_test.go
+++ b/internal/biz/usecase/resources/resources_test.go
@@ -6,11 +6,13 @@ import (
 	"io"
 	"sort"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc/metadata"
 
 	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
 	"github.com/project-kessel/inventory-api/internal/mocks"
+	"github.com/sony/gobreaker"
 
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/google/uuid"
@@ -145,7 +147,7 @@ func TestLookupResources_Success(t *testing.T) {
 		ReadAfterWriteAllowlist: []string{},
 		ConsumerEnabled:         true,
 	}
-	useCase := New(repo, inventoryRepo, authz, nil, "", log.DefaultLogger, nil, usecaseConfig)
+	useCase := New(repo, inventoryRepo, authz, nil, "", log.DefaultLogger, nil, cb, usecaseConfig)
 	stream, err := useCase.LookupResources(ctx, req)
 
 	assert.Nil(t, err)
@@ -369,6 +371,14 @@ var defaultUseCaseConfig = &UsecaseConfig{
 	ReadAfterWriteAllowlist: []string{},
 	ConsumerEnabled:         true,
 }
+var cb = gobreaker.NewCircuitBreaker(gobreaker.Settings{
+	Name:    "wait-for-notif-breaker",
+	Timeout: 1 * time.Second,
+	ReadyToTrip: func(counts gobreaker.Counts) bool {
+		// Trip after 3 consecutive failures
+		return counts.ConsecutiveFailures > 2
+	},
+})
 
 func TestCreateReturnsDbError(t *testing.T) {
 	resource := resource1()
@@ -378,7 +388,7 @@ func TestCreateReturnsDbError(t *testing.T) {
 	// DB Error
 	repo.On("FindByReporterData", mock.Anything, mock.Anything, mock.Anything).Return((*model.Resource)(nil), gorm.ErrDuplicatedKey)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
 	_, err := useCase.Create(ctx, resource)
@@ -396,7 +406,7 @@ func TestCreateReturnsDbErrorBackwardsCompatible(t *testing.T) {
 	// DB Error
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return((*model.Resource)(nil), gorm.ErrDuplicatedKey)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
 	_, err := useCase.Create(ctx, resource)
@@ -412,7 +422,7 @@ func TestCreateResourceAlreadyExists(t *testing.T) {
 	// Resource already exists
 	repo.On("FindByReporterData", mock.Anything, mock.Anything, mock.Anything).Return(&model.Resource{}, nil)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
 	_, err := useCase.Create(ctx, resource)
@@ -430,7 +440,7 @@ func TestCreateResourceAlreadyExistsBackwardsCompatible(t *testing.T) {
 	// Resource already exists
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return(&model.Resource{}, nil)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
 	_, err := useCase.Create(ctx, resource)
@@ -460,7 +470,7 @@ func TestCreateNewResource(t *testing.T) {
 	sub.On("Unsubscribe")
 	sub.On("BlockForNotification", mock.Anything).Return(nil)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, listenMan, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, listenMan, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
 	r, err := useCase.Create(ctx, resource)
@@ -499,7 +509,7 @@ func TestCreateNewResource_ConsumerDisabled(t *testing.T) {
 		ReadAfterWriteAllowlist: []string{},
 		ConsumerEnabled:         false,
 	}
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, listenMan, usecaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, listenMan, cb, usecaseConfig)
 	ctx := context.TODO()
 
 	r, err := useCase.Create(ctx, resource)
@@ -543,7 +553,7 @@ func TestCreateNewResource_ConsistencyToken(t *testing.T) {
 		ReadAfterWriteAllowlist: []string{"reporter_id"},
 		ConsumerEnabled:         true,
 	}
-	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, listenMan, usecaseConfig)
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, listenMan, cb, usecaseConfig)
 	ctx := context.TODO()
 
 	r, err := useCase.Create(ctx, resource)
@@ -563,7 +573,7 @@ func TestUpdateReturnsDbError(t *testing.T) {
 	// DB Error
 	repo.On("FindByReporterData", mock.Anything, mock.Anything, mock.Anything).Return((*model.Resource)(nil), gorm.ErrDuplicatedKey)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
 	_, err := useCase.Update(ctx, resource, model.ReporterResourceId{})
@@ -580,7 +590,7 @@ func TestUpdateReturnsDbErrorBackwardsCompatible(t *testing.T) {
 	// DB Error
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return((*model.Resource)(nil), gorm.ErrDuplicatedKey)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
 	_, err := useCase.Update(ctx, resource, model.ReporterResourceId{})
@@ -611,7 +621,7 @@ func TestUpdateNewResourceCreatesIt(t *testing.T) {
 	sub.On("Unsubscribe")
 	sub.On("BlockForNotification", mock.Anything).Return(nil)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, listenMan, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, listenMan, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
 	r, err := useCase.Update(ctx, resource, model.ReporterResourceId{})
@@ -646,7 +656,7 @@ func TestUpdateExistingResource(t *testing.T) {
 	sub.On("Unsubscribe")
 	sub.On("BlockForNotification", mock.Anything).Return(nil)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, listenMan, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, listenMan, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
 	r, err := useCase.Update(ctx, resource, model.ReporterResourceId{})
@@ -683,7 +693,7 @@ func TestUpdateExistingResourceBackwardsCompatible(t *testing.T) {
 	sub.On("Unsubscribe")
 	sub.On("BlockForNotification", mock.Anything).Return(nil)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, listenMan, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, listenMan, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
 	r, err := useCase.Update(ctx, resource, model.ReporterResourceId{})
@@ -702,7 +712,7 @@ func TestDeleteReturnsDbError(t *testing.T) {
 	// Validates backwards compatibility
 	repo.On("FindByReporterData", mock.Anything, mock.Anything, mock.Anything).Return((*model.Resource)(nil), gorm.ErrDuplicatedKey)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
 	err := useCase.Delete(ctx, model.ReporterResourceId{})
@@ -718,7 +728,7 @@ func TestDeleteReturnsDbErrorBackwardsCompatible(t *testing.T) {
 	// DB Error
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return((*model.Resource)(nil), gorm.ErrDuplicatedKey)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
 	err := useCase.Delete(ctx, model.ReporterResourceId{})
@@ -734,7 +744,7 @@ func TestDeleteNonexistentResource(t *testing.T) {
 	repo.On("FindByReporterData", mock.Anything, mock.Anything, mock.Anything).Return((*model.Resource)(nil), gorm.ErrRecordNotFound)
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return((*model.Resource)(nil), gorm.ErrRecordNotFound)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
 	err := useCase.Delete(ctx, model.ReporterResourceId{})
@@ -755,7 +765,7 @@ func TestDeleteResource(t *testing.T) {
 	}, nil)
 	repo.On("Delete", mock.Anything, (uuid.UUID)(id), mock.Anything).Return(&model.Resource{}, nil)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 
 	err = useCase.Delete(ctx, model.ReporterResourceId{})
 	assert.Nil(t, err)
@@ -778,7 +788,7 @@ func TestDeleteResourceBackwardsCompatible(t *testing.T) {
 	}, nil)
 	repo.On("Delete", mock.Anything, (uuid.UUID)(id), mock.Anything).Return(&model.Resource{}, nil)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 
 	err = useCase.Delete(ctx, model.ReporterResourceId{})
 	assert.Nil(t, err)
@@ -803,7 +813,7 @@ func TestCreateResource_PersistenceDisabled(t *testing.T) {
 		ReadAfterWriteAllowlist: []string{},
 		ConsumerEnabled:         true,
 	}
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, usecaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, usecaseConfig)
 
 	// Create the resource
 	r, err := useCase.Create(ctx, resource)
@@ -839,7 +849,7 @@ func TestUpdateResource_PersistenceDisabled(t *testing.T) {
 		ReadAfterWriteAllowlist: []string{},
 		ConsumerEnabled:         true,
 	}
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, usecaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, usecaseConfig)
 
 	r, err := useCase.Update(ctx, resource, model.ReporterResourceId{})
 	assert.Nil(t, err)
@@ -881,7 +891,7 @@ func TestUpdate_ReadAfterWrite(t *testing.T) {
 		ReadAfterWriteAllowlist: []string{"reporter_id"},
 		ConsumerEnabled:         true,
 	}
-	useCase := New(repo, inventoryRepo, authz, nil, "", log.DefaultLogger, listenMan, usecaseConfig)
+	useCase := New(repo, inventoryRepo, authz, nil, "", log.DefaultLogger, listenMan, cb, usecaseConfig)
 	ctx := context.TODO()
 
 	r, err := useCase.Update(ctx, resource, model.ReporterResourceId{})
@@ -922,7 +932,7 @@ func TestUpdate_ConsumerDisabled(t *testing.T) {
 		ReadAfterWriteAllowlist: []string{"reporter_id"},
 		ConsumerEnabled:         false,
 	}
-	useCase := New(repo, inventoryRepo, authz, nil, "", log.DefaultLogger, listenMan, usecaseConfig)
+	useCase := New(repo, inventoryRepo, authz, nil, "", log.DefaultLogger, listenMan, cb, usecaseConfig)
 	ctx := context.TODO()
 
 	r, err := useCase.Update(ctx, resource, model.ReporterResourceId{})
@@ -956,7 +966,7 @@ func TestDeleteResource_PersistenceDisabled(t *testing.T) {
 		ReadAfterWriteAllowlist: []string{},
 		ConsumerEnabled:         true,
 	}
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, usecaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, usecaseConfig)
 
 	err = useCase.Delete(ctx, model.ReporterResourceId{})
 	assert.Nil(t, err)
@@ -976,7 +986,7 @@ func TestCheck_MissingResource(t *testing.T) {
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return(&model.Resource{}, gorm.ErrRecordNotFound)
 	m.On("Check", mock.Anything, mock.Anything, "notifications_integration_view", mock.Anything, mock.Anything).Return(v1beta1.CheckResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
 
-	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	allowed, err := useCase.Check(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model.ReporterResourceId{})
 
 	assert.Nil(t, err)
@@ -1001,7 +1011,7 @@ func TestCheck_ResourceExistsError(t *testing.T) {
 
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return(&model.Resource{}, gorm.ErrUnsupportedDriver) // some random error
 
-	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	allowed, err := useCase.Check(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model.ReporterResourceId{})
 
 	assert.NotNil(t, err)
@@ -1020,7 +1030,7 @@ func TestCheck_ErrorWithKessel(t *testing.T) {
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return(&model.Resource{}, nil)
 	m.On("Check", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(v1beta1.CheckResponse_ALLOWED_FALSE, &v1beta1.ConsistencyToken{}, errors.New("failed during call to relations"))
 
-	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	allowed, err := useCase.Check(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model.ReporterResourceId{})
 
 	assert.NotNil(t, err)
@@ -1040,7 +1050,7 @@ func TestCheck_Allowed(t *testing.T) {
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return(resource, nil)
 	m.On("Check", mock.Anything, mock.Anything, "notifications_integration_write", mock.Anything, mock.Anything).Return(v1beta1.CheckResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
 
-	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	allowed, err := useCase.Check(ctx, "notifications_integration_write", "rbac", &v1beta1.SubjectReference{}, model.ReporterResourceId{})
 
 	assert.Nil(t, err)
@@ -1065,7 +1075,7 @@ func TestCheckForUpdate_ResourceExistsError(t *testing.T) {
 
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return(&model.Resource{}, gorm.ErrUnsupportedDriver) // some random error
 
-	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	allowed, err := useCase.CheckForUpdate(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model.ReporterResourceId{})
 
 	assert.NotNil(t, err)
@@ -1084,7 +1094,7 @@ func TestCheckForUpdate_ErrorWithKessel(t *testing.T) {
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return(&model.Resource{}, nil)
 	m.On("CheckForUpdate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_FALSE, &v1beta1.ConsistencyToken{}, errors.New("failed during call to relations"))
 
-	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	allowed, err := useCase.CheckForUpdate(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model.ReporterResourceId{})
 
 	assert.NotNil(t, err)
@@ -1104,7 +1114,7 @@ func TestCheckForUpdate_WorkspaceAllowed(t *testing.T) {
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return(resource, nil)
 	m.On("CheckForUpdate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
 
-	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	allowed, err := useCase.CheckForUpdate(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model.ReporterResourceId{ResourceType: "workspace"})
 
 	assert.Nil(t, err)
@@ -1123,7 +1133,7 @@ func TestCheckForUpdate_MissingResource_Allowed(t *testing.T) {
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return(&model.Resource{}, gorm.ErrRecordNotFound)
 	m.On("CheckForUpdate", mock.Anything, mock.Anything, "notifications_integration_view", mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
 
-	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	allowed, err := useCase.CheckForUpdate(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model.ReporterResourceId{})
 
 	// no consistency token being written.
@@ -1148,7 +1158,7 @@ func TestCheckForUpdate_Allowed(t *testing.T) {
 
 	repo.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&model.Resource{}, nil)
 
-	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	allowed, err := useCase.CheckForUpdate(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model.ReporterResourceId{})
 
 	assert.Nil(t, err)
@@ -1174,7 +1184,7 @@ func TestListResourcesInWorkspace_Error(t *testing.T) {
 
 	repo.On("FindByWorkspaceId", mock.Anything, mock.Anything).Return([]*model.Resource{}, errors.New("failed querying"))
 
-	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	resource_chan, err_chan, err := useCase.ListResourcesInWorkspace(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, "foo-id")
 
 	assert.NotNil(t, err)
@@ -1193,7 +1203,7 @@ func TestListResourcesInWorkspace_NoResources(t *testing.T) {
 
 	repo.On("FindByWorkspaceId", mock.Anything, mock.Anything).Return([]*model.Resource{}, nil)
 
-	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	resource_chan, err_chan, err := useCase.ListResourcesInWorkspace(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, "foo-id")
 
 	assert.Nil(t, err)
@@ -1218,7 +1228,7 @@ func TestListResourcesInWorkspace_ResourcesAllowedTrue(t *testing.T) {
 	repo.On("FindByWorkspaceId", mock.Anything, mock.Anything).Return([]*model.Resource{resource}, nil)
 	m.On("Check", mock.Anything, mock.Anything, "notifications_integration_write", mock.Anything, mock.Anything).Return(v1beta1.CheckResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
 
-	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	resource_chan, err_chan, err := useCase.ListResourcesInWorkspace(ctx, "notifications_integration_write", "rbac", &v1beta1.SubjectReference{}, "foo-id")
 
 	assert.Nil(t, err)
@@ -1261,7 +1271,7 @@ func TestListResourcesInWorkspace_MultipleResourcesAllowedTrue(t *testing.T) {
 	repo.On("FindByWorkspaceId", mock.Anything, mock.Anything).Return([]*model.Resource{resource, resource2, resource3}, nil)
 	m.On("Check", mock.Anything, mock.Anything, "notifications_integration_write", mock.Anything, mock.Anything).Return(v1beta1.CheckResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
 
-	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	resource_chan, err_chan, err := useCase.ListResourcesInWorkspace(ctx, "notifications_integration_write", "rbac", &v1beta1.SubjectReference{}, "foo-id")
 
 	assert.Nil(t, err)
@@ -1302,7 +1312,7 @@ func TestListResourcesInWorkspace_MultipleResourcesOneFalseTwoTrueLastError(t *t
 	m.On("Check", mock.Anything, mock.Anything, "notifications_integration_write", resource2, mock.Anything).Return(v1beta1.CheckResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
 	m.On("Check", mock.Anything, mock.Anything, "notifications_integration_write", resource3, mock.Anything).Return(v1beta1.CheckResponse_ALLOWED_UNSPECIFIED, &v1beta1.ConsistencyToken{}, theError)
 
-	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	resource_chan, err_chan, err := useCase.ListResourcesInWorkspace(ctx, "notifications_integration_write", "rbac", &v1beta1.SubjectReference{}, "foo-id")
 
 	assert.Nil(t, err)
@@ -1336,7 +1346,7 @@ func TestListResourcesInWorkspace_ResourcesAllowedError(t *testing.T) {
 	repo.On("FindByWorkspaceId", mock.Anything, mock.Anything).Return([]*model.Resource{resource}, nil)
 	m.On("Check", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(v1beta1.CheckResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, errors.New("failed calling relations"))
 
-	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	resource_chan, err_chan, err := useCase.ListResourcesInWorkspace(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, "foo-id")
 
 	assert.Nil(t, err)
@@ -1516,7 +1526,7 @@ func TestUpsertReturnsDbError(t *testing.T) {
 	// DB Error
 	repo.On("FindByReporterResourceIdv1beta2", mock.Anything, mock.Anything).Return((*model.Resource)(nil), gorm.ErrDuplicatedKey)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
 	_, err := useCase.Upsert(ctx, resource, v1beta2.WriteVisibility_WRITE_VISIBILITY_UNSPECIFIED)
@@ -1533,7 +1543,7 @@ func TestUpsertReturnsExistingUpdatedResource(t *testing.T) {
 	repo.On("FindByReporterResourceIdv1beta2", mock.Anything, mock.Anything).Return(resource, nil)
 	repo.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resource, nil)
 
-	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, defaultUseCaseConfig)
+	useCase := New(repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
 	res, err := useCase.Upsert(ctx, resource, v1beta2.WriteVisibility_WRITE_VISIBILITY_UNSPECIFIED)
@@ -1566,7 +1576,7 @@ func TestUpsert_ReadAfterWrite(t *testing.T) {
 		ReadAfterWriteAllowlist: []string{"reporter_id"},
 		ConsumerEnabled:         true,
 	}
-	useCase := New(repo, inventoryRepo, authz, nil, "", log.DefaultLogger, listenMan, usecaseConfig)
+	useCase := New(repo, inventoryRepo, authz, nil, "", log.DefaultLogger, listenMan, cb, usecaseConfig)
 	ctx := context.TODO()
 
 	r, err := useCase.Upsert(ctx, resource, v1beta2.WriteVisibility_IMMEDIATE)
@@ -1602,7 +1612,7 @@ func TestUpsert_ConsumerDisabled(t *testing.T) {
 		ReadAfterWriteAllowlist: []string{"reporter_id"},
 		ConsumerEnabled:         false,
 	}
-	useCase := New(repo, inventoryRepo, authz, nil, "", log.DefaultLogger, listenMan, usecaseConfig)
+	useCase := New(repo, inventoryRepo, authz, nil, "", log.DefaultLogger, listenMan, cb, usecaseConfig)
 	ctx := context.TODO()
 
 	r, err := useCase.Upsert(ctx, resource, v1beta2.WriteVisibility_IMMEDIATE)
@@ -1613,4 +1623,70 @@ func TestUpsert_ConsumerDisabled(t *testing.T) {
 	listenMan.AssertNotCalled(t, "Subscribe")
 	sub.AssertNotCalled(t, "Unsubscribe")
 	sub.AssertNotCalled(t, "BlockForNotification")
+}
+
+func TestUpsert_WaitCircuitBreaker(t *testing.T) {
+	resource := resource1()
+
+	repo := &MockedReporterResourceRepository{}
+	inventoryRepo := &MockedInventoryResourceRepository{}
+	authz := &mocks.MockAuthz{}
+	listenMan := &MockedListenManager{}
+	sub := MockedSubscription{}
+
+	repo.On("FindByReporterResourceIdv1beta2", mock.Anything, mock.Anything).Return((*model.Resource)(nil), gorm.ErrRecordNotFound)
+	repo.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resource, nil)
+
+	listenMan.On("Subscribe", mock.Anything).Return(&sub)
+
+	sub.On("Unsubscribe")
+	// Return timeout error
+	blockForNotifCall := sub.On("BlockForNotification", mock.Anything).Return(pubsub.ErrWaitContextCancelled)
+
+	usecaseConfig := &UsecaseConfig{
+		DisablePersistence:      false,
+		ReadAfterWriteEnabled:   true,
+		ReadAfterWriteAllowlist: []string{"reporter_id"},
+		ConsumerEnabled:         true,
+	}
+	useCase := New(repo, inventoryRepo, authz, nil, "", log.DefaultLogger, listenMan, cb, usecaseConfig)
+	ctx := context.TODO()
+
+	// Attempt 1
+	r, err := useCase.Upsert(ctx, resource, v1beta2.WriteVisibility_IMMEDIATE)
+	assert.Nil(t, err) // No expected error because we treat a timeout as a success
+	assert.NotNil(t, r)
+	repo.AssertExpectations(t)
+	listenMan.AssertExpectations(t)
+	sub.AssertExpectations(t)
+	assert.Equal(t, gobreaker.StateClosed, cb.State()) // Circuit breaker should be closed
+	// Attempt 2
+	r, err = useCase.Upsert(ctx, resource, v1beta2.WriteVisibility_IMMEDIATE)
+	assert.Nil(t, err) // No expected error because we treat a timeout as a success
+	assert.NotNil(t, r)
+	repo.AssertExpectations(t)
+	listenMan.AssertExpectations(t)
+	sub.AssertExpectations(t)
+	assert.Equal(t, gobreaker.StateClosed, cb.State()) // Circuit breaker should be closed
+	// Attempt 3
+	r, err = useCase.Upsert(ctx, resource, v1beta2.WriteVisibility_IMMEDIATE)
+	assert.Nil(t, err) // No expected error because we treat a timeout as a success
+	assert.NotNil(t, r)
+	repo.AssertExpectations(t)
+	listenMan.AssertExpectations(t)
+	sub.AssertExpectations(t)
+	assert.Equal(t, gobreaker.StateOpen, cb.State()) // Circuit breaker should be open
+	// Circuit breaker reset
+	blockForNotifCall.Unset()
+	time.Sleep(2 * time.Second)                               // Wait for the circuit breaker timeout
+	assert.Equal(t, gobreaker.StateHalfOpen, cb.State())      // Circuit breaker should be half-open after the timeout
+	sub.On("BlockForNotification", mock.Anything).Return(nil) // Prepare a successful notification
+	// Attempt 4
+	r, err = useCase.Upsert(ctx, resource, v1beta2.WriteVisibility_IMMEDIATE)
+	assert.Nil(t, err) // No expected error because we treat a timeout as a success
+	assert.NotNil(t, r)
+	repo.AssertExpectations(t)
+	listenMan.AssertExpectations(t)
+	sub.AssertExpectations(t)
+	assert.Equal(t, gobreaker.StateClosed, cb.State()) // Circuit breaker should be closed
 }


### PR DESCRIPTION
## Summary
- Adds wait for notification circuit breaker to v1beta2 `Upsert`
- Circuit breaker behavior
  - If we reach the target number of consecutive failed waits (3)
     - Trip the circuit breaker to open (no waiting for notifs)
     - After the timeout period, the circuit breaker will be half-open and one request will be allowed through
     - If it succeeds, the circuit breaker will fully close (wait for notifs)
     - If it fails, it will go back to open

## Pros
- Easy to implement and maintain
- Consumer implementation agnostic
    - If we ever move the consumer out of the inventory API container, there won’t be any work needed here.

## Cons
- Reactive. Requires some time to realize the consumer is down, as well as recover.
- Circuit breaker is per-pod so depending on routing and load, failures could take longer to be realized and short-circuit.