### PR TITLE
RHCLOUD-40071: Add api unit tests for v1beta2 api

### DIFF
--- a/api/kessel/inventory/v1beta2/allowed.pb_test.go
+++ b/api/kessel/inventory/v1beta2/allowed.pb_test.go
@@ -1,0 +1,35 @@
+package v1beta2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllowedEnumValues(t *testing.T) {
+	assert.Equal(t, int32(0), int32(Allowed_ALLOWED_UNSPECIFIED))
+	assert.Equal(t, int32(1), int32(Allowed_ALLOWED_TRUE))
+	assert.Equal(t, int32(2), int32(Allowed_ALLOWED_FALSE))
+}
+
+func TestAllowedStringer(t *testing.T) {
+	assert.Equal(t, "ALLOWED_UNSPECIFIED", Allowed_ALLOWED_UNSPECIFIED.String())
+	assert.Equal(t, "ALLOWED_TRUE", Allowed_ALLOWED_TRUE.String())
+	assert.Equal(t, "ALLOWED_FALSE", Allowed_ALLOWED_FALSE.String())
+}
+
+func TestAllowedEnumMaps(t *testing.T) {
+	assert.Equal(t, "ALLOWED_UNSPECIFIED", Allowed_name[int32(Allowed_ALLOWED_UNSPECIFIED)])
+	assert.Equal(t, "ALLOWED_TRUE", Allowed_name[int32(Allowed_ALLOWED_TRUE)])
+	assert.Equal(t, "ALLOWED_FALSE", Allowed_name[int32(Allowed_ALLOWED_FALSE)])
+
+	assert.Equal(t, int32(0), Allowed_value["ALLOWED_UNSPECIFIED"])
+	assert.Equal(t, int32(1), Allowed_value["ALLOWED_TRUE"])
+	assert.Equal(t, int32(2), Allowed_value["ALLOWED_FALSE"])
+}
+
+func TestAllowedEnumMethod(t *testing.T) {
+	enumPtr := Allowed_ALLOWED_TRUE.Enum()
+	assert.NotNil(t, enumPtr)
+	assert.Equal(t, Allowed_ALLOWED_TRUE, *enumPtr)
+}

