### PR TITLE
refactor resources_test mocks to be included in mocks

### DIFF
--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -2,6 +2,10 @@ package mocks
 
 import (
 	"context"
+	"github.com/google/uuid"
+	"github.com/project-kessel/inventory-api/internal/pubsub"
+	"google.golang.org/grpc/metadata"
+	"io"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 
@@ -90,4 +94,153 @@ func (m *MockConsumer) Close() error {
 func (m *MockConsumer) AssignmentLost() bool {
 	args := m.Called()
 	return args.Get(0).(bool)
+}
+
+type MockedReporterResourceRepository struct {
+	mock.Mock
+}
+type MockedInventoryResourceRepository struct {
+	mock.Mock
+}
+
+type MockedListenManager struct {
+	mock.Mock
+}
+
+type MockedSubscription struct {
+	mock.Mock
+}
+
+type MockLookupResourcesStream struct {
+	mock.Mock
+	Responses []*v1beta1.LookupResourcesResponse
+	current   int
+}
+
+func (m *MockLookupResourcesStream) Recv() (*v1beta1.LookupResourcesResponse, error) {
+	if m.current >= len(m.Responses) {
+		return nil, io.EOF
+	}
+	res := m.Responses[m.current]
+	m.current++
+	return res, nil
+}
+
+func (m *MockLookupResourcesStream) Header() (metadata.MD, error) {
+	args := m.Called()
+	return args.Get(0).(metadata.MD), args.Error(1)
+}
+
+func (m *MockLookupResourcesStream) Trailer() metadata.MD {
+	args := m.Called()
+	return args.Get(0).(metadata.MD)
+}
+
+func (m *MockLookupResourcesStream) CloseSend() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockLookupResourcesStream) Context() context.Context {
+	args := m.Called()
+	return args.Get(0).(context.Context)
+}
+
+func (m *MockLookupResourcesStream) SendMsg(msg interface{}) error {
+	args := m.Called(msg)
+	return args.Error(0)
+}
+
+func (m *MockLookupResourcesStream) RecvMsg(msg interface{}) error {
+	args := m.Called(msg)
+	return args.Error(0)
+}
+
+func (r *MockedReporterResourceRepository) Create(ctx context.Context, resource *model.Resource, namespace string, txid string) (*model.Resource, error) {
+	args := r.Called(ctx, resource, namespace, txid)
+	return args.Get(0).(*model.Resource), args.Error(1)
+}
+
+func (r *MockedReporterResourceRepository) Update(ctx context.Context, resource *model.Resource, id uuid.UUID, namespace string, txid string) (*model.Resource, error) {
+	args := r.Called(ctx, resource, id, namespace, txid)
+	return args.Get(0).(*model.Resource), args.Error(1)
+}
+
+func (r *MockedReporterResourceRepository) Delete(ctx context.Context, id uuid.UUID, namespace string) (*model.Resource, error) {
+	args := r.Called(ctx, id, namespace)
+	return args.Get(0).(*model.Resource), args.Error(1)
+}
+
+func (r *MockedReporterResourceRepository) FindByID(ctx context.Context, id uuid.UUID) (*model.Resource, error) {
+	args := r.Called(ctx, id)
+	return args.Get(0).(*model.Resource), args.Error(1)
+}
+
+func (r *MockedReporterResourceRepository) FindByReporterResourceId(ctx context.Context, id model.ReporterResourceId) (*model.Resource, error) {
+	args := r.Called(ctx, id)
+	return args.Get(0).(*model.Resource), args.Error(1)
+}
+
+func (r *MockedReporterResourceRepository) FindByInventoryIdAndReporter(ctx context.Context, inventoryId *uuid.UUID, reporterResourceId string, reporterType string) (*model.Resource, error) {
+	args := r.Called(ctx, inventoryId, reporterResourceId, reporterType)
+	return args.Get(0).(*model.Resource), args.Error(1)
+}
+
+func (r *MockedReporterResourceRepository) FindByReporterResourceIdv1beta2(ctx context.Context, id model.ReporterResourceUniqueIndex) (*model.Resource, error) {
+	args := r.Called(ctx, id)
+	return args.Get(0).(*model.Resource), args.Error(1)
+}
+
+func (r *MockedReporterResourceRepository) FindByInventoryIdAndResourceType(ctx context.Context, inventoryId *uuid.UUID, resourceType string) (*model.Resource, error) {
+	args := r.Called(ctx, inventoryId, resourceType)
+	return args.Get(0).(*model.Resource), args.Error(1)
+}
+
+func (r *MockedReporterResourceRepository) FindByReporterData(ctx context.Context, reporterId string, resourceId string) (*model.Resource, error) {
+	args := r.Called(ctx, reporterId, resourceId)
+	return args.Get(0).(*model.Resource), args.Error(1)
+}
+
+func (r *MockedReporterResourceRepository) ListAll(ctx context.Context) ([]*model.Resource, error) {
+	args := r.Called(ctx)
+	return args.Get(0).([]*model.Resource), args.Error(1)
+}
+
+func (r *MockedInventoryResourceRepository) FindByID(ctx context.Context, id uuid.UUID) (*model.InventoryResource, error) {
+	args := r.Called(ctx, id)
+	return args.Get(0).(*model.InventoryResource), args.Error(1)
+}
+
+func (r *MockedReporterResourceRepository) FindByWorkspaceId(ctx context.Context, workspace_id string) ([]*model.Resource, error) {
+	args := r.Called(ctx)
+	return args.Get(0).([]*model.Resource), args.Error(1)
+}
+
+func (m *MockedListenManager) Subscribe(txid string) pubsub.Subscription {
+	args := m.Called(txid)
+	return args.Get(0).(pubsub.Subscription)
+}
+
+func (m *MockedListenManager) WaitAndDistribute(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockedListenManager) Run(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockedSubscription) NotificationC() <-chan []byte {
+	args := m.Called()
+	return args.Get(0).(chan []byte)
+}
+
+func (m *MockedSubscription) Unsubscribe() {
+	m.Called()
+}
+
+func (m *MockedSubscription) BlockForNotification(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
 }


### PR DESCRIPTION
### PR Template:

## Describe your changes

- When looking around at different tests I noticed that there were some mocks available in [resources_test.go](https://github.com/project-kessel/inventory-api/blob/main/internal/biz/usecase/resources/resources_test.go)
- This PR takes them out of the test file and into the dedicated mocks directory so we can reuse this code elsewhere

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

