### PR TITLE
RHCLOUD-39717: Serialize resource transactions

### DIFF
--- a/.inventory-api.yaml
+++ b/.inventory-api.yaml
@@ -12,6 +12,7 @@ eventing:
   eventer: stdout
 storage:
   disable-persistence: false
+  max-serialization-retries: 10
   database: sqlite3
   sqlite3:
     dsn: inventory.db

--- a/cmd/.inventory-api.yaml
+++ b/cmd/.inventory-api.yaml
@@ -13,6 +13,7 @@ eventing:
   kafka:
 storage:
   disable-persistence: false
+  max-serialization-retries: 10
   database: sqlite3
   sqlite3:
     dsn: inventory.db

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -258,7 +258,7 @@ func NewCommand(
 
 			//v1beta2
 			// wire together inventory service handling
-			resource_repo := resourcerepo.New(db, mc)
+			resource_repo := resourcerepo.New(db, mc, storageConfig.Options.MaxSerializationRetries)
 			inventory_controller := resourcesctl.New(resource_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			inventory_service := resourcesvc.NewKesselInventoryServiceV1beta2(inventory_controller)
 			pbv1beta2.RegisterKesselInventoryServiceServer(server.GrpcServer, inventory_service)
@@ -266,35 +266,35 @@ func NewCommand(
 
 			//v1beta1
 			// wire together notificationsintegrations handling
-			notifs_repo := resourcerepo.New(db, mc)
+			notifs_repo := resourcerepo.New(db, mc, storageConfig.Options.MaxSerializationRetries)
 			notifs_controller := resourcesctl.New(notifs_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			notifs_service := notifssvc.NewKesselNotificationsIntegrationsServiceV1beta1(notifs_controller)
 			pb.RegisterKesselNotificationsIntegrationServiceServer(server.GrpcServer, notifs_service)
 			pb.RegisterKesselNotificationsIntegrationServiceHTTPServer(server.HttpServer, notifs_service)
 
 			// wire together authz handling
-			authz_repo := resourcerepo.New(db, mc)
+			authz_repo := resourcerepo.New(db, mc, storageConfig.Options.MaxSerializationRetries)
 			authz_controller := resourcesctl.New(authz_repo, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			authz_service := resourcesvc.NewKesselCheckServiceV1beta1(authz_controller)
 			authzv1beta1.RegisterKesselCheckServiceServer(server.GrpcServer, authz_service)
 			authzv1beta1.RegisterKesselCheckServiceHTTPServer(server.HttpServer, authz_service)
 
 			// wire together hosts handling
-			hosts_repo := resourcerepo.New(db, mc)
+			hosts_repo := resourcerepo.New(db, mc, storageConfig.Options.MaxSerializationRetries)
 			hosts_controller := resourcesctl.New(hosts_repo, inventoryresources_repo, authorizer, eventingManager, "hbi", log.With(logger, "subsystem", "hosts_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			hosts_service := hostssvc.NewKesselRhelHostServiceV1beta1(hosts_controller)
 			pb.RegisterKesselRhelHostServiceServer(server.GrpcServer, hosts_service)
 			pb.RegisterKesselRhelHostServiceHTTPServer(server.HttpServer, hosts_service)
 
 			// wire together k8sclusters handling
-			k8sclusters_repo := resourcerepo.New(db, mc)
+			k8sclusters_repo := resourcerepo.New(db, mc, storageConfig.Options.MaxSerializationRetries)
 			k8sclusters_controller := resourcesctl.New(k8sclusters_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8sclusters_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			k8sclusters_service := k8sclusterssvc.NewKesselK8SClusterServiceV1beta1(k8sclusters_controller)
 			pb.RegisterKesselK8SClusterServiceServer(server.GrpcServer, k8sclusters_service)
 			pb.RegisterKesselK8SClusterServiceHTTPServer(server.HttpServer, k8sclusters_service)
 
 			// wire together k8spolicies handling
-			k8spolicies_repo := resourcerepo.New(db, mc)
+			k8spolicies_repo := resourcerepo.New(db, mc, storageConfig.Options.MaxSerializationRetries)
 			k8spolicies_controller := resourcesctl.New(k8spolicies_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8spolicies_controller"), listenManager, waitForNotifCircuitBreaker, usecaseConfig)
 			k8spolicies_service := k8spoliciessvc.NewKesselK8SPolicyServiceV1beta1(k8spolicies_controller)
 			pb.RegisterKesselK8SPolicyServiceServer(server.GrpcServer, k8spolicies_service)

--- a/deploy/kessel-inventory-ephem.yaml
+++ b/deploy/kessel-inventory-ephem.yaml
@@ -11,6 +11,7 @@ objects:
       inventory-api-config.yaml: |
         storage:
           disable-persistence: false
+          max-serialization-retries: 10
         authn:
           allow-unauthenticated: true
         authz:

--- a/deploy/kind/inventory/kessel-inventory.yaml
+++ b/deploy/kind/inventory/kessel-inventory.yaml
@@ -197,6 +197,7 @@ stringData:
       read-after-write-allowlist: ["*"]
     storage:
       disable-persistence: false
+      max-serialization-retries: 10
       database: postgres
       sqlite3:
         dsn: inventory.db

--- a/development/configs/full-kessel-w-monitoring.yaml
+++ b/development/configs/full-kessel-w-monitoring.yaml
@@ -17,6 +17,7 @@ eventing:
   kafka:
 storage:
   disable-persistence: false
+  max-serialization-retries: 10
   database: postgres
   postgres:
     host: "invdatabase"

--- a/development/configs/full-setup-relations-ready.yaml
+++ b/development/configs/full-setup-relations-ready.yaml
@@ -17,6 +17,7 @@ eventing:
   kafka:
 storage:
   disable-persistence: false
+  max-serialization-retries: 10
   database: postgres
   postgres:
     host: "invdatabase"

--- a/development/configs/full-setup-w-sso.yaml
+++ b/development/configs/full-setup-w-sso.yaml
@@ -21,6 +21,7 @@ eventing:
   kafka:
 storage:
   disable-persistence: false
+  max-serialization-retries: 10
   database: postgres
   postgres:
     host: "invdatabase"

--- a/development/configs/full-setup.yaml
+++ b/development/configs/full-setup.yaml
@@ -12,6 +12,7 @@ eventing:
   kafka:
 storage:
   disable-persistence: false
+  max-serialization-retries: 10
   database: postgres
   postgres:
     host: "invdatabase"

--- a/development/configs/local-w-relations.yaml
+++ b/development/configs/local-w-relations.yaml
@@ -21,6 +21,7 @@ eventing:
   kafka:
 storage:
   disable-persistence: false
+  max-serialization-retries: 10
   database: sqlite3
   sqlite3:
     dsn: inventory.db

--- a/development/configs/split-setup-relations-ready.yaml
+++ b/development/configs/split-setup-relations-ready.yaml
@@ -17,6 +17,7 @@ eventing:
   kafka:
 storage:
   disable-persistence: false
+  max-serialization-retries: 10
   database: postgres
   postgres:
     host: "invdatabase"

--- a/development/configs/split-setup.yaml
+++ b/development/configs/split-setup.yaml
@@ -12,6 +12,7 @@ eventing:
   kafka:
 storage:
   disable-persistence: false
+  max-serialization-retries: 10
   database: postgres
   postgres:
     host: "invdatabase"

--- a/docs/dev-guides/serializable-isolation-level.md
+++ b/docs/dev-guides/serializable-isolation-level.md
@@ -1,0 +1,40 @@
+# Serializable Isolation Level in ResourceRepository
+
+This document outlines the use of the `Serializable` isolation configuration in managing database transactions within the `ResourceRepository`. `Serializable` isolation ensures data consistency and integrity during concurrent operations by using automatic conflict detection and retries between transactions, specifically on our resource CRUD operations.
+
+## Development Best Practices
+When using the `Serializable` isolation level, it is crucial to follow best practices to minimize contention and ensure optimal performance.
+
+1. **Serialization Failures Are Expected**: 
+   - The `Serializable` isolation level is designed to detect conflicts between transactions. As a result, serialization failures may occur when two transactions attempt to modify the same data concurrently. This is a normal behavior and should be expected. Excessive retries may indicate contention issues.
+   - When a serialization failure occurs, the transaction will be retried automatically up to the configured maximum number of retries.
+1. **Reads Should Live In the Transaction**: 
+   - All reads should be performed within the same transaction as your write to ensure that the data being read is used for conflict detection.
+1. **Use Indexes**: 
+   - Ensure that the database tables involved in the transactions are properly indexed. This can help reduce contention by allowing the database to quickly locate the data being accessed without scanning the entire table.
+1. **Avoid Explicit Locks**: 
+   - Explicit locks should be avoided. i.e. `SELECT FOR UPDATE` and `SELECT FOR SHARE`. These are not needed due to the protections automatically provided by serializable transactions. This is not a complete incompatibility, but if locks are being considered on top of SSI it could be indicative of design “smell”.
+1. **Keep Transactions Lean**: 
+   - Keep our transactions as lean as possible. Introducing more tables/queries to our resource transactions will increase our surface area for serialization failures. Increasingly complex transactions will produce additional stress on the DB under high load due to the conflict tracking mechanism that SSI uses
+
+## Configuration
+
+`max-serialization-retries` is available via storage config. The value holds the maximum number of retries for a transaction before it is aborted. The default value is `10`, but it can be adjusted if necessary. This should be done with caution, as increasing the number of retries may lead to performance degradation in high contention scenarios. 
+
+**Before increasing the value we should analyze the root cause of the contention and address that if possible.**
+```yaml
+storage:
+  ...
+  max-serialization-retries: 10
+```
+
+## Root Causing Contention Issues
+There are a few possible reasons for contention issues in a database:
+1. **High Concurrency**: Multiple transactions trying to access the same data simultaneously can lead to contention.
+    * Is a service provider making an unreasonable number of requests for specific or related resources?
+    * Are there multiple service providers making many requests for the same resources?
+2. **Long-Running Transactions**: Transactions that take a long time have more opportunities to conflict with others.
+    * Was there new code added that may be causing long-running transactions?
+    * You can check AWS performance insights for long-running queries.
+4. **Lack of Indexing**: Missing indexes can cause queries to scan more data than necessary, leading to contention.
+    * Are there new queries in transactions that are not using indexes?

--- a/internal/data/relationships/relationshiprepository_test.go
+++ b/internal/data/relationships/relationshiprepository_test.go
@@ -182,7 +182,8 @@ func assertEqualRelationshipHistory(t *testing.T, r *model.Relationship, rh *mod
 //}
 
 func createResource(t *testing.T, db *gorm.DB, mc *metricscollector.MetricsCollector, resource *model.Resource) uuid.UUID {
-	res, err := resources.New(db, mc).Create(context.TODO(), resource, "foobar-namespace", emptyTxId)
+	maxSerializationRetries := 3
+	res, err := resources.New(db, mc, maxSerializationRetries).Create(context.TODO(), resource, "foobar-namespace", emptyTxId)
 	assert.Nil(t, err)
 	return res.ID
 }

--- a/internal/data/resources/resourcerepository.go
+++ b/internal/data/resources/resourcerepository.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -14,14 +15,16 @@ import (
 )
 
 type Repo struct {
-	DB               *gorm.DB
-	MetricsCollector *metricscollector.MetricsCollector
+	DB                      *gorm.DB
+	MetricsCollector        *metricscollector.MetricsCollector
+	MaxSerializationRetries int
 }
 
-func New(db *gorm.DB, mc *metricscollector.MetricsCollector) *Repo {
+func New(db *gorm.DB, mc *metricscollector.MetricsCollector, maxSerializationRetries int) *Repo {
 	return &Repo{
-		DB:               db,
-		MetricsCollector: mc,
+		DB:                      db,
+		MetricsCollector:        mc,
+		MaxSerializationRetries: maxSerializationRetries,
 	}
 }
 
@@ -42,171 +45,178 @@ func copyHistory(m *model.Resource, id uuid.UUID, operationType model.OperationT
 
 func (r *Repo) Create(ctx context.Context, m *model.Resource, namespace string, txid string) (*model.Resource, error) {
 	db := r.DB.Session(&gorm.Session{})
-	tx := db.Begin()
-	updatedResources := []*model.Resource{}
+	var result *model.Resource
+	err := r.handleSerializableTransaction(db, func(tx *gorm.DB) error {
+		updatedResources := []*model.Resource{}
 
-	if m.InventoryId == nil {
-		// New inventory resource
-		inventoryResource := model.InventoryResource{
-			ResourceType: m.ResourceType,
-			WorkspaceId:  m.WorkspaceId,
+		if m.InventoryId == nil {
+			// New inventory resource
+			inventoryResource := model.InventoryResource{
+				ResourceType: m.ResourceType,
+				WorkspaceId:  m.WorkspaceId,
+			}
+			// Create a new inventory resource
+			if err := tx.Create(&inventoryResource).Error; err != nil {
+				return fmt.Errorf("creating inventory resource: %w", err)
+			}
+			m.InventoryId = &inventoryResource.ID
 		}
-		// Create a new inventory resource
-		if err := tx.Create(&inventoryResource).Error; err != nil {
-			tx.Rollback()
-			return nil, fmt.Errorf("creating inventory resource: %w", err)
+
+		if err := tx.Create(m).Error; err != nil {
+			return err
 		}
-		m.InventoryId = &inventoryResource.ID
-	}
 
-	if err := tx.Create(m).Error; err != nil {
-		tx.Rollback()
-		return nil, err
-	}
+		if err := tx.Create(copyHistory(m, m.ID, model.OperationTypeCreate)).Error; err != nil {
+			return err
+		}
 
-	if err := tx.Create(copyHistory(m, m.ID, model.OperationTypeCreate)).Error; err != nil {
-		tx.Rollback()
-		return nil, err
-	}
-
-	// Handle workspace updates for other resources with the same inventory ID
-	updatedResources, err := r.handleWorkspaceUpdates(tx, m, updatedResources)
-	if err != nil {
-		tx.Rollback()
-		return nil, err
-	}
-
-	// Deprecated
-	// TODO: Remove this when all resources are created with inventory ID
-	if err := tx.Create(&model.LocalInventoryToResource{
-		ResourceId:         m.ID,
-		ReporterResourceId: model.ReporterResourceIdFromResource(m),
-	}).Error; err != nil {
-		tx.Rollback()
-		return nil, err
-	}
-
-	// Publish outbox events for primary resource
-	err = handleOutboxEvents(tx, *m, namespace, model.OperationTypeCreated, txid)
-	if err != nil {
-		tx.Rollback()
-		return nil, err
-	}
-
-	// Publish outbox events for other resources with the same inventory ID
-	for _, updatedResource := range updatedResources {
-		err = handleOutboxEvents(tx, *updatedResource, namespace, model.OperationTypeUpdated, "")
+		// Handle workspace updates for other resources with the same inventory ID
+		updatedResources, err := r.handleWorkspaceUpdates(tx, m, updatedResources)
 		if err != nil {
-			tx.Rollback()
-			return nil, err
+			return err
 		}
-	}
 
-	tx.Commit()
+		// Deprecated
+		// TODO: Remove this when all resources are created with inventory ID
+		if err := tx.Create(&model.LocalInventoryToResource{
+			ResourceId:         m.ID,
+			ReporterResourceId: model.ReporterResourceIdFromResource(m),
+		}).Error; err != nil {
+			return err
+		}
+
+		// Publish outbox events for primary resource
+		err = handleOutboxEvents(tx, *m, namespace, model.OperationTypeCreated, txid)
+		if err != nil {
+			return err
+		}
+
+		// Publish outbox events for other resources with the same inventory ID
+		for _, updatedResource := range updatedResources {
+			err = handleOutboxEvents(tx, *updatedResource, namespace, model.OperationTypeUpdated, "")
+			if err != nil {
+				return err
+			}
+		}
+		result = m
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
 	metricscollector.Incr(r.MetricsCollector.OutboxEventWrites, string(model.OperationTypeCreated), nil)
-	return m, nil
+	return result, nil
 }
 
 func (r *Repo) Update(ctx context.Context, m *model.Resource, id uuid.UUID, namespace string, txid string) (*model.Resource, error) {
 	db := r.DB.Session(&gorm.Session{})
-	updatedResources := []*model.Resource{}
-
-	resource, err := r.FindByID(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-
-	tx := db.Begin()
-	if err := tx.Create(copyHistory(m, id, model.OperationTypeUpdate)).Error; err != nil {
-		tx.Rollback()
-		return nil, err
-	}
-
-	m.ID = id
-	m.CreatedAt = resource.CreatedAt
-	m.InventoryId = resource.InventoryId
-	if err := tx.Save(m).Error; err != nil {
-		tx.Rollback()
-		return nil, err
-	}
-
-	// Handle workspace updates for other resources with the same inventory ID
-	updatedResources, err = r.handleWorkspaceUpdates(tx, m, updatedResources)
-	if err != nil {
-		tx.Rollback()
-		return nil, err
-	}
-
-	// Publish outbox events for primary resource
-	err = handleOutboxEvents(tx, *m, namespace, model.OperationTypeUpdated, txid)
-	if err != nil {
-		tx.Rollback()
-		return nil, err
-	}
-
-	// Publish outbox event for the primary resource and other resources with the same inventory ID
-	for _, updatedResource := range updatedResources {
-		err = handleOutboxEvents(tx, *updatedResource, namespace, model.OperationTypeUpdated, "")
+	var result *model.Resource
+	err := r.handleSerializableTransaction(db, func(tx *gorm.DB) error {
+		updatedResources := []*model.Resource{}
+		resource, err := r.FindByIDWithTx(ctx, tx, id)
 		if err != nil {
-			tx.Rollback()
-			return nil, err
+			return err
 		}
-	}
 
-	tx.Commit()
+		if err := tx.Create(copyHistory(m, id, model.OperationTypeUpdate)).Error; err != nil {
+			return err
+		}
+
+		m.ID = id
+		m.CreatedAt = resource.CreatedAt
+		m.InventoryId = resource.InventoryId
+		if err := tx.Save(m).Error; err != nil {
+			return err
+		}
+
+		// Handle workspace updates for other resources with the same inventory ID
+		updatedResources, err = r.handleWorkspaceUpdates(tx, m, updatedResources)
+		if err != nil {
+			return err
+		}
+
+		// Publish outbox events for primary resource
+		err = handleOutboxEvents(tx, *m, namespace, model.OperationTypeUpdated, txid)
+		if err != nil {
+			return err
+		}
+
+		// Publish outbox event for the primary resource and other resources with the same inventory ID
+		for _, updatedResource := range updatedResources {
+			err = handleOutboxEvents(tx, *updatedResource, namespace, model.OperationTypeUpdated, "")
+			if err != nil {
+				return err
+			}
+		}
+		result = m
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
 	metricscollector.Incr(r.MetricsCollector.OutboxEventWrites, string(model.OperationTypeUpdated), nil)
-	return m, nil
+	return result, nil
 }
 
 func (r *Repo) Delete(ctx context.Context, id uuid.UUID, namespace string) (*model.Resource, error) {
 	db := r.DB.Session(&gorm.Session{})
-
-	resource, err := r.FindByID(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-
-	tx := db.Begin()
-	if err := tx.Create(copyHistory(resource, resource.ID, model.OperationTypeDelete)).Error; err != nil {
-		tx.Rollback()
-		return nil, err
-	}
-
-	// Delete relationships - We don't yet care about keeping history of deleted relationships of a deleted resource.
-	if err := tx.Where("subject_id = ? or object_id = ?", id, id).Delete(&model.Relationship{}).Error; err != nil {
-		tx.Rollback()
-		return nil, err
-	}
-
-	if err := tx.Delete(resource).Error; err != nil {
-		tx.Rollback()
-		return nil, err
-	}
-
-	if resource.InventoryId != nil {
-		// Delete Inventory Resource if no other resources are referencing it
-		var count int64
-		if err := tx.Model(&model.Resource{}).Where("inventory_id = ?", *resource.InventoryId).Count(&count).Error; err != nil {
-			tx.Rollback()
-			return nil, err
+	var result *model.Resource
+	err := r.handleSerializableTransaction(db, func(tx *gorm.DB) error {
+		resource, err := r.FindByIDWithTx(ctx, tx, id)
+		if err != nil {
+			return err
 		}
-		if count == 0 {
-			if err := tx.Delete(&model.InventoryResource{}, *resource.InventoryId).Error; err != nil {
-				tx.Rollback()
-				return nil, err
+
+		if err := tx.Create(copyHistory(resource, resource.ID, model.OperationTypeDelete)).Error; err != nil {
+			return err
+		}
+
+		// Delete relationships - We don't yet care about keeping history of deleted relationships of a deleted resource.
+		if err := tx.Where("subject_id = ? or object_id = ?", id, id).Delete(&model.Relationship{}).Error; err != nil {
+			return err
+		}
+
+		if err := tx.Delete(resource).Error; err != nil {
+			return err
+		}
+
+		if resource.InventoryId != nil {
+			// Delete Inventory Resource if no other resources are referencing it
+			var count int64
+			if err := tx.Model(&model.Resource{}).Where("inventory_id = ?", *resource.InventoryId).Count(&count).Error; err != nil {
+				return err
+			}
+			if count == 0 {
+				if err := tx.Delete(&model.InventoryResource{}, *resource.InventoryId).Error; err != nil {
+					return err
+				}
 			}
 		}
-	}
 
-	err = handleOutboxEvents(tx, *resource, namespace, model.OperationTypeDeleted, "")
+		err = handleOutboxEvents(tx, *resource, namespace, model.OperationTypeDeleted, "")
+		if err != nil {
+			return err
+		}
+
+		result = resource
+		return nil
+	})
+
 	if err != nil {
-		tx.Rollback()
+		return nil, err
+	}
+	metricscollector.Incr(r.MetricsCollector.OutboxEventWrites, string(model.OperationTypeDeleted), nil)
+	return result, nil
+}
+
+func (r *Repo) FindByIDWithTx(ctx context.Context, tx *gorm.DB, id uuid.UUID) (*model.Resource, error) {
+	resource := model.Resource{}
+	if err := tx.First(&resource, id).Error; err != nil {
 		return nil, err
 	}
 
-	tx.Commit()
-	metricscollector.Incr(r.MetricsCollector.OutboxEventWrites, string(model.OperationTypeDeleted), nil)
-	return resource, nil
+	return &resource, nil
 }
 
 func (r *Repo) FindByID(ctx context.Context, id uuid.UUID) (*model.Resource, error) {
@@ -354,4 +364,29 @@ func handleOutboxEvents(tx *gorm.DB, resource model.Resource, namespace string, 
 	}
 
 	return nil
+}
+
+// Handles serializable transaction rollbacks, commits, and retries in case of failures.
+// It retries the transaction up to maxRetries times before returning an error.
+func (r *Repo) handleSerializableTransaction(db *gorm.DB, txFunc func(tx *gorm.DB) error) error {
+	var err error
+	for i := 0; i < r.MaxSerializationRetries; i++ {
+		tx := db.Begin(&sql.TxOptions{
+			Isolation: sql.LevelSerializable,
+		})
+		err = txFunc(tx)
+		if err != nil {
+			log.Debugf("transaction failed before commit (attempt %d/%d): %v", i+1, r.MaxSerializationRetries, err)
+			tx.Rollback()
+			continue
+		}
+		err = tx.Commit().Error
+		if err != nil {
+			log.Debugf("error committing transaction (attempt %d/%d): %v", i+1, r.MaxSerializationRetries, err)
+			tx.Rollback()
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("transaction failed after %d attempts: %w", r.MaxSerializationRetries, err)
 }

--- a/internal/storage/options.go
+++ b/internal/storage/options.go
@@ -10,10 +10,11 @@ import (
 )
 
 type Options struct {
-	Postgres           *postgres.Options `mapstructure:"postgres"`
-	SqlLite3           *sqlite3.Options  `mapstructure:"sqlite3"`
-	Database           string            `mapstructure:"database"`
-	DisablePersistence bool              `mapstructure:"disable-persistence"`
+	Postgres                *postgres.Options `mapstructure:"postgres"`
+	SqlLite3                *sqlite3.Options  `mapstructure:"sqlite3"`
+	Database                string            `mapstructure:"database"`
+	DisablePersistence      bool              `mapstructure:"disable-persistence"`
+	MaxSerializationRetries int               `mapstructure:"max-serialization-retries"`
 }
 
 const (
@@ -23,10 +24,11 @@ const (
 
 func NewOptions() *Options {
 	return &Options{
-		Postgres:           postgres.NewOptions(),
-		SqlLite3:           sqlite3.NewOptions(),
-		Database:           "sqlite3",
-		DisablePersistence: false,
+		Postgres:                postgres.NewOptions(),
+		SqlLite3:                sqlite3.NewOptions(),
+		Database:                "sqlite3",
+		DisablePersistence:      false,
+		MaxSerializationRetries: 10,
 	}
 }
 
@@ -37,6 +39,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 
 	fs.StringVar(&o.Database, prefix+"database", o.Database, "The database type to use.  Either sqlite3 or postgres.")
 	fs.BoolVar(&o.DisablePersistence, prefix+"disable-persistence", o.DisablePersistence, "Disable storing data in the database")
+	fs.IntVar(&o.MaxSerializationRetries, prefix+"max-serialization-retries", o.MaxSerializationRetries, "Maximum number of retries for serialized transactions")
 
 	o.Postgres.AddFlags(fs, prefix+"postgres")
 	o.SqlLite3.AddFlags(fs, prefix+"sqlite3")


### PR DESCRIPTION
* Introduces a serializable transaction handler in the resource repository
  * Creates and manages transactions
  * Sets isolation level for transactions
  * Handles Commit/Rollback/Retry
* Adds FindByIDWithTx function to accept transactions when finding resources by id
* Tests FindByID, FindByIDWithTx, and failure mechanism for serialization

## Summary by Sourcery

Enable serializable transaction handling in the resource repository with automatic retry logic and migrate CRUD operations to use it

New Features:
- Introduce handleSerializableTransaction to run retryable serializable transactions
- Add FindByIDWithTx to fetch resources using an existing transaction
- Refactor Create, Update, and Delete to execute within serializable transactions

Enhancements:
- Remove manual transaction begin/commit/rollback and consolidate transaction logic
- Define MAX_RETRIES constant to cap transaction retry attempts

Tests:
- Add TestFindByID to validate lookup without a transaction
- Add TestFindByIDWithTx to validate lookup within a transaction
- Add TestSerializableUpdateFails to verify retry behavior on serialization conflicts