### PR TITLE
RHCLOUD-39805: updates inventory dashboard for end-to-end replication lag

### DIFF
--- a/dashboards/grafana-dashboard-kessel-inventory-api.configmap.yaml
+++ b/dashboards/grafana-dashboard-kessel-inventory-api.configmap.yaml
@@ -746,7 +746,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "count(inventory_consumer_state{state=\"up\"})",
+              "expr": "count(kessel_inventory_consumer_state{state=\"up\"})",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -820,7 +820,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "max(inventory_consumer_replyq)",
+              "expr": "max(kessel_inventory_consumer_replyq)",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -887,7 +887,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "min(inventory_consumer_rebalance_age)",
+              "expr": "min(kessel_inventory_consumer_rebalance_age)",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -1234,7 +1234,7 @@ data:
               "disableTextWrap": false,
               "editorMode": "builder",
               "exemplar": false,
-              "expr": "changes(inventory_consumer_rebalance_cnt_total[$__interval])",
+              "expr": "changes(kessel_inventory_consumer_rebalance_cnt_total[$__interval])",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": true,
@@ -1329,7 +1329,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(inventory_consumer_msgs_processed_total[$__rate_interval]))",
+              "expr": "sum(rate(kessel_inventory_consumer_msgs_processed_total[$__rate_interval]))",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -1420,7 +1420,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(inventory_consumer_msg_process_failures_total[$__rate_interval])) / sum(rate(inventory_consumer_msgs_processed_total[$__rate_interval])) or sum(up{job=\"kessel-inventory-api\"}) * 0",
+              "expr": "sum(rate(kessel_inventory_consumer_msg_process_failures_total[$__rate_interval])) / sum(rate(kessel_inventory_consumer_msgs_processed_total[$__rate_interval])) or sum(up{job=\"kessel-inventory-api\"}) * 0",
               "format": "time_series",
               "instant": false,
               "legendFormat": "__auto",
@@ -1514,7 +1514,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(inventory_consumer_consumer_errors_total[$__rate_interval])) / sum(rate(inventory_consumer_msgs_processed_total[$__rate_interval])) or sum(up{job=\"kessel-inventory-api\"}) * 0",
+              "expr": "sum(rate(kessel_inventory_consumer_consumer_errors_total[$__rate_interval])) / sum(rate(kessel_inventory_consumer_msgs_processed_total[$__rate_interval])) or sum(up{job=\"kessel-inventory-api\"}) * 0",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -1583,7 +1583,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "inventory_consumer_kafka_error_events_total",
+              "expr": "kessel_inventory_consumer_kafka_error_events_total",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -1617,7 +1617,7 @@ data:
                     "aggregations": [],
                     "operation": "groupby"
                   },
-                  "inventory_consumer_kafka_error_events_total": {
+                  "kessel_inventory_consumer_kafka_error_events_total": {
                     "aggregations": []
                   }
                 }
@@ -1625,6 +1625,249 @@ data:
             }
           ],
           "type": "table"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 46
+          },
+          "id": 21,
+          "panels": [],
+          "title": "Replication",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "(in $range)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 0,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 47
+          },
+          "id": 22,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(kessel_inventory_outbox_event_writes_total[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Outbox Events",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "(in $range)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 0,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 47
+          },
+          "id": 23,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(kessel_inventory_consumer_msgs_processed_total[$__range]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Processed Messages",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Lag from point where resource is written to outbox table, to consumed and processed by inventory consumer",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 1,
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "dashed"
+                }
+              },
+              "fieldMinMax": false,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.8
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 47
+          },
+          "id": 24,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(kessel_inventory_outbox_event_writes_total[3m])) - sum(rate(kessel_inventory_consumer_msgs_processed_total[3m]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "End to end replication lag",
+          "type": "timeseries"
         }
       ],
       "refresh": "",
@@ -1692,7 +1935,7 @@ data:
       "timezone": "browser",
       "title": "Kessel - Inventory API",
       "uid": "ddxs3i6o0xpmof",
-      "version": 6,
+      "version": 7,
       "weekStart": ""
     }
 kind: ConfigMap

