### PR TITLE
RHCLOUD-39805: refactor metrics collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.out
 # HTML test coverage report produce with `go tool cover`
 coverage.html
+coverage.txt
 
 # Dependency directories (remove the comment below to include it)
 vendor/

--- a/internal/consumer/consumer_test.go
+++ b/internal/consumer/consumer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/project-kessel/inventory-api/internal/metricscollector"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/project-kessel/inventory-api/internal/biz/model"
@@ -34,7 +35,7 @@ type TestCase struct {
 	config          *Config
 	completedConfig CompletedConfig
 	inv             InventoryConsumer
-	metrics         MetricsCollector
+	metrics         metricscollector.MetricsCollector
 	logger          *log.Helper
 }
 

--- a/internal/metricscollector/metricscollector.go
+++ b/internal/metricscollector/metricscollector.go
@@ -1,4 +1,4 @@
-package consumer
+package metricscollector
 
 import (
 	"context"
@@ -89,10 +89,10 @@ type MetricsCollector struct {
 	assignmentSize metric.Int64Gauge
 
 	// App Specific Metrics
-	msgsProcessed      metric.Int64Counter
-	msgProcessFailures metric.Int64Counter
-	consumerErrors     metric.Int64Counter
-	kafkaErrorEvents   metric.Int64Counter
+	MsgsProcessed      metric.Int64Counter
+	MsgProcessFailures metric.Int64Counter
+	ConsumerErrors     metric.Int64Counter
+	KafkaErrorEvents   metric.Int64Counter
 }
 
 // New instantiates a new MetricsCollector
@@ -148,16 +148,16 @@ func (m *MetricsCollector) New(meter metric.Meter) error {
 	}
 
 	// create app metrics
-	if m.msgsProcessed, err = meter.Int64Counter(prefix + "msgs_processed"); err != nil {
+	if m.MsgsProcessed, err = meter.Int64Counter(prefix + "msgs_processed"); err != nil {
 		return err
 	}
-	if m.msgProcessFailures, err = meter.Int64Counter(prefix + "msg_process_failures"); err != nil {
+	if m.MsgProcessFailures, err = meter.Int64Counter(prefix + "msg_process_failures"); err != nil {
 		return err
 	}
-	if m.consumerErrors, err = meter.Int64Counter(prefix + "consumer_errors"); err != nil {
+	if m.ConsumerErrors, err = meter.Int64Counter(prefix + "consumer_errors"); err != nil {
 		return err
 	}
-	if m.kafkaErrorEvents, err = meter.Int64Counter(prefix + "kafka_error_events"); err != nil {
+	if m.KafkaErrorEvents, err = meter.Int64Counter(prefix + "kafka_error_events"); err != nil {
 		return err
 	}
 	return nil

--- a/internal/metricscollector/metricscollector_test.go
+++ b/internal/metricscollector/metricscollector_test.go
@@ -1,14 +1,15 @@
-package consumer
+package metricscollector
 
 import (
 	"reflect"
 	"testing"
 
+	"github.com/project-kessel/inventory-api/internal/consumer"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMetrics_New(t *testing.T) {
-	test := TestCase{
+	test := consumer.TestCase{
 		name:        "TestMetricsNew_DefaultMeters",
 		description: "ensures a metrics collector is configured with all default meters",
 	}

--- a/internal/metricscollector/metricscollector_test.go
+++ b/internal/metricscollector/metricscollector_test.go
@@ -4,19 +4,20 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/project-kessel/inventory-api/internal/consumer"
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel"
 )
 
 func TestMetrics_New(t *testing.T) {
-	test := consumer.TestCase{
-		name:        "TestMetricsNew_DefaultMeters",
-		description: "ensures a metrics collector is configured with all default meters",
+	test := struct {
+		mc MetricsCollector
+	}{
+		mc: MetricsCollector{},
 	}
-	errs := test.TestSetup()
-	assert.Nil(t, errs)
+	err := test.mc.New(otel.Meter("github.com/project-kessel/inventory-api/blob/main/internal/server/otel"))
+	assert.Nil(t, err)
 
-	structValues := reflect.ValueOf(test.metrics)
+	structValues := reflect.ValueOf(test.mc)
 	numField := structValues.NumField()
 
 	// ensures all fields in struct are properly instantiated
@@ -26,5 +27,5 @@ func TestMetrics_New(t *testing.T) {
 		assert.True(t, !field.IsZero())
 	}
 	// ensures the number of fields in the type and instantiated version match
-	assert.Equal(t, reflect.TypeOf(MetricsCollector{}).NumField(), reflect.TypeOf(test.metrics).NumField())
+	assert.Equal(t, reflect.TypeOf(MetricsCollector{}).NumField(), reflect.TypeOf(test.mc).NumField())
 }


### PR DESCRIPTION
### PR Template:

## Describe your changes

Moves the MetricsCollector out of consumer and into its own package. This will give us a central location to define all metrics and use this specific type for anything that needs to increment metrics. Doing this as a precursor to adding metrics for outbox events without having to pass the consumer to it just for metrics.


## Ticket reference (if applicable)
For RHCLOUD-39805

## Summary by Sourcery

Extract the MetricsCollector into a standalone internal/metricscollector package and update all consumer code and tests to use the new package and exported metric fields.

Enhancements:
- Move MetricsCollector out of the consumer package into its own internal/metricscollector module.
- Rename metric fields to exported identifiers and adjust Incr calls to use the metricscollector package.
- Update consumer imports and code references to point to the new metricscollector package.
- Remove now-duplicated metrics definitions from the consumer package and centralize them in metricscollector.

Tests:
- Adjust metricscollector and consumer tests to import the new package and validate the refactored MetricsCollector API.