### PR TITLE
fix: seperate coverage results with flags

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,12 +55,20 @@ jobs:
         with:
           name: v1beta2-code-coverage
           path: v1beta2-coverage.out
-      - name: code-cov report
+      - name: Upload main coverage to Codecov
         id: code-cov-report
         uses: codecov/codecov-action@v5
         with:
-          files: coverage.txt,v1beta2-coverage.out
+          files: coverage.txt
+          flags: main
           disable_search: true
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
-
+      - name: Upload v1beta2 coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: v1beta2-coverage.out
+          flags: v1beta2
+          disable_search: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Split the Codecov upload in the build-test CI workflow into separate steps for main and v1beta2 coverage reports, each with its own flag, disabling search and enabling verbose output.

CI:
- Rename and split the single Codecov upload into two steps for main and v1beta2 coverage
- Assign distinct flags (main and v1beta2) to each coverage upload
- Disable search and enable verbose mode for both Codecov steps