### PR TITLE
RHCLOUD-39805: add outbox write counter

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -10,8 +10,10 @@ import (
 	"time"
 
 	"github.com/go-kratos/kratos/v2/log"
+	"github.com/project-kessel/inventory-api/internal/metricscollector"
 	"github.com/sony/gobreaker"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel"
 	"gorm.io/gorm"
 
 	"github.com/project-kessel/inventory-api/cmd/common"
@@ -162,6 +164,14 @@ func NewCommand(
 				return err
 			}
 
+			// setup metrics collector for consumer and custom metrics
+			mc := &metricscollector.MetricsCollector{}
+			meter := otel.Meter("github.com/project-kessel/inventory-api/blob/main/internal/server/otel")
+			err = mc.New(meter)
+			if err != nil {
+				return err
+			}
+
 			// START: construct pubsub (postgres only)
 			var listenManager *pubsub.ListenManager
 			var notifier *pubsub.PgxNotifier
@@ -248,7 +258,7 @@ func NewCommand(
 
 			//v1beta2
 			// wire together inventory service handling
-			resource_repo := resourcerepo.New(db)
+			resource_repo := resourcerepo.New(db, mc)
 			inventory_controller := resourcesctl.New(resource_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			inventory_service := resourcesvc.NewKesselInventoryServiceV1beta2(inventory_controller)
 			pbv1beta2.RegisterKesselInventoryServiceServer(server.GrpcServer, inventory_service)
@@ -256,35 +266,35 @@ func NewCommand(
 
 			//v1beta1
 			// wire together notificationsintegrations handling
-			notifs_repo := resourcerepo.New(db)
+			notifs_repo := resourcerepo.New(db, mc)
 			notifs_controller := resourcesctl.New(notifs_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			notifs_service := notifssvc.NewKesselNotificationsIntegrationsServiceV1beta1(notifs_controller)
 			pb.RegisterKesselNotificationsIntegrationServiceServer(server.GrpcServer, notifs_service)
 			pb.RegisterKesselNotificationsIntegrationServiceHTTPServer(server.HttpServer, notifs_service)
 
 			// wire together authz handling
-			authz_repo := resourcerepo.New(db)
+			authz_repo := resourcerepo.New(db, mc)
 			authz_controller := resourcesctl.New(authz_repo, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			authz_service := resourcesvc.NewKesselCheckServiceV1beta1(authz_controller)
 			authzv1beta1.RegisterKesselCheckServiceServer(server.GrpcServer, authz_service)
 			authzv1beta1.RegisterKesselCheckServiceHTTPServer(server.HttpServer, authz_service)
 
 			// wire together hosts handling
-			hosts_repo := resourcerepo.New(db)
+			hosts_repo := resourcerepo.New(db, mc)
 			hosts_controller := resourcesctl.New(hosts_repo, inventoryresources_repo, authorizer, eventingManager, "hbi", log.With(logger, "subsystem", "hosts_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			hosts_service := hostssvc.NewKesselRhelHostServiceV1beta1(hosts_controller)
 			pb.RegisterKesselRhelHostServiceServer(server.GrpcServer, hosts_service)
 			pb.RegisterKesselRhelHostServiceHTTPServer(server.HttpServer, hosts_service)
 
 			// wire together k8sclusters handling
-			k8sclusters_repo := resourcerepo.New(db)
+			k8sclusters_repo := resourcerepo.New(db, mc)
 			k8sclusters_controller := resourcesctl.New(k8sclusters_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8sclusters_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			k8sclusters_service := k8sclusterssvc.NewKesselK8SClusterServiceV1beta1(k8sclusters_controller)
 			pb.RegisterKesselK8SClusterServiceServer(server.GrpcServer, k8sclusters_service)
 			pb.RegisterKesselK8SClusterServiceHTTPServer(server.HttpServer, k8sclusters_service)
 
 			// wire together k8spolicies handling
-			k8spolicies_repo := resourcerepo.New(db)
+			k8spolicies_repo := resourcerepo.New(db, mc)
 			k8spolicies_controller := resourcesctl.New(k8spolicies_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8spolicies_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			k8spolicies_service := k8spoliciessvc.NewKesselK8SPolicyServiceV1beta1(k8spolicies_controller)
 			pb.RegisterKesselK8SPolicyServiceServer(server.GrpcServer, k8spolicies_service)

--- a/internal/data/relationships/relationshiprepository_test.go
+++ b/internal/data/relationships/relationshiprepository_test.go
@@ -38,7 +38,7 @@ func setupMetricsCollector(t *testing.T) *metricscollector.MetricsCollector {
 
 func setupTest(t *testing.T) (*gorm.DB, *metricscollector.MetricsCollector) {
 	db := setupGorm(t)
-	mc := &metricscollector.MetricsCollector{}
+	mc := setupMetricsCollector(t)
 	return db, mc
 }
 

--- a/internal/data/relationships/relationshiprepository_test.go
+++ b/internal/data/relationships/relationshiprepository_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/google/uuid"
+	"github.com/project-kessel/inventory-api/internal/metricscollector"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
@@ -24,6 +26,20 @@ func setupGorm(t *testing.T) *gorm.DB {
 	require.Nil(t, err)
 
 	return db
+}
+
+func setupMetricsCollector(t *testing.T) *metricscollector.MetricsCollector {
+	mc := &metricscollector.MetricsCollector{}
+	meter := otel.Meter("github.com/project-kessel/inventory-api/blob/main/internal/server/otel")
+	err := mc.New(meter)
+	require.Nil(t, err)
+	return mc
+}
+
+func setupTest(t *testing.T) (*gorm.DB, *metricscollector.MetricsCollector) {
+	db := setupGorm(t)
+	mc := &metricscollector.MetricsCollector{}
+	return db, mc
 }
 
 var (
@@ -165,19 +181,19 @@ func assertEqualRelationshipHistory(t *testing.T, r *model.Relationship, rh *mod
 //	assert.Equal(t, litrExpected, litr)
 //}
 
-func createResource(t *testing.T, db *gorm.DB, resource *model.Resource) uuid.UUID {
-	res, err := resources.New(db).Create(context.TODO(), resource, "foobar-namespace", emptyTxId)
+func createResource(t *testing.T, db *gorm.DB, mc *metricscollector.MetricsCollector, resource *model.Resource) uuid.UUID {
+	res, err := resources.New(db, mc).Create(context.TODO(), resource, "foobar-namespace", emptyTxId)
 	assert.Nil(t, err)
 	return res.ID
 }
 
 func TestCreateRelationship(t *testing.T) {
-	db := setupGorm(t)
+	db, mc := setupTest(t)
 	repo := New(db)
 	ctx := context.TODO()
 
-	subjectId := createResource(t, db, resourceSubject())
-	objectId := createResource(t, db, resourceObject())
+	subjectId := createResource(t, db, mc, resourceSubject())
+	objectId := createResource(t, db, mc, resourceObject())
 
 	// Saving a relationship not present in the system saves correctly
 	r, err := repo.Save(ctx, relationship1(subjectId, objectId))
@@ -197,7 +213,7 @@ func TestCreateRelationship(t *testing.T) {
 }
 
 func TestCreateRelationshipFailsIfEitherResourceIsNotFound(t *testing.T) {
-	db := setupGorm(t)
+	db, mc := setupTest(t)
 	repo := New(db)
 	ctx := context.TODO()
 
@@ -209,14 +225,14 @@ func TestCreateRelationshipFailsIfEitherResourceIsNotFound(t *testing.T) {
 	assert.Error(t, err)
 
 	// Only subject
-	subjectId := createResource(t, db, resourceSubject())
+	subjectId := createResource(t, db, mc, resourceSubject())
 	_, err = repo.Save(ctx, relationship1(subjectId, uuid.Nil))
 	assert.Error(t, err)
 
 	// Only object
 	db = setupGorm(t)
 	repo = New(db)
-	objectId := createResource(t, db, resourceSubject())
+	objectId := createResource(t, db, mc, resourceSubject())
 	_, err = repo.Save(ctx, relationship1(uuid.Nil, objectId))
 	assert.Error(t, err)
 }
@@ -235,12 +251,12 @@ func TestUpdateFailsIfRelationshipNotFound(t *testing.T) {
 }
 
 func TestUpdateResource(t *testing.T) {
-	db := setupGorm(t)
+	db, mc := setupTest(t)
 	repo := New(db)
 	ctx := context.TODO()
 
-	subjectId := createResource(t, db, resourceSubject())
-	objectId := createResource(t, db, resourceObject())
+	subjectId := createResource(t, db, mc, resourceSubject())
+	objectId := createResource(t, db, mc, resourceObject())
 	r, err := repo.Save(ctx, relationship1(subjectId, objectId))
 	assert.NotNil(t, r)
 	assert.Nil(t, err)
@@ -279,12 +295,12 @@ func TestDeleteFailsIfResourceNotFound(t *testing.T) {
 }
 
 func TestDeleteAfterCreate(t *testing.T) {
-	db := setupGorm(t)
+	db, mc := setupTest(t)
 	repo := New(db)
 	ctx := context.TODO()
 
-	subjectId := createResource(t, db, resourceSubject())
-	objectId := createResource(t, db, resourceObject())
+	subjectId := createResource(t, db, mc, resourceSubject())
+	objectId := createResource(t, db, mc, resourceObject())
 	r, err := repo.Save(ctx, relationship1(subjectId, objectId))
 	assert.NotNil(t, r)
 	assert.Nil(t, err)
@@ -304,12 +320,12 @@ func TestDeleteAfterCreate(t *testing.T) {
 }
 
 func TestDeleteAfterUpdate(t *testing.T) {
-	db := setupGorm(t)
+	db, mc := setupTest(t)
 	repo := New(db)
 	ctx := context.TODO()
 
-	subjectId := createResource(t, db, resourceSubject())
-	objectId := createResource(t, db, resourceObject())
+	subjectId := createResource(t, db, mc, resourceSubject())
+	objectId := createResource(t, db, mc, resourceObject())
 
 	// Create
 	r, err := repo.Save(ctx, relationship1(subjectId, objectId))
@@ -332,12 +348,12 @@ func TestDeleteAfterUpdate(t *testing.T) {
 }
 
 func TestFindRelationship(t *testing.T) {
-	db := setupGorm(t)
+	db, mc := setupTest(t)
 	repo := New(db)
 	ctx := context.TODO()
 
-	subjectId := createResource(t, db, resourceSubject())
-	objectId := createResource(t, db, resourceObject())
+	subjectId := createResource(t, db, mc, resourceSubject())
+	objectId := createResource(t, db, mc, resourceObject())
 
 	// Saving a relationship not present in the system saves correctly
 	r, err := repo.Save(ctx, relationship1(subjectId, objectId))
@@ -359,12 +375,12 @@ func TestFindRelationship(t *testing.T) {
 }
 
 func TestListAll(t *testing.T) {
-	db := setupGorm(t)
+	db, mc := setupTest(t)
 	repo := New(db)
 	ctx := context.TODO()
 
-	subjectId := createResource(t, db, resourceSubject())
-	objectId := createResource(t, db, resourceObject())
+	subjectId := createResource(t, db, mc, resourceSubject())
+	objectId := createResource(t, db, mc, resourceObject())
 
 	// first check negative case with zero relationships
 	relationships, err := repo.ListAll(ctx)

--- a/internal/data/resources/resourcerepository.go
+++ b/internal/data/resources/resourcerepository.go
@@ -103,6 +103,7 @@ func (r *Repo) Create(ctx context.Context, m *model.Resource, namespace string, 
 	}
 
 	tx.Commit()
+	metricscollector.Incr(r.MetricsCollector.OutboxEventWrites, string(model.OperationTypeCreated), nil)
 	return m, nil
 }
 
@@ -153,6 +154,7 @@ func (r *Repo) Update(ctx context.Context, m *model.Resource, id uuid.UUID, name
 	}
 
 	tx.Commit()
+	metricscollector.Incr(r.MetricsCollector.OutboxEventWrites, string(model.OperationTypeUpdated), nil)
 	return m, nil
 }
 
@@ -203,6 +205,7 @@ func (r *Repo) Delete(ctx context.Context, id uuid.UUID, namespace string) (*mod
 	}
 
 	tx.Commit()
+	metricscollector.Incr(r.MetricsCollector.OutboxEventWrites, string(model.OperationTypeDeleted), nil)
 	return resource, nil
 }
 

--- a/internal/data/resources/resourcerepository.go
+++ b/internal/data/resources/resourcerepository.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/google/uuid"
+	"github.com/project-kessel/inventory-api/internal/metricscollector"
 	"gorm.io/gorm"
 
 	"github.com/project-kessel/inventory-api/internal/biz/model"
@@ -13,12 +14,14 @@ import (
 )
 
 type Repo struct {
-	DB *gorm.DB
+	DB               *gorm.DB
+	MetricsCollector *metricscollector.MetricsCollector
 }
 
-func New(db *gorm.DB) *Repo {
+func New(db *gorm.DB, mc *metricscollector.MetricsCollector) *Repo {
 	return &Repo{
-		DB: db,
+		DB:               db,
+		MetricsCollector: mc,
 	}
 }
 

--- a/internal/data/resources/resourcerepository_test.go
+++ b/internal/data/resources/resourcerepository_test.go
@@ -42,7 +42,8 @@ func setupMetricsCollector(t *testing.T) *metricscollector.MetricsCollector {
 
 func setupTest(t *testing.T) (*gorm.DB, *Repo) {
 	db := setupGorm(t)
-	repo := New(db, nil)
+	mc := setupMetricsCollector(t)
+	repo := New(db, mc)
 	return db, repo
 }
 

--- a/internal/data/resources/resourcerepository_test.go
+++ b/internal/data/resources/resourcerepository_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/google/uuid"
+	"github.com/project-kessel/inventory-api/internal/metricscollector"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
@@ -28,6 +30,20 @@ func setupGorm(t *testing.T) *gorm.DB {
 	require.Nil(t, err)
 
 	return db
+}
+
+func setupMetricsCollector(t *testing.T) *metricscollector.MetricsCollector {
+	mc := &metricscollector.MetricsCollector{}
+	meter := otel.Meter("github.com/project-kessel/inventory-api/blob/main/internal/server/otel")
+	err := mc.New(meter)
+	require.Nil(t, err)
+	return mc
+}
+
+func setupTest(t *testing.T) (*gorm.DB, *Repo) {
+	db := setupGorm(t)
+	repo := New(db, nil)
+	return db, repo
 }
 
 func resource1() *model.Resource {
@@ -115,8 +131,7 @@ func assertEqualLocalHistoryToResource(t *testing.T, r *model.Resource, litr *mo
 }
 
 func TestCreateResource(t *testing.T) {
-	db := setupGorm(t)
-	repo := New(db)
+	db, repo := setupTest(t)
 	ctx := context.TODO()
 
 	// Saving a resource not present in the system saves correctly
@@ -154,8 +169,7 @@ func TestCreateResource(t *testing.T) {
 }
 
 func TestCreateResourceWithInventoryId(t *testing.T) {
-	db := setupGorm(t)
-	repo := New(db)
+	db, repo := setupTest(t)
 	ctx := context.TODO()
 	res1 := resource1()
 	res2 := resource1()
@@ -202,8 +216,7 @@ func TestCreateResourceWithInventoryId(t *testing.T) {
 }
 
 func TestUpdateFailsIfResourceNotFound(t *testing.T) {
-	db := setupGorm(t)
-	repo := New(db)
+	db, repo := setupTest(t)
 	ctx := context.TODO()
 
 	id, err := uuid.NewV7()
@@ -220,8 +233,7 @@ func TestUpdateFailsIfResourceNotFound(t *testing.T) {
 }
 
 func TestUpdateResource(t *testing.T) {
-	db := setupGorm(t)
-	repo := New(db)
+	db, repo := setupTest(t)
 	ctx := context.TODO()
 
 	r, err := repo.Create(ctx, resource1(), namespace, emptyTxId)
@@ -263,8 +275,7 @@ func TestUpdateResource(t *testing.T) {
 }
 
 func TestDeleteFailsIfResourceNotFound(t *testing.T) {
-	db := setupGorm(t)
-	repo := New(db)
+	db, repo := setupTest(t)
 	ctx := context.TODO()
 
 	id, err := uuid.NewV7()
@@ -281,8 +292,7 @@ func TestDeleteFailsIfResourceNotFound(t *testing.T) {
 }
 
 func TestDeleteAfterCreate(t *testing.T) {
-	db := setupGorm(t)
-	repo := New(db)
+	db, repo := setupTest(t)
 	ctx := context.TODO()
 
 	r, err := repo.Create(ctx, resource1(), namespace, emptyTxId)
@@ -319,8 +329,7 @@ func TestDeleteAfterCreate(t *testing.T) {
 }
 
 func TestDeleteAfterUpdate(t *testing.T) {
-	db := setupGorm(t)
-	repo := New(db)
+	db, repo := setupTest(t)
 	ctx := context.TODO()
 
 	// Create
@@ -349,8 +358,7 @@ func TestDeleteAfterUpdate(t *testing.T) {
 }
 
 func TestFindByReporterResourceId(t *testing.T) {
-	db := setupGorm(t)
-	repo := New(db)
+	_, repo := setupTest(t)
 	ctx := context.TODO()
 
 	// Saving a resource not present in the system saves correctly
@@ -374,8 +382,7 @@ func TestFindByReporterResourceId(t *testing.T) {
 }
 
 func TestFindByReporterData(t *testing.T) {
-	db := setupGorm(t)
-	repo := New(db)
+	_, repo := setupTest(t)
 	ctx := context.TODO()
 	res := resource1()
 	res.ReporterId = "ACM"
@@ -397,8 +404,7 @@ func TestFindByReporterData(t *testing.T) {
 }
 
 func TestFindByWorkspaceId(t *testing.T) {
-	db := setupGorm(t)
-	repo := New(db)
+	_, repo := setupTest(t)
 	ctx := context.TODO()
 	res := resource1()
 	res.ReporterId = "ACM"
@@ -422,8 +428,7 @@ func TestFindByWorkspaceId(t *testing.T) {
 }
 
 func TestListAll(t *testing.T) {
-	db := setupGorm(t)
-	repo := New(db)
+	_, repo := setupTest(t)
 	ctx := context.TODO()
 
 	// check negative case without any resources, slice with 0 elements returned

--- a/internal/metricscollector/metricscollector.go
+++ b/internal/metricscollector/metricscollector.go
@@ -10,7 +10,10 @@ import (
 
 const (
 	outboxTopic = "outbox.event.kessel.tuples"
-	prefix      = "inventory_consumer_"
+	// consumerPrefix should be used for all consumer-related metrics
+	consumerPrefix = "kessel_inventory_consumer_"
+	// prefix should be used for all other metrics unrelated to the consumer
+	prefix = "kessel_inventory_"
 )
 
 // LabelSet adds desired attributes to each metric recorded from stats messages to ensure consistent labeling.
@@ -93,6 +96,7 @@ type MetricsCollector struct {
 	MsgProcessFailures metric.Int64Counter
 	ConsumerErrors     metric.Int64Counter
 	KafkaErrorEvents   metric.Int64Counter
+	OutboxEventWrites  metric.Int64Counter
 }
 
 // New instantiates a new MetricsCollector
@@ -100,64 +104,69 @@ func (m *MetricsCollector) New(meter metric.Meter) error {
 	var err error
 
 	// create top-level metrics
-	if m.replyq, err = meter.Int64Gauge(prefix + "replyq"); err != nil {
+	if m.replyq, err = meter.Int64Gauge(consumerPrefix + "replyq"); err != nil {
 		return err
 	}
 
 	// create topic.partitions metrics
-	if m.fetchqCnt, err = meter.Int64Gauge(prefix + "fetchq_cnt"); err != nil {
+	if m.fetchqCnt, err = meter.Int64Gauge(consumerPrefix + "fetchq_cnt"); err != nil {
 		return err
 	}
-	if m.fetchqSize, err = meter.Int64Gauge(prefix + "fetchq_size"); err != nil {
+	if m.fetchqSize, err = meter.Int64Gauge(consumerPrefix + "fetchq_size"); err != nil {
 		return err
 	}
-	if m.fetchState, err = meter.Int64Gauge(prefix + "fetchq_state"); err != nil {
+	if m.fetchState, err = meter.Int64Gauge(consumerPrefix + "fetchq_state"); err != nil {
 		return err
 	}
-	if m.loOffset, err = meter.Int64Gauge(prefix + "lo_offset"); err != nil {
+	if m.loOffset, err = meter.Int64Gauge(consumerPrefix + "lo_offset"); err != nil {
 		return err
 	}
-	if m.hiOffset, err = meter.Int64Gauge(prefix + "hi_offset"); err != nil {
+	if m.hiOffset, err = meter.Int64Gauge(consumerPrefix + "hi_offset"); err != nil {
 		return err
 	}
-	if m.lsOffset, err = meter.Int64Gauge(prefix + "ls_offset"); err != nil {
+	if m.lsOffset, err = meter.Int64Gauge(consumerPrefix + "ls_offset"); err != nil {
 		return err
 	}
-	if m.consumerLag, err = meter.Int64Gauge(prefix + "consumer_lag"); err != nil {
+	if m.consumerLag, err = meter.Int64Gauge(consumerPrefix + "consumer_lag"); err != nil {
 		return err
 	}
-	if m.consumerLagStored, err = meter.Int64Gauge(prefix + "consumer_lag_stored"); err != nil {
+	if m.consumerLagStored, err = meter.Int64Gauge(consumerPrefix + "consumer_lag_stored"); err != nil {
 		return err
 	}
 
 	// create cgrp metrics
-	if m.state, err = meter.Int64Gauge(prefix + "state"); err != nil {
+	if m.state, err = meter.Int64Gauge(consumerPrefix + "state"); err != nil {
 		return err
 	}
-	if m.stateAge, err = meter.Int64Gauge(prefix + "stateage"); err != nil {
+	if m.stateAge, err = meter.Int64Gauge(consumerPrefix + "stateage"); err != nil {
 		return err
 	}
-	if m.rebalanceAge, err = meter.Int64Gauge(prefix + "rebalance_age"); err != nil {
+	if m.rebalanceAge, err = meter.Int64Gauge(consumerPrefix + "rebalance_age"); err != nil {
 		return err
 	}
-	if m.rebalanceCnt, err = meter.Int64Counter(prefix + "rebalance_cnt"); err != nil {
+	if m.rebalanceCnt, err = meter.Int64Counter(consumerPrefix + "rebalance_cnt"); err != nil {
 		return err
 	}
-	if m.assignmentSize, err = meter.Int64Gauge(prefix + "assignment_size"); err != nil {
+	if m.assignmentSize, err = meter.Int64Gauge(consumerPrefix + "assignment_size"); err != nil {
 		return err
 	}
 
-	// create app metrics
-	if m.MsgsProcessed, err = meter.Int64Counter(prefix + "msgs_processed"); err != nil {
+	// create consumer custom app metrics
+	if m.MsgsProcessed, err = meter.Int64Counter(consumerPrefix + "msgs_processed"); err != nil {
 		return err
 	}
-	if m.MsgProcessFailures, err = meter.Int64Counter(prefix + "msg_process_failures"); err != nil {
+	if m.MsgProcessFailures, err = meter.Int64Counter(consumerPrefix + "msg_process_failures"); err != nil {
 		return err
 	}
-	if m.ConsumerErrors, err = meter.Int64Counter(prefix + "consumer_errors"); err != nil {
+	if m.ConsumerErrors, err = meter.Int64Counter(consumerPrefix + "consumer_errors"); err != nil {
 		return err
 	}
-	if m.KafkaErrorEvents, err = meter.Int64Counter(prefix + "kafka_error_events"); err != nil {
+	if m.KafkaErrorEvents, err = meter.Int64Counter(consumerPrefix + "kafka_error_events"); err != nil {
+		return err
+	}
+
+	// create all other custom app metrics
+	if m.OutboxEventWrites, err = meter.Int64Counter(prefix + "outbox_event_writes"); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
### PR Template:

## Describe your changes

* adds new `OutboxEventWrites` metric for capturing every time a write to outbox is done
* adds MetricsCollector to resource repo to record outbox write events after DB commits
* updates test for changes to repo params
  * adds some helper functions to for simpler instantiation and code resuse
* updates metric prefixes for existing metric types
  * consumer metrics prefix has been updated to `kessel-inventory_` to ensure we dont conflict with any potential HBI consumer metrics in the future
  * changing this prefix may skew metrics in stage once updated
  * adds new prefix for `kessel_inventory_` that can be used for any other metrics going forward
  * dashboard queries will need to be updated for new metric names (to be done in follow up PR while adding new visuals)


# Validation
Spun up Inventory with monitoring stack locally to generate metrics

```shell
# tested using load-generator script with 50 requests each (Create, Update, Delete)
# new metrics prefixes set, new metrics available, msgs_processed and outbox writes are equal which is expected, any drift would be a concern
$ curl -s localhost:8081/metrics | grep -E "outbox_event|msgs_processed"
# HELP kessel_inventory_consumer_msgs_processed_total 
# TYPE kessel_inventory_consumer_msgs_processed_total counter
kessel_inventory_consumer_msgs_processed_total{operation="created",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version=""} 50
kessel_inventory_consumer_msgs_processed_total{operation="deleted",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version=""} 50
kessel_inventory_consumer_msgs_processed_total{operation="updated",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version=""} 50
# HELP kessel_inventory_outbox_event_writes_total 
# TYPE kessel_inventory_outbox_event_writes_total counter
kessel_inventory_outbox_event_writes_total{operation="created",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version=""} 50
kessel_inventory_outbox_event_writes_total{operation="deleted",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version=""} 50
kessel_inventory_outbox_event_writes_total{operation="updated",otel_scope_name="github.com/project-kessel/inventory-api/blob/main/internal/server/otel",otel_scope_version=""} 50
```

## Ticket reference (if applicable)
For RHCLOUD-39805

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Add a new outbox write counter and integrate the MetricsCollector into the data layer and server startup while updating metric naming conventions.

New Features:
- Introduce an OutboxEventWrites counter to record each outbox write after database commits

Enhancements:
- Split and rename metric prefixes into consumer (kessel_inventory_consumer_) and general (kessel_inventory_) categories
- Inject MetricsCollector into resource and relationship repositories and wire it through server initialization

Tests:
- Refactor resource and relationship repository tests to use setupMetricsCollector and setupTest helpers for injecting the metrics collector