--- a/development/configs/monitoring/dashboards/grafana-dashboard-kessel-inventory-api.configmap.json
+++ b/development/configs/monitoring/dashboards/grafana-dashboard-kessel-inventory-api.configmap.json
@@ -743,7 +743,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "count(inventory_consumer_state{state=\"up\"})",
+          "expr": "count(kessel_inventory_consumer_state{state=\"up\"})",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -817,7 +817,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "max(inventory_consumer_replyq)",
+          "expr": "max(kessel_inventory_consumer_replyq)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -884,7 +884,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "min(inventory_consumer_rebalance_age)",
+          "expr": "min(kessel_inventory_consumer_rebalance_age)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1231,7 +1231,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "changes(inventory_consumer_rebalance_cnt_total[$__interval])",
+          "expr": "changes(kessel_inventory_consumer_rebalance_cnt_total[$__interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1326,7 +1326,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(inventory_consumer_msgs_processed_total[$__rate_interval]))",
+          "expr": "sum(rate(kessel_inventory_consumer_msgs_processed_total[$__rate_interval]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1417,7 +1417,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(inventory_consumer_msg_process_failures_total[$__rate_interval])) / sum(rate(inventory_consumer_msgs_processed_total[$__rate_interval])) or sum(up{job=\"kessel-inventory-api\"}) * 0",
+          "expr": "sum(rate(kessel_inventory_consumer_msg_process_failures_total[$__rate_interval])) / sum(rate(kessel_inventory_consumer_msgs_processed_total[$__rate_interval])) or sum(up{job=\"kessel-inventory-api\"}) * 0",
           "format": "time_series",
           "instant": false,
           "legendFormat": "__auto",
@@ -1511,7 +1511,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(inventory_consumer_consumer_errors_total[$__rate_interval])) / sum(rate(inventory_consumer_msgs_processed_total[$__rate_interval])) or sum(up{job=\"kessel-inventory-api\"}) * 0",
+          "expr": "sum(rate(kessel_inventory_consumer_consumer_errors_total[$__rate_interval])) / sum(rate(kessel_inventory_consumer_msgs_processed_total[$__rate_interval])) or sum(up{job=\"kessel-inventory-api\"}) * 0",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1580,7 +1580,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "inventory_consumer_kafka_error_events_total",
+          "expr": "kessel_inventory_consumer_kafka_error_events_total",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1614,7 +1614,7 @@
                 "aggregations": [],
                 "operation": "groupby"
               },
-              "inventory_consumer_kafka_error_events_total": {
+              "kessel_inventory_consumer_kafka_error_events_total": {
                 "aggregations": []
               }
             }
@@ -1622,6 +1622,249 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "id": 21,
+      "panels": [],
+      "title": "Replication",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "(in $range)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 47
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(kessel_inventory_outbox_event_writes_total[$__range]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Outbox Events",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "(in $range)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 47
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(kessel_inventory_consumer_msgs_processed_total[$__range]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Processed Messages",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Lag from point where resource is written to outbox table, to consumed and processed by inventory consumer",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 1,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 47
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(kessel_inventory_outbox_event_writes_total[3m])) - sum(rate(kessel_inventory_consumer_msgs_processed_total[3m]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "End to end replication lag",
+      "type": "timeseries"
     }
   ],
   "refresh": "",
@@ -1689,6 +1932,6 @@
   "timezone": "browser",
   "title": "Kessel - Inventory API",
   "uid": "ddxs3i6o0xpmof",
-  "version": 6,
+  "version": 7,
   "weekStart": ""
 }


### PR DESCRIPTION
### PR Template:

## Describe your changes

* updates dashboard for new metrics added to capture end-to-end replication lag (outbox table  to processed message)
* also updates existing visuals for prefix name change; consumer metric names were updated to avoid any potential conflicts with HBI metrics (inventory collision)

## Ticket reference (if applicable)
For RHCLOUD-39805

## Summary by Sourcery

Update the Kessel Inventory API Grafana dashboard to capture end-to-end replication lag and avoid metric naming collisions.

New Features:
- Add a "Replication" section with stat panels for Outbox Events and Processed Messages, and a timeseries chart for end-to-end replication lag.

Enhancements:
- Rename all inventory consumer metrics with a kessel_ prefix to prevent conflicts and update visuals accordingly.

Chores:
- Bump dashboard version from 6 to 7.