--- a/api/kessel/inventory/v1beta2/check_for_update_request.pb_test.go
+++ b/api/kessel/inventory/v1beta2/check_for_update_request.pb_test.go
@@ -1,0 +1,113 @@
+package v1beta2
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+	"testing"
+)
+
+func TestCheckForUpdateRequest_FullRoundTrip(t *testing.T) {
+	relation := "members"
+	cr := &CheckForUpdateRequest{
+		Object: &ResourceReference{
+			ResourceType: "host",
+			ResourceId:   "host-123",
+		},
+		Relation: "view",
+		Subject: &SubjectReference{
+			Relation: &relation,
+			Resource: &ResourceReference{
+				ResourceType: "principal",
+				ResourceId:   "sarah",
+			},
+		},
+	}
+
+	// Marshal to JSON and back
+	data, err := json.Marshal(cr)
+	assert.NoError(t, err)
+
+	var out CheckForUpdateRequest
+	err = json.Unmarshal(data, &out)
+	assert.NoError(t, err)
+
+	// Check object
+	assert.Equal(t, "host", out.GetObject().GetResourceType())
+	assert.Equal(t, "host-123", out.GetObject().GetResourceId())
+
+	// Check relation
+	assert.Equal(t, "view", out.GetRelation())
+
+	// Check subject
+	assert.NotNil(t, out.GetSubject())
+	assert.Equal(t, "members", out.GetSubject().GetRelation())
+	assert.NotNil(t, out.GetSubject().GetResource())
+	assert.Equal(t, "principal", out.GetSubject().GetResource().GetResourceType())
+	assert.Equal(t, "sarah", out.GetSubject().GetResource().GetResourceId())
+}
+
+func TestCheckForUpdateRequest_Reset(t *testing.T) {
+	cr := &CheckForUpdateRequest{
+		Object:   &ResourceReference{ResourceType: "vm", ResourceId: "123"},
+		Relation: "read",
+		Subject:  &SubjectReference{},
+	}
+	cr.Reset()
+	assert.Nil(t, cr.Object)
+	assert.Equal(t, "", cr.Relation)
+	assert.Nil(t, cr.Subject)
+}
+func TestCheckForUpdateRequest_String(t *testing.T) {
+	cr := &CheckForUpdateRequest{
+		Object:   &ResourceReference{ResourceType: "host"},
+		Relation: "view",
+	}
+	s := cr.String()
+	assert.NotEmpty(t, s)
+	// Optionally, check that it mentions your field values
+	assert.Contains(t, s, "host")
+	assert.Contains(t, s, "view")
+}
+
+func TestCheckForUpdateRequest_ProtoMessage(t *testing.T) {
+	var cr interface{} = &CheckForUpdateRequest{}
+	_, ok := cr.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestCheckForUpdateRequest_ProtoReflect(t *testing.T) {
+	cr := &CheckForUpdateRequest{
+		Object:   &ResourceReference{ResourceType: "host"},
+		Relation: "view",
+	}
+	m := cr.ProtoReflect()
+	assert.NotNil(t, m)
+	assert.Equal(t, "view", m.Interface().(*CheckForUpdateRequest).Relation)
+}
+
+func TestCheckForUpdateRequest_NilFields(t *testing.T) {
+	var cr *CheckForUpdateRequest
+	// All getters should be safe to call on nil and return zero values
+	assert.Nil(t, cr.GetObject())
+	assert.Equal(t, "", cr.GetRelation())
+	assert.Nil(t, cr.GetSubject())
+}
+
+func TestCheckForUpdateRequest_EmptyStruct(t *testing.T) {
+	var cr CheckForUpdateRequest
+	// All getters should return zero values, not panic
+	assert.Nil(t, cr.GetObject())
+	assert.Equal(t, "", cr.GetRelation())
+	assert.Nil(t, cr.GetSubject())
+}
+
+func TestCheckForUpdateRequest_SubjectNilResource(t *testing.T) {
+	cr := &CheckForUpdateRequest{
+		Subject: &SubjectReference{
+			Resource: nil,
+		},
+	}
+	assert.Nil(t, cr.GetSubject().GetResource())
+	assert.Equal(t, "", cr.GetSubject().GetRelation())
+}

--- a/api/kessel/inventory/v1beta2/check_for_update_response.pb_test.go
+++ b/api/kessel/inventory/v1beta2/check_for_update_response.pb_test.go
@@ -1,0 +1,76 @@
+package v1beta2
+
+import (
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+	"testing"
+)
+
+func TestCheckForUpdateResponse_GetAllowed_Nil(t *testing.T) {
+	var resp *CheckForUpdateResponse
+	assert.Equal(t, Allowed_ALLOWED_UNSPECIFIED, resp.GetAllowed())
+}
+
+func TestCheckForUpdateResponse_GetAllowed_ZeroStruct(t *testing.T) {
+	var resp CheckForUpdateResponse
+	assert.Equal(t, Allowed_ALLOWED_UNSPECIFIED, resp.GetAllowed())
+}
+
+func TestCheckForUpdateResponse_GetAllowed_True(t *testing.T) {
+	resp := &CheckForUpdateResponse{Allowed: Allowed_ALLOWED_TRUE}
+	assert.Equal(t, Allowed_ALLOWED_TRUE, resp.GetAllowed())
+}
+
+func TestCheckForUpdateResponse_GetAllowed_False(t *testing.T) {
+	resp := &CheckForUpdateResponse{Allowed: Allowed_ALLOWED_FALSE}
+	assert.Equal(t, Allowed_ALLOWED_FALSE, resp.GetAllowed())
+}
+
+func TestCheckForUpdateResponse_Reset(t *testing.T) {
+	resp := &CheckForUpdateResponse{Allowed: Allowed_ALLOWED_TRUE}
+	resp.Reset()
+	assert.Equal(t, Allowed_ALLOWED_UNSPECIFIED, resp.GetAllowed())
+}
+
+func TestCheckForUpdateResponse_String(t *testing.T) {
+	resp := &CheckForUpdateResponse{Allowed: Allowed_ALLOWED_TRUE}
+	s := resp.String()
+	assert.NotEmpty(t, s)
+	assert.Contains(t, s, "ALLOWED_TRUE")
+}
+
+func TestCheckForUpdateResponse_ProtoMessage(t *testing.T) {
+	var resp interface{} = &CheckForUpdateResponse{}
+	_, ok := resp.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestCheckForUpdateResponse_ProtoReflect(t *testing.T) {
+	resp := &CheckForUpdateResponse{Allowed: Allowed_ALLOWED_FALSE}
+	m := resp.ProtoReflect()
+	assert.NotNil(t, m)
+	assert.Equal(t, Allowed_ALLOWED_FALSE, m.Interface().(*CheckForUpdateResponse).Allowed)
+}
+
+func TestCheckForUpdateResponse_MarshalUnmarshal(t *testing.T) {
+	orig := &CheckForUpdateResponse{Allowed: Allowed_ALLOWED_TRUE}
+	data, err := proto.Marshal(orig)
+	assert.NoError(t, err)
+
+	var decoded CheckForUpdateResponse
+	err = proto.Unmarshal(data, &decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, Allowed_ALLOWED_TRUE, decoded.GetAllowed())
+}
+
+func TestCheckForUpdateResponse_AllAllowedValues(t *testing.T) {
+	values := []Allowed{
+		Allowed_ALLOWED_UNSPECIFIED,
+		Allowed_ALLOWED_TRUE,
+		Allowed_ALLOWED_FALSE,
+	}
+	for _, v := range values {
+		resp := &CheckForUpdateResponse{Allowed: v}
+		assert.Equal(t, v, resp.GetAllowed())
+	}
+}

--- a/api/kessel/inventory/v1beta2/check_request.pb_test.go
+++ b/api/kessel/inventory/v1beta2/check_request.pb_test.go
@@ -1,0 +1,113 @@
+package v1beta2
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+	"testing"
+)
+
+func TestCheckRequest_FullRoundTrip(t *testing.T) {
+	relation := "members"
+	cr := &CheckRequest{
+		Object: &ResourceReference{
+			ResourceType: "host",
+			ResourceId:   "host-123",
+		},
+		Relation: "view",
+		Subject: &SubjectReference{
+			Relation: &relation,
+			Resource: &ResourceReference{
+				ResourceType: "principal",
+				ResourceId:   "sarah",
+			},
+		},
+	}
+
+	// Marshal to JSON and back
+	data, err := json.Marshal(cr)
+	assert.NoError(t, err)
+
+	var out CheckRequest
+	err = json.Unmarshal(data, &out)
+	assert.NoError(t, err)
+
+	// Check object
+	assert.Equal(t, "host", out.GetObject().GetResourceType())
+	assert.Equal(t, "host-123", out.GetObject().GetResourceId())
+
+	// Check relation
+	assert.Equal(t, "view", out.GetRelation())
+
+	// Check subject
+	assert.NotNil(t, out.GetSubject())
+	assert.Equal(t, "members", out.GetSubject().GetRelation())
+	assert.NotNil(t, out.GetSubject().GetResource())
+	assert.Equal(t, "principal", out.GetSubject().GetResource().GetResourceType())
+	assert.Equal(t, "sarah", out.GetSubject().GetResource().GetResourceId())
+}
+
+func TestCheckRequest_Reset(t *testing.T) {
+	cr := &CheckRequest{
+		Object:   &ResourceReference{ResourceType: "vm", ResourceId: "123"},
+		Relation: "read",
+		Subject:  &SubjectReference{},
+	}
+	cr.Reset()
+	assert.Nil(t, cr.Object)
+	assert.Equal(t, "", cr.Relation)
+	assert.Nil(t, cr.Subject)
+}
+func TestCheckRequest_String(t *testing.T) {
+	cr := &CheckRequest{
+		Object:   &ResourceReference{ResourceType: "host"},
+		Relation: "view",
+	}
+	s := cr.String()
+	assert.NotEmpty(t, s)
+	// Optionally, check that it mentions your field values
+	assert.Contains(t, s, "host")
+	assert.Contains(t, s, "view")
+}
+
+func TestCheckRequest_ProtoMessage(t *testing.T) {
+	var cr interface{} = &CheckRequest{}
+	_, ok := cr.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestCheckRequest_ProtoReflect(t *testing.T) {
+	cr := &CheckRequest{
+		Object:   &ResourceReference{ResourceType: "host"},
+		Relation: "view",
+	}
+	m := cr.ProtoReflect()
+	assert.NotNil(t, m)
+	assert.Equal(t, "view", m.Interface().(*CheckRequest).Relation)
+}
+
+func TestCheckRequest_NilFields(t *testing.T) {
+	var cr *CheckRequest
+	// All getters should be safe to call on nil and return zero values
+	assert.Nil(t, cr.GetObject())
+	assert.Equal(t, "", cr.GetRelation())
+	assert.Nil(t, cr.GetSubject())
+}
+
+func TestCheckRequest_EmptyStruct(t *testing.T) {
+	var cr CheckRequest
+	// All getters should return zero values, not panic
+	assert.Nil(t, cr.GetObject())
+	assert.Equal(t, "", cr.GetRelation())
+	assert.Nil(t, cr.GetSubject())
+}
+
+func TestCheckRequest_SubjectNilResource(t *testing.T) {
+	cr := &CheckRequest{
+		Subject: &SubjectReference{
+			Resource: nil,
+		},
+	}
+	assert.Nil(t, cr.GetSubject().GetResource())
+	assert.Equal(t, "", cr.GetSubject().GetRelation())
+}

--- a/api/kessel/inventory/v1beta2/check_response.pb_test.go
+++ b/api/kessel/inventory/v1beta2/check_response.pb_test.go
@@ -1,0 +1,77 @@
+package v1beta2
+
+import (
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+	"testing"
+)
+
+func TestCheckResponse_GetAllowed_Nil(t *testing.T) {
+	var cr *CheckResponse
+	assert.Equal(t, Allowed_ALLOWED_UNSPECIFIED, cr.GetAllowed())
+}
+
+func TestCheckResponse_GetAllowed_ZeroStruct(t *testing.T) {
+	var cr CheckResponse
+	assert.Equal(t, Allowed_ALLOWED_UNSPECIFIED, cr.GetAllowed())
+}
+
+func TestCheckResponse_GetAllowed_True(t *testing.T) {
+	cr := &CheckResponse{Allowed: Allowed_ALLOWED_TRUE}
+	assert.Equal(t, Allowed_ALLOWED_TRUE, cr.GetAllowed())
+}
+
+func TestCheckResponse_GetAllowed_False(t *testing.T) {
+	cr := &CheckResponse{Allowed: Allowed_ALLOWED_FALSE}
+	assert.Equal(t, Allowed_ALLOWED_FALSE, cr.GetAllowed())
+}
+
+func TestCheckResponse_Reset(t *testing.T) {
+	cr := &CheckResponse{Allowed: Allowed_ALLOWED_TRUE}
+	cr.Reset()
+	assert.Equal(t, Allowed_ALLOWED_UNSPECIFIED, cr.GetAllowed())
+}
+
+func TestCheckResponse_String(t *testing.T) {
+	cr := &CheckResponse{Allowed: Allowed_ALLOWED_TRUE}
+	s := cr.String()
+	assert.NotEmpty(t, s)
+	assert.Contains(t, s, "ALLOWED_TRUE")
+}
+
+func TestCheckResponse_ProtoReflect(t *testing.T) {
+	cr := &CheckResponse{Allowed: Allowed_ALLOWED_FALSE}
+	m := cr.ProtoReflect()
+	assert.NotNil(t, m)
+	assert.Equal(t, Allowed_ALLOWED_FALSE, m.Interface().(*CheckResponse).Allowed)
+}
+
+func TestCheckResponse_ProtoMessage(t *testing.T) {
+	var cr interface{} = &CheckResponse{}
+	_, ok := cr.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestCheckResponse_MarshalUnmarshal(t *testing.T) {
+	orig := &CheckResponse{Allowed: Allowed_ALLOWED_TRUE}
+	data, err := proto.Marshal(orig)
+	assert.NoError(t, err)
+
+	var decoded CheckResponse
+	err = proto.Unmarshal(data, &decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, Allowed_ALLOWED_TRUE, decoded.GetAllowed())
+}
+
+// Test all possible Allowed values
+func TestCheckResponse_AllAllowedValues(t *testing.T) {
+	values := []Allowed{
+		Allowed_ALLOWED_UNSPECIFIED,
+		Allowed_ALLOWED_TRUE,
+		Allowed_ALLOWED_FALSE,
+	}
+	for _, v := range values {
+		cr := &CheckResponse{Allowed: v}
+		assert.Equal(t, v, cr.GetAllowed())
+	}
+}

--- a/api/kessel/inventory/v1beta2/consistency.pb_test.go
+++ b/api/kessel/inventory/v1beta2/consistency.pb_test.go
@@ -1,0 +1,80 @@
+package v1beta2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestConsistency_MinimizeLatency(t *testing.T) {
+	cons := &Consistency{
+		Requirement: &Consistency_MinimizeLatency{MinimizeLatency: true},
+	}
+	assert.True(t, cons.GetMinimizeLatency())
+	assert.Nil(t, cons.GetAtLeastAsFresh())
+}
+
+func TestConsistency_AtLeastAsFresh(t *testing.T) {
+	ct := &ConsistencyToken{Token: "snap"}
+	cons := &Consistency{
+		Requirement: &Consistency_AtLeastAsFresh{AtLeastAsFresh: ct},
+	}
+	assert.False(t, cons.GetMinimizeLatency())
+	assert.NotNil(t, cons.GetAtLeastAsFresh())
+	assert.Equal(t, "snap", cons.GetAtLeastAsFresh().GetToken())
+}
+
+func TestConsistency_GetMinimizeLatency_FalseDefault(t *testing.T) {
+	cons := &Consistency{}
+	assert.False(t, cons.GetMinimizeLatency())
+}
+
+func TestConsistency_GetAtLeastAsFresh_NilDefault(t *testing.T) {
+	cons := &Consistency{}
+	assert.Nil(t, cons.GetAtLeastAsFresh())
+}
+
+func TestConsistency_GetRequirement_NilStruct(t *testing.T) {
+	var cons *Consistency
+	assert.Nil(t, cons.GetRequirement())
+	assert.False(t, cons.GetMinimizeLatency())
+	assert.Nil(t, cons.GetAtLeastAsFresh())
+}
+
+func TestConsistency_Reset(t *testing.T) {
+	cons := &Consistency{
+		Requirement: &Consistency_MinimizeLatency{MinimizeLatency: true},
+	}
+	cons.Reset()
+	assert.Nil(t, cons.GetRequirement())
+	assert.False(t, cons.GetMinimizeLatency())
+}
+
+func TestConsistency_ProtoMessage(t *testing.T) {
+	var cons interface{} = &Consistency{}
+	_, ok := cons.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestConsistency_ProtoReflect(t *testing.T) {
+	cons := &Consistency{
+		Requirement: &Consistency_MinimizeLatency{MinimizeLatency: true},
+	}
+	m := cons.ProtoReflect()
+	assert.NotNil(t, m)
+	ci, ok := m.Interface().(*Consistency)
+	assert.True(t, ok)
+	assert.True(t, ci.GetMinimizeLatency())
+}
+
+func TestConsistency_JSONRoundTrip_Empty(t *testing.T) {
+	cons := &Consistency{}
+	data, err := json.Marshal(cons)
+	assert.NoError(t, err)
+
+	var out Consistency
+	assert.NoError(t, json.Unmarshal(data, &out))
+	assert.Nil(t, out.GetRequirement())
+}

--- a/api/kessel/inventory/v1beta2/consistency_token.pb_test.go
+++ b/api/kessel/inventory/v1beta2/consistency_token.pb_test.go
@@ -1,0 +1,70 @@
+package v1beta2
+
+import (
+	"encoding/json"
+	"google.golang.org/protobuf/proto"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConsistencyToken_GetToken(t *testing.T) {
+	ct := &ConsistencyToken{Token: "abc123"}
+	assert.Equal(t, "abc123", ct.GetToken())
+}
+
+func TestConsistencyToken_GetToken_Empty(t *testing.T) {
+	ct := &ConsistencyToken{}
+	assert.Equal(t, "", ct.GetToken())
+}
+
+func TestConsistencyToken_GetToken_NilStruct(t *testing.T) {
+	var ct *ConsistencyToken
+	assert.Equal(t, "", ct.GetToken())
+}
+
+func TestConsistencyToken_Reset(t *testing.T) {
+	ct := &ConsistencyToken{Token: "something"}
+	ct.Reset()
+	assert.Equal(t, "", ct.Token)
+}
+
+func TestConsistencyToken_String(t *testing.T) {
+	ct := &ConsistencyToken{Token: "foo"}
+	s := ct.String()
+	assert.NotEmpty(t, s)
+	assert.Contains(t, s, "foo")
+}
+
+func TestConsistencyToken_ProtoMessage(t *testing.T) {
+	var ct interface{} = &ConsistencyToken{}
+	_, ok := ct.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestConsistencyToken_ProtoReflect(t *testing.T) {
+	ct := &ConsistencyToken{Token: "foo"}
+	m := ct.ProtoReflect()
+	assert.NotNil(t, m)
+	assert.Equal(t, "foo", m.Interface().(*ConsistencyToken).GetToken())
+}
+
+func TestConsistencyToken_JSONRoundTrip(t *testing.T) {
+	ct := &ConsistencyToken{Token: "bar"}
+	b, err := json.Marshal(ct)
+	assert.NoError(t, err)
+
+	var out ConsistencyToken
+	assert.NoError(t, json.Unmarshal(b, &out))
+	assert.Equal(t, "bar", out.GetToken())
+}
+
+func TestConsistencyToken_JSONRoundTrip_Empty(t *testing.T) {
+	ct := &ConsistencyToken{}
+	b, err := json.Marshal(ct)
+	assert.NoError(t, err)
+
+	var out ConsistencyToken
+	assert.NoError(t, json.Unmarshal(b, &out))
+	assert.Equal(t, "", out.GetToken())
+}

--- a/api/kessel/inventory/v1beta2/delete_resource_request.pb_test.go
+++ b/api/kessel/inventory/v1beta2/delete_resource_request.pb_test.go
@@ -1,0 +1,122 @@
+package v1beta2_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test full DeleteResourceRequest with ReporterReference present
+func TestDeleteResourceRequest_Full(t *testing.T) {
+	req := &v1beta2.DeleteResourceRequest{
+		Reference: &v1beta2.ResourceReference{
+			ResourceType: "host",
+			ResourceId:   "host-123",
+			Reporter: &v1beta2.ReporterReference{
+				Type: "hbi",
+			},
+		},
+	}
+
+	data, err := json.Marshal(req)
+	assert.NoError(t, err)
+
+	var out v1beta2.DeleteResourceRequest
+	err = json.Unmarshal(data, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, "host", out.GetReference().GetResourceType())
+	assert.Equal(t, "host-123", out.GetReference().GetResourceId())
+	assert.Equal(t, "hbi", out.GetReference().GetReporter().GetType())
+}
+
+// Test minimal DeleteResourceRequest (no reporter)
+func TestDeleteResourceRequest_Minimal(t *testing.T) {
+	req := &v1beta2.DeleteResourceRequest{
+		Reference: &v1beta2.ResourceReference{
+			ResourceType: "k8s_cluster",
+			ResourceId:   "cluster-abc",
+		},
+	}
+
+	data, err := json.Marshal(req)
+	assert.NoError(t, err)
+
+	var out v1beta2.DeleteResourceRequest
+	err = json.Unmarshal(data, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, "k8s_cluster", out.GetReference().GetResourceType())
+	assert.Equal(t, "cluster-abc", out.GetReference().GetResourceId())
+	assert.Nil(t, out.GetReference().GetReporter())
+}
+
+// Test missing reference field
+func TestDeleteResourceRequest_MissingReference(t *testing.T) {
+	jsonData := `{}`
+
+	var out v1beta2.DeleteResourceRequest
+	err := json.Unmarshal([]byte(jsonData), &out)
+	assert.NoError(t, err)
+	assert.Nil(t, out.Reference)
+}
+
+// Negative test: reporter field is the wrong type
+func TestDeleteResourceRequest_InvalidReporterType(t *testing.T) {
+	jsonData := `{
+		"reference": {
+			"resource_type": "host",
+			"resource_id": "123",
+			"reporter": "should-be-object"
+		}
+	}`
+
+	var out v1beta2.DeleteResourceRequest
+	err := json.Unmarshal([]byte(jsonData), &out)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot unmarshal string into Go struct field")
+}
+
+// Negative test: resource_id is an integer instead of a string
+func TestDeleteResourceRequest_InvalidResourceIDType(t *testing.T) {
+	jsonData := `{
+		"reference": {
+			"resource_type": "host",
+			"resource_id": 42
+		}
+	}`
+
+	var out v1beta2.DeleteResourceRequest
+	err := json.Unmarshal([]byte(jsonData), &out)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot unmarshal number into Go struct field")
+}
+
+func TestDeleteResourceRequest_NilReferenceExplicit(t *testing.T) {
+	req := &v1beta2.DeleteResourceRequest{
+		Reference: nil,
+	}
+	data, err := json.Marshal(req)
+	assert.NoError(t, err)
+
+	var out v1beta2.DeleteResourceRequest
+	err = json.Unmarshal(data, &out)
+	assert.NoError(t, err)
+	assert.Nil(t, out.Reference)
+}
+
+func TestDeleteResourceRequest_ResetAndValidate(t *testing.T) {
+	req := &v1beta2.DeleteResourceRequest{
+		Reference: &v1beta2.ResourceReference{
+			ResourceType: "host",
+			ResourceId:   "host-123",
+		},
+	}
+
+	assert.NotNil(t, req.Reference)
+	assert.Equal(t, "host", req.Reference.ResourceType)
+	assert.Equal(t, "host-123", req.Reference.ResourceId)
+
+	req.Reset()
+	assert.Nil(t, req.Reference)
+}

--- a/api/kessel/inventory/v1beta2/delete_resource_request.pb_test.go
+++ b/api/kessel/inventory/v1beta2/delete_resource_request.pb_test.go
@@ -2,6 +2,7 @@ package v1beta2_test
 
 import (
 	"encoding/json"
+	"google.golang.org/protobuf/proto"
 	"testing"
 
 	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
@@ -119,4 +120,35 @@ func TestDeleteResourceRequest_ResetAndValidate(t *testing.T) {
 
 	req.Reset()
 	assert.Nil(t, req.Reference)
+}
+
+func TestDeleteResourceRequest_ProtoMessage(t *testing.T) {
+	var msg interface{} = &v1beta2.DeleteResourceRequest{}
+	_, ok := msg.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestDeleteResourceRequest_String(t *testing.T) {
+	req := &v1beta2.DeleteResourceRequest{
+		Reference: &v1beta2.ResourceReference{
+			ResourceType: "host",
+			ResourceId:   "host-123",
+		},
+	}
+	s := req.String()
+	assert.NotEmpty(t, s)
+	assert.Contains(t, s, "host-123")
+}
+
+func TestDeleteResourceRequest_String_Empty(t *testing.T) {
+	req := &v1beta2.DeleteResourceRequest{}
+	s := req.String()
+	assert.Equal(t, "", s)
+}
+
+func TestDeleteResourceRequest_ProtoReflect(t *testing.T) {
+	req := &v1beta2.DeleteResourceRequest{}
+	m := req.ProtoReflect()
+	assert.NotNil(t, m)
+	assert.Contains(t, m.Descriptor().Name(), "DeleteResourceRequest")
 }

--- a/api/kessel/inventory/v1beta2/delete_resource_response.pb_test.go
+++ b/api/kessel/inventory/v1beta2/delete_resource_response.pb_test.go
@@ -1,0 +1,28 @@
+package v1beta2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+// delete resource has an empty response anyway
+func TestDeleteResourceResponse_Reset(t *testing.T) {
+	resp := &DeleteResourceResponse{}
+	resp.Reset()
+	assert.True(t, proto.Equal(&DeleteResourceResponse{}, resp))
+}
+
+func TestDeleteResourceResponse_ProtoMessage(t *testing.T) {
+	var msg interface{} = &DeleteResourceResponse{}
+	_, ok := msg.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestDeleteResourceResponse_ProtoReflect(t *testing.T) {
+	resp := &DeleteResourceResponse{}
+	m := resp.ProtoReflect()
+	assert.NotNil(t, m)
+	assert.Equal(t, resp, m.Interface().(*DeleteResourceResponse))
+}

--- a/api/kessel/inventory/v1beta2/report_resource_request.pb_test.go
+++ b/api/kessel/inventory/v1beta2/report_resource_request.pb_test.go
@@ -1,0 +1,135 @@
+package v1beta2_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+	"github.com/stretchr/testify/assert"
+)
+
+func minimalResourceRepresentations() *v1beta2.ResourceRepresentations {
+	return &v1beta2.ResourceRepresentations{}
+}
+
+func TestReportResourceRequest_MarshalUnmarshalFull(t *testing.T) {
+	req := &v1beta2.ReportResourceRequest{
+		InventoryId:        strPtr("inv-123"),
+		Type:               "k8s_cluster",
+		ReporterType:       "acm",
+		ReporterInstanceId: "acm-1",
+		Representations:    minimalResourceRepresentations(),
+		WriteVisibility:    v1beta2.WriteVisibility_IMMEDIATE,
+	}
+	data, err := json.Marshal(req)
+	assert.NoError(t, err)
+
+	var out v1beta2.ReportResourceRequest
+	err = json.Unmarshal(data, &out)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "inv-123", out.GetInventoryId())
+	assert.Equal(t, "k8s_cluster", out.GetType())
+	assert.Equal(t, "acm", out.GetReporterType())
+	assert.Equal(t, "acm-1", out.GetReporterInstanceId())
+	assert.Equal(t, v1beta2.WriteVisibility_IMMEDIATE, out.GetWriteVisibility())
+	assert.NotNil(t, out.GetRepresentations())
+}
+
+func TestReportResourceRequest_Minimal(t *testing.T) {
+	req := &v1beta2.ReportResourceRequest{
+		Type:               "host",
+		ReporterType:       "hbi",
+		ReporterInstanceId: "hbi-1",
+		Representations:    minimalResourceRepresentations(),
+	}
+	data, err := json.Marshal(req)
+	assert.NoError(t, err)
+
+	var out v1beta2.ReportResourceRequest
+	err = json.Unmarshal(data, &out)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "", out.GetInventoryId())
+	assert.Equal(t, v1beta2.WriteVisibility_WRITE_VISIBILITY_UNSPECIFIED, out.GetWriteVisibility())
+	assert.Equal(t, "host", out.GetType())
+	assert.Equal(t, "hbi", out.GetReporterType())
+}
+
+func TestReportResourceRequest_MissingRepresentations(t *testing.T) {
+	req := &v1beta2.ReportResourceRequest{
+		Type:               "host",
+		ReporterType:       "hbi",
+		ReporterInstanceId: "hbi-1",
+	}
+	data, err := json.Marshal(req)
+	assert.NoError(t, err)
+
+	var out v1beta2.ReportResourceRequest
+	err = json.Unmarshal(data, &out)
+	assert.NoError(t, err)
+	assert.Nil(t, out.Representations)
+}
+
+func TestReportResourceRequest_InvalidWriteVisibility(t *testing.T) {
+	// Unknown enum should parse as zero value (unspecified)
+	jsonData := `{
+		"type": "host",
+		"reporter_type": "hbi",
+		"reporter_instance_id": "abc",
+		"write_visibility": 999
+	}`
+	var out v1beta2.ReportResourceRequest
+	err := json.Unmarshal([]byte(jsonData), &out)
+	assert.NoError(t, err)
+	assert.Equal(t, v1beta2.WriteVisibility(999), out.GetWriteVisibility())
+}
+
+func TestReportResourceRequest_UnknownFieldsIgnored(t *testing.T) {
+	jsonData := `{
+		"type": "host",
+		"reporter_type": "hbi",
+		"reporter_instance_id": "abc",
+		"unknown_field": "ignored"
+	}`
+	var out v1beta2.ReportResourceRequest
+	err := json.Unmarshal([]byte(jsonData), &out)
+	assert.NoError(t, err)
+	assert.Equal(t, "host", out.GetType())
+	assert.Equal(t, "hbi", out.GetReporterType())
+}
+
+func TestReportResourceRequest_InvalidType(t *testing.T) {
+	jsonData := `{
+		"type": 42,
+		"reporter_type": "hbi",
+		"reporter_instance_id": "abc"
+	}`
+	var out v1beta2.ReportResourceRequest
+	err := json.Unmarshal([]byte(jsonData), &out)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot unmarshal number")
+}
+
+func TestReportResourceRequest_Reset(t *testing.T) {
+	req := &v1beta2.ReportResourceRequest{
+		Type:               "host",
+		ReporterType:       "hbi",
+		ReporterInstanceId: "abc",
+	}
+	req.Reset()
+	assert.Equal(t, "", req.Type)
+	assert.Equal(t, "", req.ReporterType)
+	assert.Equal(t, "", req.ReporterInstanceId)
+}
+
+func TestReportResourceRequest_String(t *testing.T) {
+	req := &v1beta2.ReportResourceRequest{
+		Type: "host",
+	}
+	str := req.String()
+	assert.Contains(t, str, "host")
+}
+
+// Utility
+func strPtr(s string) *string { return &s }

--- a/api/kessel/inventory/v1beta2/report_resource_response.pb_test.go
+++ b/api/kessel/inventory/v1beta2/report_resource_response.pb_test.go
@@ -1,0 +1,33 @@
+package v1beta2
+
+import (
+	"google.golang.org/protobuf/proto"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReportResourceResponse_Reset(t *testing.T) {
+	resp := &ReportResourceResponse{}
+	resp.Reset()
+	assert.NotNil(t, resp)
+}
+
+func TestReportResourceResponse_ProtoMessage(t *testing.T) {
+	var resp interface{} = &ReportResourceResponse{}
+	_, ok := resp.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestReportResourceResponse_ProtoReflect(t *testing.T) {
+	resp := &ReportResourceResponse{}
+	m := resp.ProtoReflect()
+	assert.NotNil(t, m)
+	assert.Contains(t, "ReportResourceResponse", m.Descriptor().Name())
+}
+
+func TestReportResourceResponse_AllNil(t *testing.T) {
+	var resp *ReportResourceResponse
+	// resp is nil
+	assert.Nil(t, resp)
+}

--- a/api/kessel/inventory/v1beta2/reporter_reference.pb_test.go
+++ b/api/kessel/inventory/v1beta2/reporter_reference.pb_test.go
@@ -1,0 +1,59 @@
+package v1beta2_test
+
+import (
+	"testing"
+
+	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReporterReference_BasicFields(t *testing.T) {
+	instID := "hbi"
+	r := &v1beta2.ReporterReference{
+		Type:       "host",
+		InstanceId: &instID,
+	}
+
+	assert.Equal(t, "host", r.GetType())
+	assert.Equal(t, "hbi", r.GetInstanceId())
+}
+
+func TestReporterReference_NilInstanceId(t *testing.T) {
+	r := &v1beta2.ReporterReference{
+		Type: "k8s_policy",
+	}
+	assert.Equal(t, "k8s_policy", r.GetType())
+	assert.Equal(t, "", r.GetInstanceId())
+}
+
+func TestReporterReference_ResetAndFields(t *testing.T) {
+	instID := "hello"
+	r := &v1beta2.ReporterReference{
+		Type:       "test",
+		InstanceId: &instID,
+	}
+
+	assert.Equal(t, "test", r.GetType())
+	assert.Equal(t, "hello", r.GetInstanceId())
+
+	r.Reset()
+	assert.Equal(t, "", r.Type)
+	assert.Nil(t, r.InstanceId)
+}
+
+func TestReporterReference_Methods(t *testing.T) {
+	instID := "xyz"
+	r := &v1beta2.ReporterReference{
+		Type:       "reporter",
+		InstanceId: &instID,
+	}
+
+	// String method
+	s := r.String()
+	assert.Contains(t, s, "reporter")
+
+	// ProtoMessage, ProtoReflect, Descriptor: just call them for coverage
+	r.ProtoMessage()
+	_ = r.ProtoReflect()
+	_, _ = r.Descriptor()
+}

--- a/api/kessel/inventory/v1beta2/representation_metadata.pb_test.go
+++ b/api/kessel/inventory/v1beta2/representation_metadata.pb_test.go
@@ -1,0 +1,74 @@
+package v1beta2_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepresentationMetadata_Getters(t *testing.T) {
+	consoleHref := "https://console.example.com"
+	reporterVersion := "v1.0.1"
+
+	meta := &v1beta2.RepresentationMetadata{
+		LocalResourceId: "abc-123",
+		ApiHref:         "https://api.example.com/resource/abc-123",
+		ConsoleHref:     &consoleHref,
+		ReporterVersion: &reporterVersion,
+	}
+
+	assert.Equal(t, "abc-123", meta.GetLocalResourceId())
+	assert.Equal(t, "https://api.example.com/resource/abc-123", meta.GetApiHref())
+	assert.Equal(t, "https://console.example.com", meta.GetConsoleHref())
+	assert.Equal(t, "v1.0.1", meta.GetReporterVersion())
+}
+
+func TestRepresentationMetadata_Getters_NilOptionals(t *testing.T) {
+	meta := &v1beta2.RepresentationMetadata{
+		LocalResourceId: "xyz-789",
+		ApiHref:         "https://api.example.com/resource/xyz-789",
+	}
+
+	assert.Equal(t, "", meta.GetConsoleHref(), "Expected empty string for nil ConsoleHref")
+	assert.Equal(t, "", meta.GetReporterVersion(), "Expected empty string for nil ReporterVersion")
+}
+
+func TestRepresentationMetadata_InvalidJSON_Unmarshal(t *testing.T) {
+	invalidJSON := `{"local_resource_id": "bad-id", "api_href": 123}` // api_href should be a string
+
+	var meta v1beta2.RepresentationMetadata
+	err := json.Unmarshal([]byte(invalidJSON), &meta)
+
+	assert.Error(t, err, "Expected error when unmarshalling invalid JSON types")
+}
+
+func TestRepresentationMetadata_EmptyJSON_Unmarshal(t *testing.T) {
+	emptyJSON := `{}`
+
+	var meta v1beta2.RepresentationMetadata
+	err := json.Unmarshal([]byte(emptyJSON), &meta)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "", meta.GetLocalResourceId())
+	assert.Equal(t, "", meta.GetApiHref())
+	assert.Equal(t, "", meta.GetConsoleHref())
+	assert.Equal(t, "", meta.GetReporterVersion())
+}
+
+func TestRepresentationMetadata_PartialFields(t *testing.T) {
+	jsonData := `{
+		"local_resource_id": "partial-id",
+		"console_href": "https://console.partial"
+	}`
+
+	var meta v1beta2.RepresentationMetadata
+	err := json.Unmarshal([]byte(jsonData), &meta)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "partial-id", meta.GetLocalResourceId())
+	assert.Equal(t, "", meta.GetApiHref())
+	assert.Equal(t, "https://console.partial", meta.GetConsoleHref())
+	assert.Equal(t, "", meta.GetReporterVersion())
+}

--- a/api/kessel/inventory/v1beta2/representation_type.pb_test.go
+++ b/api/kessel/inventory/v1beta2/representation_type.pb_test.go
@@ -1,0 +1,100 @@
+package v1beta2
+
+import (
+	"encoding/json"
+	"google.golang.org/protobuf/proto"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepresentationType_GetResourceType(t *testing.T) {
+	rt := &RepresentationType{ResourceType: "host"}
+	assert.Equal(t, "host", rt.GetResourceType())
+
+	rtNil := (*RepresentationType)(nil)
+	assert.Equal(t, "", rtNil.GetResourceType())
+}
+
+func TestRepresentationType_GetReporterType(t *testing.T) {
+	reporter := "hbi"
+	rt := &RepresentationType{ReporterType: &reporter}
+	assert.Equal(t, "hbi", rt.GetReporterType())
+
+	rtNoReporter := &RepresentationType{}
+	assert.Equal(t, "", rtNoReporter.GetReporterType())
+
+	rtNil := (*RepresentationType)(nil)
+	assert.Equal(t, "", rtNil.GetReporterType())
+}
+
+func TestRepresentationType_Reset(t *testing.T) {
+	reporter := "hbi"
+	rt := &RepresentationType{
+		ResourceType: "host",
+		ReporterType: &reporter,
+	}
+	rt.Reset()
+	assert.Equal(t, "", rt.GetResourceType())
+	assert.Equal(t, "", rt.GetReporterType())
+}
+
+func TestRepresentationType_String(t *testing.T) {
+	reporter := "hbi"
+	rt := &RepresentationType{
+		ResourceType: "host",
+		ReporterType: &reporter,
+	}
+	s := rt.String()
+	assert.NotEmpty(t, s)
+	assert.Contains(t, s, "host")
+	assert.Contains(t, s, "hbi")
+}
+
+func TestRepresentationType_ProtoMessage(t *testing.T) {
+	var rt interface{} = &RepresentationType{}
+	_, ok := rt.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestRepresentationType_ProtoReflect(t *testing.T) {
+	reporter := "hbi"
+	rt := &RepresentationType{ResourceType: "host", ReporterType: &reporter}
+	m := rt.ProtoReflect()
+	assert.NotNil(t, m)
+	assert.Equal(t, "host", m.Interface().(*RepresentationType).GetResourceType())
+}
+
+func TestRepresentationType_JSONRoundTrip(t *testing.T) {
+	reporter := "hbi"
+	rt := &RepresentationType{
+		ResourceType: "host",
+		ReporterType: &reporter,
+	}
+	b, err := json.Marshal(rt)
+	assert.NoError(t, err)
+
+	var out RepresentationType
+	assert.NoError(t, json.Unmarshal(b, &out))
+	assert.Equal(t, "host", out.GetResourceType())
+	assert.Equal(t, "hbi", out.GetReporterType())
+}
+
+func TestRepresentationType_JSONRoundTrip_NoReporter(t *testing.T) {
+	rt := &RepresentationType{
+		ResourceType: "host",
+	}
+	b, err := json.Marshal(rt)
+	assert.NoError(t, err)
+
+	var out RepresentationType
+	assert.NoError(t, json.Unmarshal(b, &out))
+	assert.Equal(t, "host", out.GetResourceType())
+	assert.Equal(t, "", out.GetReporterType())
+}
+
+func TestRepresentationType_AllNil(t *testing.T) {
+	var rt *RepresentationType
+	assert.Equal(t, "", rt.GetResourceType())
+	assert.Equal(t, "", rt.GetReporterType())
+}

--- a/api/kessel/inventory/v1beta2/request_pagination.pb_test.go
+++ b/api/kessel/inventory/v1beta2/request_pagination.pb_test.go
@@ -1,0 +1,100 @@
+package v1beta2
+
+import (
+	"encoding/json"
+	"google.golang.org/protobuf/proto"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestPagination_GetLimit(t *testing.T) {
+	rp := &RequestPagination{Limit: 25}
+	assert.Equal(t, uint32(25), rp.GetLimit())
+
+	var rpNil *RequestPagination
+	assert.Equal(t, uint32(0), rpNil.GetLimit())
+}
+
+func TestRequestPagination_GetContinuationToken(t *testing.T) {
+	token := "abc123"
+	rp := &RequestPagination{ContinuationToken: &token}
+	assert.Equal(t, "abc123", rp.GetContinuationToken())
+
+	rpEmpty := &RequestPagination{}
+	assert.Equal(t, "", rpEmpty.GetContinuationToken())
+
+	var rpNil *RequestPagination
+	assert.Equal(t, "", rpNil.GetContinuationToken())
+}
+
+func TestRequestPagination_Reset(t *testing.T) {
+	token := "token"
+	rp := &RequestPagination{
+		Limit:             42,
+		ContinuationToken: &token,
+	}
+	rp.Reset()
+	assert.Equal(t, uint32(0), rp.GetLimit())
+	assert.Equal(t, "", rp.GetContinuationToken())
+}
+
+func TestRequestPagination_String(t *testing.T) {
+	token := "tkn"
+	rp := &RequestPagination{
+		Limit:             77,
+		ContinuationToken: &token,
+	}
+	s := rp.String()
+	assert.NotEmpty(t, s)
+	assert.Contains(t, s, "77")
+	assert.Contains(t, s, "tkn")
+}
+
+func TestRequestPagination_ProtoMessage(t *testing.T) {
+	var rp interface{} = &RequestPagination{}
+	_, ok := rp.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestRequestPagination_ProtoReflect(t *testing.T) {
+	token := "t"
+	rp := &RequestPagination{Limit: 1, ContinuationToken: &token}
+	m := rp.ProtoReflect()
+	assert.NotNil(t, m)
+	assert.Equal(t, uint32(1), m.Interface().(*RequestPagination).GetLimit())
+}
+
+func TestRequestPagination_JSONRoundTrip(t *testing.T) {
+	token := "page-3"
+	rp := &RequestPagination{
+		Limit:             10,
+		ContinuationToken: &token,
+	}
+	b, err := json.Marshal(rp)
+	assert.NoError(t, err)
+
+	var out RequestPagination
+	assert.NoError(t, json.Unmarshal(b, &out))
+	assert.Equal(t, uint32(10), out.GetLimit())
+	assert.Equal(t, "page-3", out.GetContinuationToken())
+}
+
+func TestRequestPagination_JSONRoundTrip_EmptyToken(t *testing.T) {
+	rp := &RequestPagination{
+		Limit: 99,
+	}
+	b, err := json.Marshal(rp)
+	assert.NoError(t, err)
+
+	var out RequestPagination
+	assert.NoError(t, json.Unmarshal(b, &out))
+	assert.Equal(t, uint32(99), out.GetLimit())
+	assert.Equal(t, "", out.GetContinuationToken())
+}
+
+func TestRequestPagination_AllNil(t *testing.T) {
+	var rp *RequestPagination
+	assert.Equal(t, uint32(0), rp.GetLimit())
+	assert.Equal(t, "", rp.GetContinuationToken())
+}

--- a/api/kessel/inventory/v1beta2/resource.pb_test.go
+++ b/api/kessel/inventory/v1beta2/resource.pb_test.go
@@ -137,8 +137,6 @@ func TestResourceValidation(t *testing.T) {
 					Metadata: &RepresentationMetadata{
 						LocalResourceId: "cluster-123",
 						ApiHref:         "https://api.example.com",
-						ConsoleHref:     proto.String("https://console.example.com"),
-						ReporterVersion: proto.String("1.0.0"),
 					},
 					Common: &structpb.Struct{
 						Fields: map[string]*structpb.Value{
@@ -420,4 +418,61 @@ func TestDeleteResourceValidation(t *testing.T) {
 	}
 
 	t.Logf("Passed Tests: %d / %d", len(tests)-failedTests, len(tests))
+}
+
+func TestResource_Populated(t *testing.T) {
+	invID := "abc-123"
+	reps := &ResourceRepresentations{}
+	res := &Resource{
+		InventoryId:        &invID,
+		Type:               "host",
+		ReporterType:       "some_reporter",
+		ReporterInstanceId: "riid-001",
+		Representations:    reps,
+	}
+	assert.Equal(t, invID, res.GetInventoryId())
+	assert.Equal(t, "host", res.GetType())
+	assert.Equal(t, "some_reporter", res.GetReporterType())
+	assert.Equal(t, "riid-001", res.GetReporterInstanceId())
+	assert.Equal(t, reps, res.GetRepresentations())
+}
+
+func TestResource_Reset(t *testing.T) {
+	invID := "reset"
+	res := &Resource{
+		InventoryId:        &invID,
+		Type:               "host",
+		ReporterType:       "hbi",
+		ReporterInstanceId: "reset-01",
+		Representations:    &ResourceRepresentations{},
+	}
+	res.Reset()
+	// After Reset, all fields should be zero/nil
+	assert.Equal(t, "", res.GetInventoryId())
+	assert.Equal(t, "", res.GetType())
+	assert.Equal(t, "", res.GetReporterType())
+	assert.Equal(t, "", res.GetReporterInstanceId())
+	assert.Nil(t, res.GetRepresentations())
+}
+
+func TestResource_String(t *testing.T) {
+	res := &Resource{Type: "foobar"}
+	s := res.String()
+	assert.NotEmpty(t, s)
+	assert.Contains(t, s, "foobar")
+}
+
+func TestResource_ProtoMessage(t *testing.T) {
+	var res interface{} = &Resource{}
+	_, ok := res.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestResource_ProtoReflect(t *testing.T) {
+	res := &Resource{Type: "reflect-test"}
+	m := res.ProtoReflect()
+	assert.NotNil(t, m)
+	// Check that the returned message interface matches expectations
+	iface := m.Interface().(*Resource)
+	assert.Equal(t, "reflect-test", iface.GetType())
 }

--- a/api/kessel/inventory/v1beta2/resource_reference.pb_test.go
+++ b/api/kessel/inventory/v1beta2/resource_reference.pb_test.go
@@ -2,6 +2,7 @@ package v1beta2_test
 
 import (
 	"encoding/json"
+	"google.golang.org/protobuf/proto"
 	"testing"
 
 	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
@@ -77,4 +78,33 @@ func TestResourceReference_Empty(t *testing.T) {
 	assert.Empty(t, ref.ResourceType)
 	assert.Empty(t, ref.ResourceId)
 	assert.Nil(t, ref.Reporter)
+}
+
+func TestResourceReference_Reset(t *testing.T) {
+	ref := &v1beta2.ResourceReference{
+		ResourceType: "host",
+		ResourceId:   "host-99",
+		Reporter:     &v1beta2.ReporterReference{Type: "foo"},
+	}
+
+	assert.Equal(t, "host", ref.ResourceType)
+	assert.Equal(t, "host-99", ref.ResourceId)
+	assert.NotNil(t, ref.Reporter)
+
+	refString1 := ref.String()
+	assert.Contains(t, refString1, "host-99")
+
+	ref.Reset()
+	assert.Empty(t, ref.ResourceType)
+	assert.Empty(t, ref.ResourceId)
+	assert.Nil(t, ref.Reporter)
+
+	refString2 := ref.String()
+	assert.Contains(t, refString2, "")
+}
+
+func TestResourceReference_ProtoMessage(t *testing.T) {
+	var ref interface{} = &v1beta2.ResourceReference{}
+	_, ok := ref.(proto.Message)
+	assert.True(t, ok)
 }

--- a/api/kessel/inventory/v1beta2/resource_reference.pb_test.go
+++ b/api/kessel/inventory/v1beta2/resource_reference.pb_test.go
@@ -1,0 +1,80 @@
+package v1beta2_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test successful marshal/unmarshal round-trip with all fields.
+func TestResourceReference_Full(t *testing.T) {
+	ref := &v1beta2.ResourceReference{
+		ResourceType: "host",
+		ResourceId:   "123",
+		Reporter: &v1beta2.ReporterReference{
+			Type: "hbi",
+		},
+	}
+
+	data, err := json.Marshal(ref)
+	assert.NoError(t, err)
+
+	var out v1beta2.ResourceReference
+	err = json.Unmarshal(data, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, "host", out.ResourceType)
+	assert.Equal(t, "123", out.ResourceId)
+	assert.NotNil(t, out.Reporter)
+	assert.Equal(t, "hbi", out.Reporter.Type)
+}
+
+// Test with only required fields (no reporter).
+func TestResourceReference_Minimal(t *testing.T) {
+	ref := &v1beta2.ResourceReference{
+		ResourceType: "k8s_cluster",
+		ResourceId:   "cluster-001",
+	}
+
+	data, err := json.Marshal(ref)
+	assert.NoError(t, err)
+
+	var out v1beta2.ResourceReference
+	err = json.Unmarshal(data, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, "k8s_cluster", out.ResourceType)
+	assert.Equal(t, "cluster-001", out.ResourceId)
+	assert.Nil(t, out.Reporter)
+}
+
+// Test invalid JSON: resource_id is missing
+func TestResourceReference_MissingResourceID(t *testing.T) {
+	jsonData := `{"resource_type": "host"}`
+	var ref v1beta2.ResourceReference
+	err := json.Unmarshal([]byte(jsonData), &ref)
+	assert.NoError(t, err) // Unmarshal will succeed, but validation will fail elsewhere
+	assert.Equal(t, "host", ref.ResourceType)
+	assert.Empty(t, ref.ResourceId)
+}
+
+// Test invalid JSON type: reporter should be an object, not a string
+func TestResourceReference_InvalidReporterType(t *testing.T) {
+	jsonData := `{
+		"resource_type": "host",
+		"resource_id": "abc",
+		"reporter": "should-be-an-object"
+	}`
+	var ref v1beta2.ResourceReference
+	err := json.Unmarshal([]byte(jsonData), &ref)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot unmarshal string into Go struct field")
+}
+
+// Test empty object
+func TestResourceReference_Empty(t *testing.T) {
+	var ref v1beta2.ResourceReference
+	assert.Empty(t, ref.ResourceType)
+	assert.Empty(t, ref.ResourceId)
+	assert.Nil(t, ref.Reporter)
+}

--- a/api/kessel/inventory/v1beta2/resource_representations.pb_test.go
+++ b/api/kessel/inventory/v1beta2/resource_representations.pb_test.go
@@ -2,6 +2,7 @@ package v1beta2_test
 
 import (
 	"encoding/json"
+	"google.golang.org/protobuf/proto"
 	"testing"
 
 	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
@@ -65,4 +66,48 @@ func TestResourceRepresentations_InvalidJSON(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot unmarshal number into Go struct field")
+}
+
+func TestResourceRepresentations_Reset(t *testing.T) {
+	commonStruct, _ := structpb.NewStruct(map[string]interface{}{"workspace_id": "1"})
+	reporterStruct, _ := structpb.NewStruct(map[string]interface{}{"satellite_id": "2"})
+	rr := &v1beta2.ResourceRepresentations{
+		Metadata: &v1beta2.RepresentationMetadata{
+			LocalResourceId: "some-id",
+			ApiHref:         "some-url",
+		},
+		Common:   commonStruct,
+		Reporter: reporterStruct,
+	}
+
+	assert.NotNil(t, rr.Metadata)
+	assert.NotNil(t, rr.Common)
+	assert.NotNil(t, rr.Reporter)
+
+	rrString1 := rr.String()
+	assert.Contains(t, rrString1, "some-id")
+
+	rr.Reset()
+	assert.Nil(t, rr.Metadata)
+	assert.Nil(t, rr.Common)
+	assert.Nil(t, rr.Reporter)
+
+	rrString2 := rr.String()
+
+	assert.Empty(t, rrString2)
+	assert.NotContains(t, rrString2, "some-id")
+
+}
+
+func TestResourceRepresentations_ProtoMessage(t *testing.T) {
+	var rr interface{} = &v1beta2.ResourceRepresentations{}
+	_, ok := rr.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestResourceRepresentations_ProtoReflect(t *testing.T) {
+	rr := &v1beta2.ResourceRepresentations{}
+	m := rr.ProtoReflect()
+	assert.NotNil(t, m)
+	assert.Equal(t, "ResourceRepresentations", string(m.Descriptor().Name()))
 }

--- a/api/kessel/inventory/v1beta2/resource_representations.pb_test.go
+++ b/api/kessel/inventory/v1beta2/resource_representations.pb_test.go
@@ -1,0 +1,68 @@
+package v1beta2_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// common and reporter representation data is tested for validity in the middleware layer;
+// At the API layer these can be invalid but will be caught later on.
+
+func TestResourceRepresentations_MarshalUnmarshalJSON(t *testing.T) {
+	commonStruct, _ := structpb.NewStruct(map[string]interface{}{"workspace_id": "1"})
+	reporterStruct, _ := structpb.NewStruct(map[string]interface{}{"satellite_id": "2"})
+
+	original := &v1beta2.ResourceRepresentations{
+		Metadata: &v1beta2.RepresentationMetadata{
+			LocalResourceId: "host-123",
+			ApiHref:         "www.host-123.com",
+		},
+		Common:   commonStruct,
+		Reporter: reporterStruct,
+	}
+
+	data, err := json.Marshal(original)
+	assert.NoError(t, err)
+
+	var decoded v1beta2.ResourceRepresentations
+	err = json.Unmarshal(data, &decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, "host-123", decoded.GetMetadata().GetLocalResourceId())
+	assert.Equal(t, "www.host-123.com", decoded.GetMetadata().GetApiHref())
+	assert.Equal(t, "1", decoded.GetCommon().Fields["workspace_id"].GetStringValue())
+	assert.Equal(t, "2", decoded.GetReporter().Fields["satellite_id"].GetStringValue())
+}
+
+func TestResourceRepresentations_MissingMetadata(t *testing.T) {
+	jsonData := `{
+		"common": {"workspace_id": "3"},
+		"reporter": {"satellite_id": "4"}
+	}`
+
+	var rr v1beta2.ResourceRepresentations
+	err := json.Unmarshal([]byte(jsonData), &rr)
+	assert.NoError(t, err)
+
+	assert.Nil(t, rr.Metadata)
+	assert.Equal(t, "3", rr.GetCommon().Fields["workspace_id"].GetStringValue())
+}
+
+func TestResourceRepresentations_InvalidJSON(t *testing.T) {
+	invalidJSON := `{
+		"metadata": {
+			"local_resource_id": 1,
+			"api_href": "www.bad-local-resource-id.com"
+		},
+		"common": {"workspace_id": "2"}
+	}`
+
+	var rr v1beta2.ResourceRepresentations
+	err := json.Unmarshal([]byte(invalidJSON), &rr)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot unmarshal number into Go struct field")
+}

--- a/api/kessel/inventory/v1beta2/response_pagination.pb_test.go
+++ b/api/kessel/inventory/v1beta2/response_pagination.pb_test.go
@@ -1,0 +1,60 @@
+package v1beta2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestResponsePagination_GetContinuationToken_NonEmpty(t *testing.T) {
+	rp := &ResponsePagination{ContinuationToken: "foobar"}
+	assert.Equal(t, "foobar", rp.GetContinuationToken())
+}
+
+func TestResponsePagination_GetContinuationToken_Empty(t *testing.T) {
+	rp := &ResponsePagination{}
+	assert.Equal(t, "", rp.GetContinuationToken())
+}
+
+func TestResponsePagination_Reset(t *testing.T) {
+	rp := &ResponsePagination{ContinuationToken: "abc"}
+	rp.Reset()
+	assert.Equal(t, "", rp.ContinuationToken)
+}
+
+func TestResponsePagination_String(t *testing.T) {
+	rp := &ResponsePagination{ContinuationToken: "token"}
+	s := rp.String()
+	assert.NotEmpty(t, s)
+	assert.Contains(t, s, "token")
+}
+
+func TestResponsePagination_ProtoMessage(t *testing.T) {
+	var msg interface{} = &ResponsePagination{}
+	_, ok := msg.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestResponsePagination_ProtoReflect(t *testing.T) {
+	rp := &ResponsePagination{ContinuationToken: "foo"}
+	m := rp.ProtoReflect()
+	assert.NotNil(t, m)
+	assert.Equal(t, "foo", m.Interface().(*ResponsePagination).GetContinuationToken())
+}
+
+func TestResponsePagination_JSONRoundTrip(t *testing.T) {
+	rp := &ResponsePagination{ContinuationToken: "json-token"}
+	b, err := json.Marshal(rp)
+	assert.NoError(t, err)
+
+	var out ResponsePagination
+	assert.NoError(t, json.Unmarshal(b, &out))
+	assert.Equal(t, "json-token", out.GetContinuationToken())
+}
+
+func TestResponsePagination_AllNil(t *testing.T) {
+	var rp *ResponsePagination
+	assert.Equal(t, "", rp.GetContinuationToken())
+}

--- a/api/kessel/inventory/v1beta2/streamed_list_objects_request.pb_test.go
+++ b/api/kessel/inventory/v1beta2/streamed_list_objects_request.pb_test.go
@@ -1,0 +1,119 @@
+package v1beta2
+
+import (
+	"encoding/json"
+	"google.golang.org/protobuf/proto"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStreamedListObjectsRequest_Getters(t *testing.T) {
+	typ := &RepresentationType{ResourceType: "host"}
+	subject := &SubjectReference{}
+	pagination := &RequestPagination{Limit: 10}
+	consistency := &Consistency{}
+	req := &StreamedListObjectsRequest{
+		ObjectType:  typ,
+		Relation:    "view",
+		Subject:     subject,
+		Pagination:  pagination,
+		Consistency: consistency,
+	}
+	assert.Equal(t, typ, req.GetObjectType())
+	assert.Equal(t, "view", req.GetRelation())
+	assert.Equal(t, subject, req.GetSubject())
+	assert.Equal(t, pagination, req.GetPagination())
+	assert.Equal(t, consistency, req.GetConsistency())
+
+	// nil receiver
+	var reqNil *StreamedListObjectsRequest
+	assert.Nil(t, reqNil.GetObjectType())
+	assert.Equal(t, "", reqNil.GetRelation())
+	assert.Nil(t, reqNil.GetSubject())
+	assert.Nil(t, reqNil.GetPagination())
+	assert.Nil(t, reqNil.GetConsistency())
+}
+
+func TestStreamedListObjectsRequest_Reset(t *testing.T) {
+	typ := &RepresentationType{ResourceType: "host"}
+	subject := &SubjectReference{}
+	pagination := &RequestPagination{Limit: 99}
+	consistency := &Consistency{}
+	req := &StreamedListObjectsRequest{
+		ObjectType:  typ,
+		Relation:    "view",
+		Subject:     subject,
+		Pagination:  pagination,
+		Consistency: consistency,
+	}
+	req.Reset()
+	assert.Nil(t, req.GetObjectType())
+	assert.Equal(t, "", req.GetRelation())
+	assert.Nil(t, req.GetSubject())
+	assert.Nil(t, req.GetPagination())
+	assert.Nil(t, req.GetConsistency())
+}
+
+func TestStreamedListObjectsRequest_String(t *testing.T) {
+	typ := &RepresentationType{ResourceType: "host"}
+	subject := &SubjectReference{}
+	req := &StreamedListObjectsRequest{
+		ObjectType: typ,
+		Relation:   "view",
+		Subject:    subject,
+	}
+	s := req.String()
+	assert.NotEmpty(t, s)
+	assert.Contains(t, s, "host")
+	assert.Contains(t, s, "view")
+}
+
+func TestStreamedListObjectsRequest_ProtoMessage(t *testing.T) {
+	var req interface{} = &StreamedListObjectsRequest{}
+	_, ok := req.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestStreamedListObjectsRequest_ProtoReflect(t *testing.T) {
+	typ := &RepresentationType{ResourceType: "host"}
+	req := &StreamedListObjectsRequest{ObjectType: typ, Relation: "view"}
+	m := req.ProtoReflect()
+	assert.NotNil(t, m)
+	assert.Equal(t, "view", m.Interface().(*StreamedListObjectsRequest).GetRelation())
+}
+
+func TestStreamedListObjectsRequest_JSONRoundTrip_Full(t *testing.T) {
+	token := "t"
+	req := &StreamedListObjectsRequest{
+		ObjectType:  &RepresentationType{ResourceType: "host", ReporterType: &token},
+		Relation:    "view",
+		Subject:     &SubjectReference{},
+		Pagination:  &RequestPagination{Limit: 77, ContinuationToken: &token},
+		Consistency: &Consistency{},
+	}
+	b, err := json.Marshal(req)
+	assert.NoError(t, err)
+	var out StreamedListObjectsRequest
+	assert.NoError(t, json.Unmarshal(b, &out))
+	assert.Equal(t, "host", out.GetObjectType().GetResourceType())
+	assert.Equal(t, "view", out.GetRelation())
+	assert.NotNil(t, out.GetSubject())
+	assert.NotNil(t, out.GetPagination())
+	assert.NotNil(t, out.GetConsistency())
+}
+
+func TestStreamedListObjectsRequest_JSONRoundTrip_NilFields(t *testing.T) {
+	req := &StreamedListObjectsRequest{
+		Relation: "write",
+	}
+	b, err := json.Marshal(req)
+	assert.NoError(t, err)
+	var out StreamedListObjectsRequest
+	assert.NoError(t, json.Unmarshal(b, &out))
+	assert.Equal(t, "write", out.GetRelation())
+	assert.Nil(t, out.GetObjectType())
+	assert.Nil(t, out.GetSubject())
+	assert.Nil(t, out.GetPagination())
+	assert.Nil(t, out.GetConsistency())
+}

--- a/api/kessel/inventory/v1beta2/streamed_list_objects_response.pb_test.go
+++ b/api/kessel/inventory/v1beta2/streamed_list_objects_response.pb_test.go
@@ -1,0 +1,106 @@
+package v1beta2
+
+import (
+	"encoding/json"
+	"google.golang.org/protobuf/proto"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStreamedListObjectsResponse_Getters(t *testing.T) {
+	obj := &ResourceReference{ResourceType: "host", ResourceId: "123"}
+	pagination := &ResponsePagination{ContinuationToken: "abc"}
+	consistencyToken := &ConsistencyToken{Token: "zzz"}
+	resp := &StreamedListObjectsResponse{
+		Object:           obj,
+		Pagination:       pagination,
+		ConsistencyToken: consistencyToken,
+	}
+	assert.Equal(t, obj, resp.GetObject())
+	assert.Equal(t, pagination, resp.GetPagination())
+	assert.Equal(t, consistencyToken, resp.GetConsistencyToken())
+
+	// nil receiver
+	var respNil *StreamedListObjectsResponse
+	assert.Nil(t, respNil.GetObject())
+	assert.Nil(t, respNil.GetPagination())
+	assert.Nil(t, respNil.GetConsistencyToken())
+}
+
+func TestStreamedListObjectsResponse_Reset(t *testing.T) {
+	obj := &ResourceReference{ResourceType: "host"}
+	pagination := &ResponsePagination{ContinuationToken: "abc"}
+	consistencyToken := &ConsistencyToken{Token: "a"}
+	resp := &StreamedListObjectsResponse{
+		Object:           obj,
+		Pagination:       pagination,
+		ConsistencyToken: consistencyToken,
+	}
+	resp.Reset()
+	assert.Nil(t, resp.GetObject())
+	assert.Nil(t, resp.GetPagination())
+	assert.Nil(t, resp.GetConsistencyToken())
+}
+
+func TestStreamedListObjectsResponse_String(t *testing.T) {
+	obj := &ResourceReference{ResourceType: "host"}
+	resp := &StreamedListObjectsResponse{Object: obj}
+	s := resp.String()
+	assert.NotEmpty(t, s)
+	assert.Contains(t, s, "host")
+}
+
+func TestStreamedListObjectsResponse_ProtoMessage(t *testing.T) {
+	var resp interface{} = &StreamedListObjectsResponse{}
+	_, ok := resp.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestStreamedListObjectsResponse_ProtoReflect(t *testing.T) {
+	obj := &ResourceReference{ResourceType: "host"}
+	resp := &StreamedListObjectsResponse{Object: obj}
+	m := resp.ProtoReflect()
+	assert.NotNil(t, m)
+	assert.Equal(t, "host", m.Interface().(*StreamedListObjectsResponse).GetObject().GetResourceType())
+}
+
+func TestStreamedListObjectsResponse_JSONRoundTrip_Full(t *testing.T) {
+	obj := &ResourceReference{ResourceType: "host", ResourceId: "123"}
+	pagination := &ResponsePagination{ContinuationToken: "def"}
+	consistencyToken := &ConsistencyToken{Token: "token"}
+	resp := &StreamedListObjectsResponse{
+		Object:           obj,
+		Pagination:       pagination,
+		ConsistencyToken: consistencyToken,
+	}
+	b, err := json.Marshal(resp)
+	assert.NoError(t, err)
+	var out StreamedListObjectsResponse
+	assert.NoError(t, json.Unmarshal(b, &out))
+	assert.NotNil(t, out.GetObject())
+	assert.Equal(t, "host", out.GetObject().GetResourceType())
+	assert.Equal(t, "123", out.GetObject().GetResourceId())
+	assert.NotNil(t, out.GetPagination())
+	assert.Equal(t, "def", out.GetPagination().ContinuationToken)
+	assert.NotNil(t, out.GetConsistencyToken())
+	assert.Equal(t, "token", out.GetConsistencyToken().GetToken())
+}
+
+func TestStreamedListObjectsResponse_JSONRoundTrip_NilFields(t *testing.T) {
+	resp := &StreamedListObjectsResponse{}
+	b, err := json.Marshal(resp)
+	assert.NoError(t, err)
+	var out StreamedListObjectsResponse
+	assert.NoError(t, json.Unmarshal(b, &out))
+	assert.Nil(t, out.GetObject())
+	assert.Nil(t, out.GetPagination())
+	assert.Nil(t, out.GetConsistencyToken())
+}
+
+func TestStreamedListObjectsResponse_AllNil(t *testing.T) {
+	var resp *StreamedListObjectsResponse
+	assert.Nil(t, resp.GetObject())
+	assert.Nil(t, resp.GetPagination())
+	assert.Nil(t, resp.GetConsistencyToken())
+}

--- a/api/kessel/inventory/v1beta2/subject_reference.pb_test.go
+++ b/api/kessel/inventory/v1beta2/subject_reference.pb_test.go
@@ -1,0 +1,106 @@
+package v1beta2
+
+import (
+	"encoding/json"
+	"google.golang.org/protobuf/proto"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubjectReference_GetRelation_WithRelation(t *testing.T) {
+	val := "view"
+	sr := &SubjectReference{Relation: &val}
+	assert.Equal(t, "view", sr.GetRelation())
+}
+
+func TestSubjectReference_GetRelation_NilRelation(t *testing.T) {
+	sr := &SubjectReference{}
+	assert.Equal(t, "", sr.GetRelation())
+}
+
+func TestSubjectReference_GetResource_NonNil(t *testing.T) {
+	sr := &SubjectReference{
+		Resource: &ResourceReference{ResourceType: "principal", ResourceId: "sarah"},
+	}
+	assert.NotNil(t, sr.GetResource())
+	assert.Equal(t, "principal", sr.GetResource().ResourceType)
+}
+
+func TestSubjectReference_GetResource_Nil(t *testing.T) {
+	sr := &SubjectReference{}
+	assert.Nil(t, sr.GetResource())
+}
+
+func TestSubjectReference_Reset(t *testing.T) {
+	val := "view"
+	sr := &SubjectReference{
+		Relation: &val,
+		Resource: &ResourceReference{ResourceType: "host"},
+	}
+	sr.Reset()
+	assert.Nil(t, sr.Relation)
+	assert.Nil(t, sr.Resource)
+}
+
+func TestSubjectReference_String(t *testing.T) {
+	val := "view"
+	sr := &SubjectReference{
+		Relation: &val,
+		Resource: &ResourceReference{ResourceType: "host", ResourceId: "789"},
+	}
+	s := sr.String()
+	assert.NotEmpty(t, s)
+	assert.Contains(t, s, "view")
+	assert.Contains(t, s, "host")
+}
+
+func TestSubjectReference_ProtoMessage(t *testing.T) {
+	var sr interface{} = &SubjectReference{}
+	_, ok := sr.(proto.Message)
+	assert.True(t, ok)
+}
+
+func TestSubjectReference_ProtoReflect(t *testing.T) {
+	val := "view"
+	sr := &SubjectReference{Relation: &val}
+	m := sr.ProtoReflect()
+	assert.NotNil(t, m)
+	assert.Equal(t, "view", m.Interface().(*SubjectReference).GetRelation())
+}
+
+func TestSubjectReference_JSONRoundTrip_WithRelation(t *testing.T) {
+	val := "view"
+	sr := &SubjectReference{
+		Relation: &val,
+		Resource: &ResourceReference{ResourceType: "principal", ResourceId: "sarah"},
+	}
+	b, err := json.Marshal(sr)
+	assert.NoError(t, err)
+
+	var out SubjectReference
+	assert.NoError(t, json.Unmarshal(b, &out))
+	assert.Equal(t, "view", out.GetRelation())
+	assert.Equal(t, "principal", out.GetResource().ResourceType)
+	assert.Equal(t, "sarah", out.GetResource().ResourceId)
+}
+
+func TestSubjectReference_JSONRoundTrip_WithoutRelation(t *testing.T) {
+	sr := &SubjectReference{
+		Resource: &ResourceReference{ResourceType: "principal", ResourceId: "xyz"},
+	}
+	b, err := json.Marshal(sr)
+	assert.NoError(t, err)
+
+	var out SubjectReference
+	assert.NoError(t, json.Unmarshal(b, &out))
+	assert.Equal(t, "", out.GetRelation())
+	assert.Equal(t, "principal", out.GetResource().ResourceType)
+	assert.Equal(t, "xyz", out.GetResource().ResourceId)
+}
+
+func TestSubjectReference_AllNil(t *testing.T) {
+	var sr *SubjectReference
+	assert.Equal(t, "", sr.GetRelation())
+	assert.Nil(t, sr.GetResource())
+}

--- a/api/kessel/inventory/v1beta2/write_visibility.pb_test.go
+++ b/api/kessel/inventory/v1beta2/write_visibility.pb_test.go
@@ -1,0 +1,48 @@
+package v1beta2
+
+import (
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"testing"
+)
+
+func TestWriteVisibility_Enum(t *testing.T) {
+	ev := WriteVisibility_WRITE_VISIBILITY_UNSPECIFIED
+	ptr := ev.Enum()
+	assert.NotNil(t, ptr)
+	assert.Equal(t, ev, *ptr)
+}
+
+func TestWriteVisibility_String(t *testing.T) {
+	assert.Equal(t, "WRITE_VISIBILITY_UNSPECIFIED", WriteVisibility_WRITE_VISIBILITY_UNSPECIFIED.String())
+	assert.Equal(t, "MINIMIZE_LATENCY", WriteVisibility_MINIMIZE_LATENCY.String())
+	assert.Equal(t, "IMMEDIATE", WriteVisibility_IMMEDIATE.String())
+}
+
+func TestWriteVisibility_Number(t *testing.T) {
+	assert.Equal(t, protoreflect.EnumNumber(0), WriteVisibility_WRITE_VISIBILITY_UNSPECIFIED.Number())
+	assert.Equal(t, protoreflect.EnumNumber(1), WriteVisibility_MINIMIZE_LATENCY.Number())
+	assert.Equal(t, protoreflect.EnumNumber(2), WriteVisibility_IMMEDIATE.Number())
+}
+
+func TestWriteVisibility_Descriptor(t *testing.T) {
+	// Descriptor() and Type() should return a non-nil value
+	assert.NotNil(t, WriteVisibility_WRITE_VISIBILITY_UNSPECIFIED.Descriptor())
+	assert.NotNil(t, WriteVisibility_WRITE_VISIBILITY_UNSPECIFIED.Type())
+}
+
+func TestWriteVisibility_ValueMaps(t *testing.T) {
+	assert.Equal(t, int32(0), WriteVisibility_value["WRITE_VISIBILITY_UNSPECIFIED"])
+	assert.Equal(t, int32(1), WriteVisibility_value["MINIMIZE_LATENCY"])
+	assert.Equal(t, int32(2), WriteVisibility_value["IMMEDIATE"])
+
+	assert.Equal(t, "WRITE_VISIBILITY_UNSPECIFIED", WriteVisibility_name[0])
+	assert.Equal(t, "MINIMIZE_LATENCY", WriteVisibility_name[1])
+	assert.Equal(t, "IMMEDIATE", WriteVisibility_name[2])
+}
+
+func TestWriteVisibility_EnumDescriptor(t *testing.T) {
+	b, idx := WriteVisibility_WRITE_VISIBILITY_UNSPECIFIED.EnumDescriptor()
+	assert.NotNil(t, b)
+	assert.NotNil(t, idx)
+}


### PR DESCRIPTION
### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Add comprehensive JSON marshalling and validation unit tests for v1beta2 API protobuf messages and clean up outdated test assertions

Tests:
- Add DeleteResourceRequest tests covering valid full/minimal requests, missing reference, and invalid field types
- Add ResourceReference tests for full/minimal payloads, missing fields, invalid reporter types, and empty object
- Add RepresentationMetadata tests for getters, nil optionals, empty/partial JSON, and invalid JSON types
- Add ResourceRepresentations tests for JSON marshal/unmarshal, including valid round-trip, missing metadata, and invalid payloads

Chores:
- Remove obsolete ConsoleHref and ReporterVersion assertions from ResourceValidation tests