### PR TITLE
RHCLOUD-39786: improves clowder injection

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,7 +78,7 @@ func init() {
 	}
 
 	if clowder.IsClowderEnabled() {
-		err := options.InjectClowdAppConfig()
+		err := options.InjectClowdAppConfig(clowder.LoadedConfig)
 		if err != nil {
 			panic(err)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,10 +5,18 @@ import (
 	"testing"
 
 	. "github.com/project-kessel/inventory-api/cmd/common"
+	"github.com/project-kessel/inventory-api/internal/authz"
+	"github.com/project-kessel/inventory-api/internal/authz/kessel"
+	"github.com/project-kessel/inventory-api/internal/consumer"
+	"github.com/project-kessel/inventory-api/internal/consumer/auth"
+	"github.com/project-kessel/inventory-api/internal/storage"
+	"github.com/project-kessel/inventory-api/internal/storage/postgres"
 
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 	"github.com/stretchr/testify/assert"
 )
+
+var testCA = `-----BEGIN CERTIFICATE-----\nFAKE-CA\n-----END CERTIFICATE-----`
 
 func ParseCA(t *testing.T, path string) string {
 	file, err := os.ReadFile(path)
@@ -20,8 +28,6 @@ func ParseCA(t *testing.T, path string) string {
 }
 
 func TestConfigureStorage(t *testing.T) {
-	var testCA = `-----BEGIN CERTIFICATE-----\nFAKE-CA\n-----END CERTIFICATE-----`
-
 	test := struct {
 		name      string
 		appconfig *clowder.AppConfig
@@ -99,6 +105,7 @@ func TestConfigureAuthz(t *testing.T) {
 		appconfig: &clowder.AppConfig{
 			Endpoints: []clowder.DependencyEndpoint{
 				clowder.DependencyEndpoint{
+					App:      authz.RelationsAPI,
 					Hostname: "kessel-relations",
 				},
 			},
@@ -123,7 +130,7 @@ func TestConfigureConsumer(t *testing.T) {
 		expected    []string
 	}{
 		{
-			name: "ensure boostrap server is set properly when only one is provided",
+			name: "ensure boostrap server is set properly when only one is provided - no auth settings",
 			appconfig: &clowder.AppConfig{
 				Kafka: &clowder.KafkaConfig{
 					Brokers: []clowder.BrokerConfig{
@@ -139,7 +146,7 @@ func TestConfigureConsumer(t *testing.T) {
 			expected:    []string{"test-kafka-server:9092"},
 		},
 		{
-			name: "ensure boostrap server is set properly when multiple are provided",
+			name: "ensure boostrap server is set properly when multiple are provided - no auth settings",
 			appconfig: &clowder.AppConfig{
 				Kafka: &clowder.KafkaConfig{
 					Brokers: []clowder.BrokerConfig{
@@ -204,4 +211,189 @@ func TestConfigureConsumer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInjectClowdAppConfig(t *testing.T) {
+	authzTest := struct {
+		name      string
+		appconfig *clowder.AppConfig
+		options   *OptionsConfig
+		expected  *OptionsConfig
+	}{
+		name: "Authz is configured and injected, storage and consumer are ignored",
+		appconfig: &clowder.AppConfig{
+			Endpoints: []clowder.DependencyEndpoint{
+				clowder.DependencyEndpoint{
+					App:      authz.RelationsAPI,
+					Hostname: "kessel-relations",
+				},
+			},
+		},
+		options: NewOptionsConfig(),
+		expected: &OptionsConfig{
+			Authz: &authz.Options{
+				Authz: authz.Kessel,
+				Kessel: &kessel.Options{
+					URL: "kessel-relations:9000",
+				},
+			},
+		},
+	}
+
+	t.Run(authzTest.name, func(t *testing.T) {
+		err := authzTest.options.InjectClowdAppConfig(authzTest.appconfig)
+		assert.NoError(t, err)
+		assert.Equal(t, authzTest.expected.Authz.Authz, authzTest.options.Authz.Authz)
+		assert.Equal(t, authzTest.expected.Authz.Kessel.URL, authzTest.options.Authz.Kessel.URL)
+		assert.Nil(t, authzTest.expected.Storage)
+		assert.Nil(t, authzTest.expected.Consumer)
+	})
+
+	storageTest := struct {
+		name      string
+		appconfig *clowder.AppConfig
+		options   *OptionsConfig
+		expected  *OptionsConfig
+	}{
+		name: "Storage is configured and injected, authz and consumer are ignored",
+		appconfig: &clowder.AppConfig{
+			Endpoints: []clowder.DependencyEndpoint{},
+			Database: &clowder.DatabaseConfig{
+				Hostname: "postgres",
+				Name:     "postgres",
+				Port:     5432,
+				Username: "db-user",
+				Password: "db-password",
+			},
+		},
+		options: NewOptionsConfig(),
+		expected: &OptionsConfig{
+			Storage: &storage.Options{
+				Database: storage.Postgres,
+				Postgres: &postgres.Options{
+					Host:     "postgres",
+					Port:     "5432",
+					User:     "db-user",
+					Password: "db-password",
+					DbName:   "postgres",
+				},
+			},
+		},
+	}
+
+	t.Run(storageTest.name, func(t *testing.T) {
+		err := storageTest.options.InjectClowdAppConfig(storageTest.appconfig)
+		assert.NoError(t, err)
+		assert.Equal(t, storageTest.expected.Storage.Database, storageTest.options.Storage.Database)
+		assert.Equal(t, storageTest.expected.Storage.Postgres.Host, storageTest.options.Storage.Postgres.Host)
+		assert.Equal(t, storageTest.expected.Storage.Postgres.Port, storageTest.options.Storage.Postgres.Port)
+		assert.Equal(t, storageTest.expected.Storage.Postgres.User, storageTest.options.Storage.Postgres.User)
+		assert.Equal(t, storageTest.expected.Storage.Postgres.Password, storageTest.options.Storage.Postgres.Password)
+		assert.Equal(t, storageTest.expected.Storage.Postgres.DbName, storageTest.options.Storage.Postgres.DbName)
+		assert.Nil(t, storageTest.expected.Authz)
+		assert.Nil(t, storageTest.expected.Consumer)
+	})
+
+	consumerTest := struct {
+		name      string
+		appconfig *clowder.AppConfig
+		options   *OptionsConfig
+		expected  *OptionsConfig
+	}{
+		name: "Consumer is configured and injected with no auth settings, authz and storage are ignored",
+		appconfig: &clowder.AppConfig{
+			Endpoints: []clowder.DependencyEndpoint{},
+			Kafka: &clowder.KafkaConfig{
+				Brokers: []clowder.BrokerConfig{
+					{
+						Hostname: "test-kafka-server",
+						Port:     ToPointer(9092),
+					},
+				},
+			},
+		},
+		options: NewOptionsConfig(),
+		expected: &OptionsConfig{
+			Consumer: &consumer.Options{
+				BootstrapServers: []string{"test-kafka-server:9092"},
+			},
+		},
+	}
+	t.Run(consumerTest.name, func(t *testing.T) {
+		err := consumerTest.options.InjectClowdAppConfig(consumerTest.appconfig)
+		assert.NoError(t, err)
+		assert.Equal(t, consumerTest.expected.Consumer.BootstrapServers, consumerTest.options.Consumer.BootstrapServers)
+		assert.Nil(t, consumerTest.expected.Authz)
+		assert.Nil(t, consumerTest.expected.Storage)
+	})
+
+	consumerAuthTest := struct {
+		name      string
+		appconfig *clowder.AppConfig
+		options   *OptionsConfig
+		expected  *OptionsConfig
+	}{
+		name: "Consumer is configured and injected with auth settings, authz and storage are ignored",
+		appconfig: &clowder.AppConfig{
+			Endpoints: []clowder.DependencyEndpoint{},
+			Kafka: &clowder.KafkaConfig{
+				Brokers: []clowder.BrokerConfig{
+					{
+						Hostname:         "test-kafka-server-01",
+						Port:             ToPointer(9092),
+						SecurityProtocol: ToPointer("SASL_SSL"),
+						Sasl: &clowder.KafkaSASLConfig{
+							Password:         ToPointer("test-password"),
+							SaslMechanism:    ToPointer("SCRAM-SHA-512"),
+							SecurityProtocol: ToPointer("SASL_SSL"),
+							Username:         ToPointer("test-user"),
+						},
+					},
+				},
+			},
+		},
+		options: NewOptionsConfig(),
+		expected: &OptionsConfig{
+			Consumer: &consumer.Options{
+				BootstrapServers: []string{"test-kafka-server-01:9092"},
+				AuthOptions: &auth.Options{
+					SecurityProtocol: "SASL_SSL",
+					SASLMechanism:    "SCRAM-SHA-512",
+					SASLUsername:     "test-user",
+					SASLPassword:     "test-password",
+				},
+			},
+		},
+	}
+	t.Run(consumerAuthTest.name, func(t *testing.T) {
+		err := consumerAuthTest.options.InjectClowdAppConfig(consumerAuthTest.appconfig)
+		assert.NoError(t, err)
+		assert.Equal(t, consumerAuthTest.expected.Consumer.BootstrapServers, consumerAuthTest.options.Consumer.BootstrapServers)
+		assert.Equal(t, consumerAuthTest.expected.Consumer.AuthOptions.SecurityProtocol, consumerAuthTest.options.Consumer.AuthOptions.SecurityProtocol)
+		assert.Equal(t, consumerAuthTest.expected.Consumer.AuthOptions.SASLMechanism, consumerAuthTest.options.Consumer.AuthOptions.SASLMechanism)
+		assert.Equal(t, consumerAuthTest.expected.Consumer.AuthOptions.SASLUsername, consumerAuthTest.options.Consumer.AuthOptions.SASLUsername)
+		assert.Equal(t, consumerAuthTest.expected.Consumer.AuthOptions.SASLPassword, consumerAuthTest.options.Consumer.AuthOptions.SASLPassword)
+		assert.Nil(t, consumerAuthTest.expected.Authz)
+		assert.Nil(t, consumerAuthTest.expected.Storage)
+	})
+
+	noConfigTest := struct {
+		name      string
+		appconfig *clowder.AppConfig
+		options   *OptionsConfig
+		expected  *OptionsConfig
+	}{
+		name:      "No values found in AppConfig -- Clowder changes nothing",
+		appconfig: &clowder.AppConfig{},
+		options:   NewOptionsConfig(),
+		expected:  NewOptionsConfig(),
+	}
+
+	t.Run(noConfigTest.name, func(t *testing.T) {
+		err := noConfigTest.options.InjectClowdAppConfig(noConfigTest.appconfig)
+		assert.NoError(t, err)
+		assert.Equal(t, noConfigTest.expected.Authz, noConfigTest.options.Authz)
+		assert.Equal(t, noConfigTest.expected.Storage, noConfigTest.options.Storage)
+		assert.Equal(t, noConfigTest.expected.Consumer, noConfigTest.options.Consumer)
+	})
 }

--- a/scripts/load-generator-v1beta2.sh
+++ b/scripts/load-generator-v1beta2.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# prints a handy help menu with usage
+help_me() {
+    echo "USAGE: load-generator.sh {-n <NUM_RUNS>} {-i <INTERVAL>} {-p <PORT_NUM>} [-h]"
+    echo "load-generator: creates load on inventory API by creating, updating, and deleting resources for test purposes"
+    echo "It requires a local running Inventory API or port-forwarding connection to one in ephemeral (using port defined with -p)"
+    echo ""
+    echo "REQUIRED ARGUMENTS:"
+    echo "  -n NUM_RUNS: The number of times to run a test loop (one run is one create, update, and delete loop"
+    echo "  -i INTERVAL: Amount of time between runs"
+    echo "  -p PORT_NUM: Port number used for Inventory API"
+    echo ""
+    echo "OPTIONS:"
+    echo "  -h Prints usage information"
+    echo ""
+    echo "EXAMPLE:"
+    echo "# Run 5 test loops with a 3 second break between tests"
+    echo "  load-generator.sh -n 5 -i 3"
+    exit 0
+}
+
+livez_check() {
+  STATUS=$(curl -s $LIVEZ_URL | jq -r '.status')
+  if [[ "${STATUS}" != "OK" ]]; then
+    echo "LiveZ check failed -- is Inventory running or port-forwarded?"
+    exit 1
+  fi
+}
+
+while getopts "n:i:p:h" flag; do
+    case "${flag}" in
+        n) NUM_RUNS=${OPTARG};;
+        i) INTERVAL=${OPTARG};;
+        p) PORT_NUM=${OPTARG};;
+        h) help_me;;
+    esac
+done
+
+if [[  -z "${NUM_RUNS}" || -z "${INTERVAL}"  || -z "${PORT_NUM}" ]]; then
+  echo "Error: required arguments not provided"
+  help_me
+fi
+
+LIVEZ_URL="localhost:${PORT_NUM}/api/inventory/v1/livez"
+INVENTORY_URL="localhost:${PORT_NUM}/api/inventory/v1beta2/resources"
+
+for ((i = 0 ; i < ${NUM_RUNS} ; i++)); do
+  livez_check
+  REPORTER_INSTANCE_ID=$(uuidgen)
+  WORKSPACE_ID=$(uuidgen)
+  LOCAL_RESOURCE_ID=$(uuidgen)
+
+  REQUEST=$(jq -c --null-input \
+    --arg reporter_instance_id "$REPORTER_INSTANCE_ID" \
+    --arg workspace_id  "$WORKSPACE_ID" \
+    --arg local_resource_id "$LOCAL_RESOURCE_ID" \
+    '{"type":"notifications_integration","reporterType":"NOTIFICATIONS","reporterInstanceId":$reporter_instance_id,"representations":{"metadata":{"localResourceId":$local_resource_id,"apiHref":"https://www.campbell-butler.biz/","consoleHref":"http://www.benton.net/","reporterVersion":"1.5.7"},"common":{"workspace_id":$workspace_id},"reporter":{"reporter_type":"NOTIFICATIONS","reporter_instance_id":$reporter_instance_id,"local_resource_id":$local_resource_id}}}')
+
+  DELETE_REQUEST=$(jq -c --null-input \
+    --arg local_resource_id "$LOCAL_RESOURCE_ID" \
+    '{"reference":{"resource_type":"notifications_integration","resource_id":$local_resource_id,"reporter":{"type":"NOTIFICATIONS"}}}')
+
+  echo "Creating resource..."
+  curl -H "Content-Type: application/json" -d $REQUEST $INVENTORY_URL
+
+  echo "Deleting resource..."
+  curl -X DELETE -H "Content-Type: application/json" -d $DELETE_REQUEST $INVENTORY_URL
+
+  sleep $INTERVAL
+done


### PR DESCRIPTION
### PR Template:

## Describe your changes

injection is now based solely on existence of values in appconfig
  * this ensures any default values in service do not prevent injection from occuring
* updates `InjectClowdAppConfig` function to take the app as an argument to allow for testing the function
  * `clowder.LoadedConfig` relies on the existence of a file in the running container which isn't easily tested in Go tests
* updates tests to add `InjectClowdAppConfig` testing
* adds load generator script for v2 testing

## Ticket reference (if applicable)
for RHCLOUD-39786

## Validation
Since our current ephemeral deployment doesnt fully rely on Clowder for all settings because of our Kafka setup, i used our stage/prod deploy file and deployed to ephemeral

What was changed to validate: 
* Created a modified version of the inventory-api-config secret that:
  * Disabled the consumer to ensure it didnt fail the pod and show the consumer is configured regardless of enabled or not
  * Ensured no bootstrap server settings were defined so that Clowder configured it
  * Ensured no storage or authz URL's were set to ensure Clowder configured it
  
Secret used for test
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: inventory-api-config
stringData:
  inventory-api-config.yaml: |
    storage:
      disable-persistence: false
    authn:
      allow-unauthenticated: true
    authz:
      kessel:
        insecure-client: true
        enable-oidc-auth: false
    consumer:
      enabled: false
      topic: outbox.event.kessel.tuples
      retry-options:
        consumer-max-retries: -1
        operation-max-retries: -1
        backoff-factor: 5
        max-backoff-seconds: 30
      auth:
        enabled: false
    consistency:
      read-after-write-enabled: true 
      read-after-write-allowlist: ["*"] 
    log:
      level: "debug"
```
Debug Logs showing Authz, Storage, and Consumer properly injected for Clowder-provided configurations
```shell
$ oc logs kessel-inventory-api-bf756c584-q5hg8
Defaulted container "kessel-inventory-api" out of: kessel-inventory-api, crcauth, migration-init (init)
***** Starting with FIPS crypto enabled *****
INFO msg=Using config file: /inventory/inventory-api-config.yaml
Log Level is set to: debug
DEBUG msg=Server Configuration: Public URL: http://localhost:8000, HTTP Listener: 0.0.0.0:8000, GRPC Listener: 0.0.0.0:9000
DEBUG msg=Storage Configuration: Host: kessel-inventory-db.ephemeral-pyedqf.svc, DB: kessel-inventory, Port: 5432, SSLMode: , RDSCACert: 
DEBUG msg=Authz Configuration: URL: kessel-relations-api.ephemeral-pyedqf.svc:9000, Insecure?: true, OIDC?: false
DEBUG msg=Consumer Configuration: Bootstrap Server: [env-ephemeral-pyedqf-fb57a722-kafka-bootstrap.ephemeral-pyedqf.svc:9092], Topic: outbox.event.kessel.tuples, Consumer Max Retries: -1, Operation Max Retries: -1, Backoff Factor: 5, Max Backoff Seconds: 30
DEBUG msg=Consumer Auth Settings: Enabled: false, Security Protocol: sasl_plaintext, Mechanism: SCRAM-SHA-512, Username: inventory-consumer
DEBUG msg=Consistency Configuration: Read-After-Write Enabled: true, Read-After-Write Allowlist: [*]
Log Level is set to: debug
```

## Summary by Sourcery

Improve Clowder config integration by refactoring injection to use explicit appconfig values, enhancing consumer auth handling, extending test coverage, and adding a load generator script

New Features:
- Introduce load-generator-v1beta2.sh for automated v2 API load testing

Enhancements:
- Refactor InjectClowdAppConfig to accept a Clowder AppConfig argument and use common.IsNil checks to drive injection
- Simplify ConfigureConsumer to apply Kafka broker security and SASL options directly from appconfig
- Update root command to pass clowder.LoadedConfig into InjectClowdAppConfig instead of using a global

Tests:
- Add TestInjectClowdAppConfig covering authz, storage, and consumer injection scenarios with and without auth settings
- Update existing config tests for CA parsing and bootstrap server naming