### PR TITLE
RHCLOUD-40238: Add test coverage to internal/middleware

### DIFF
--- a/internal/middleware/pagination_test.go
+++ b/internal/middleware/pagination_test.go
@@ -1,0 +1,48 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/project-kessel/inventory-api/internal/middleware"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPaginationMiddleware(t *testing.T) {
+	type testCase struct {
+		name      string
+		pageParam string
+		sizeParam string
+		wantPage  int
+		wantSize  int
+	}
+
+	tests := []testCase{
+		{"defaults", "", "", 1, 10},
+		{"custom values", "3", "20", 3, 20},
+		{"invalid values", "bad", "bad", 1, 10},
+		{"negative values", "-5", "-8", 1, 10},
+		{"zero values", "0", "0", 1, 10},
+		{"too large size", "1", "999", 1, 100},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				val := r.Context().Value(middleware.PaginationRequestKey)
+				assert.NotNil(t, val)
+				pagination, ok := val.(*middleware.PaginationRequest)
+				assert.True(t, ok)
+				assert.Equal(t, tc.wantPage, pagination.Page)
+				assert.Equal(t, tc.wantSize, pagination.MaxSize)
+			})
+
+			paginated := middleware.Pagination(handler)
+
+			req := httptest.NewRequest("GET", "/?page="+tc.pageParam+"&size="+tc.sizeParam, nil)
+			rr := httptest.NewRecorder()
+			paginated.ServeHTTP(rr, req)
+		})
+	}
+}

--- a/internal/middleware/preload_schema.go
+++ b/internal/middleware/preload_schema.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var schemaCache sync.Map
+var SchemaCache sync.Map
 
 func PreloadAllSchemas(resourceDir string) error {
 	if viper.GetBool("resources.use_cache") {
@@ -49,7 +49,7 @@ func PreloadAllSchemasFromFilesystem(resourceDir string) error {
 		// Load and store common resource schema
 		commonResourceSchema, err := LoadCommonResourceDataSchema(resourceType, resourceDir)
 		if err == nil {
-			schemaCache.Store(fmt.Sprintf("common:%s", resourceType), commonResourceSchema)
+			SchemaCache.Store(fmt.Sprintf("common:%s", resourceType), commonResourceSchema)
 		}
 
 		_, err = loadConfigFile(resourceDir, resourceType)
@@ -76,7 +76,7 @@ func PreloadAllSchemasFromFilesystem(resourceDir string) error {
 			reporterType := reporter.Name()
 			reporterSchema, isReporterSchemaExists, err := LoadResourceSchema(resourceType, reporterType, resourceDir)
 			if err == nil && isReporterSchemaExists {
-				schemaCache.Store(fmt.Sprintf("%s:%s", resourceType, reporterType), reporterSchema)
+				SchemaCache.Store(fmt.Sprintf("%s:%s", resourceType, reporterType), reporterSchema)
 			} else {
 				log.Warnf("No schema found for %s:%s", resourceType, reporterType)
 			}
@@ -100,7 +100,7 @@ func LoadSchemaCacheFromJSON(filePath string) error {
 	}
 
 	for key, value := range cacheMap {
-		schemaCache.Store(key, value)
+		SchemaCache.Store(key, value)
 	}
 
 	log.Infof("Schema cache successfully loaded from %s", filePath)
@@ -108,8 +108,8 @@ func LoadSchemaCacheFromJSON(filePath string) error {
 }
 
 // Retrieves schema from cache
-func getSchemaFromCache(cacheKey string) (string, error) {
-	if cachedSchema, ok := schemaCache.Load(cacheKey); ok {
+func GetSchemaFromCache(cacheKey string) (string, error) {
+	if cachedSchema, ok := SchemaCache.Load(cacheKey); ok {
 		return cachedSchema.(string), nil
 	}
 	return "", fmt.Errorf("schema not found for key '%s'", cacheKey)
@@ -135,6 +135,6 @@ func loadConfigFile(resourceDir string, resourceType string) (struct {
 		return config, fmt.Errorf("missing 'resource_reporters' field in config for '%s'", resourceType)
 	}
 	configResourceType := NormalizeResourceType(config.ResourceType)
-	schemaCache.Store(fmt.Sprintf("config:%s", configResourceType), configData)
+	SchemaCache.Store(fmt.Sprintf("config:%s", configResourceType), configData)
 	return config, nil
 }

--- a/internal/middleware/preload_schema.go
+++ b/internal/middleware/preload_schema.go
@@ -52,7 +52,7 @@ func PreloadAllSchemasFromFilesystem(resourceDir string) error {
 			SchemaCache.Store(fmt.Sprintf("common:%s", resourceType), commonResourceSchema)
 		}
 
-		_, err = loadConfigFile(resourceDir, resourceType)
+		_, err = LoadConfigFile(resourceDir, resourceType)
 		if err != nil {
 			log.Errorf("Failed to load config file for '%s': %v", resourceType, err)
 			return err
@@ -115,7 +115,7 @@ func GetSchemaFromCache(cacheKey string) (string, error) {
 	return "", fmt.Errorf("schema not found for key '%s'", cacheKey)
 }
 
-func loadConfigFile(resourceDir string, resourceType string) (struct {
+func LoadConfigFile(resourceDir string, resourceType string) (struct {
 	ResourceType      string   `yaml:"resource_type"`
 	ResourceReporters []string `yaml:"resource_reporters"`
 }, error) {

--- a/internal/middleware/preload_schema_test.go
+++ b/internal/middleware/preload_schema_test.go
@@ -1,0 +1,90 @@
+package middleware_test
+
+import (
+	"github.com/project-kessel/inventory-api/internal/middleware"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestPreloadAllSchemas_UsesCachePath(t *testing.T) {
+	cacheContent := `{"test-key":{"schema":"{}"}}`
+	cacheFile := "schema_cache.json"
+	err := os.WriteFile(cacheFile, []byte(cacheContent), 0644)
+	assert.NoError(t, err)
+	defer func() { _ = os.Remove(cacheFile) }()
+
+	// use cache
+	viper.Set("resources.use_cache", true)
+
+	err = middleware.PreloadAllSchemas("/bad/directory")
+	assert.NoError(t, err)
+
+	val, ok := middleware.SchemaCache.Load("test-key")
+	assert.True(t, ok)
+	assert.NotNil(t, val)
+}
+
+func TestPreloadAllSchemas_FailsOnMissingCache(t *testing.T) {
+	viper.Set("resources.use_cache", true)
+	_ = os.Remove("schema_cache.json") // ensure it's missing
+
+	err := middleware.PreloadAllSchemas("/bad/directory")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read schema cache file")
+}
+
+func TestPreloadAllSchemas_FailsOnFilesystemError(t *testing.T) {
+	viper.Set("resources.use_cache", false)
+	err := middleware.PreloadAllSchemas("/bad/directory")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no directories inside schema directory")
+}
+
+func TestLoadSchemaCacheFromJSON_MissingFile(t *testing.T) {
+	err := middleware.LoadSchemaCacheFromJSON("/bad/directory/schema_cache.json")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read schema cache file")
+}
+
+func TestLoadSchemaCacheFromJSON_ValidFile(t *testing.T) {
+	cacheContent := `{"resourceA": {"schema": "{}"}}`
+	tmpFile, err := os.CreateTemp("", "schema_cache.json")
+	assert.NoError(t, err)
+
+	_, err = tmpFile.WriteString(cacheContent)
+	assert.NoError(t, err)
+	err = tmpFile.Close()
+	assert.NoError(t, err)
+
+	err = middleware.LoadSchemaCacheFromJSON(tmpFile.Name())
+	assert.NoError(t, err)
+
+}
+
+func TestLoadSchemaCacheFromJSON_InvalidJSON(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "schema_cache_*.json")
+	assert.NoError(t, err)
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	_, err = tmpFile.WriteString("{not-json:") // Malformed JSON
+	assert.NoError(t, err)
+	err = tmpFile.Close()
+	assert.NoError(t, err)
+
+	err = middleware.LoadSchemaCacheFromJSON(tmpFile.Name())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to unmarshal schema cache JSON")
+}
+
+func TestGetSchemaFromCache_NotFound(t *testing.T) {
+	// cache key does not exist
+	cacheKey := "bad-key"
+	middleware.SchemaCache.Delete(cacheKey)
+
+	schema, err := middleware.GetSchemaFromCache(cacheKey)
+	assert.Error(t, err)
+	assert.Empty(t, schema)
+	assert.Contains(t, err.Error(), "schema not found")
+}

--- a/internal/middleware/preload_schema_test.go
+++ b/internal/middleware/preload_schema_test.go
@@ -5,6 +5,8 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -87,4 +89,81 @@ func TestGetSchemaFromCache_NotFound(t *testing.T) {
 	assert.Error(t, err)
 	assert.Empty(t, schema)
 	assert.Contains(t, err.Error(), "schema not found")
+}
+
+func TestLoadConfigFile(t *testing.T) {
+	type testCase struct {
+		name         string
+		fileContents string
+		setupFile    bool
+		expectErr    string
+	}
+
+	tmpDir := t.TempDir()
+	resourceType := "host"
+	configDir := filepath.Join(tmpDir, resourceType)
+	err := os.Mkdir(configDir, 0755)
+	assert.NoError(t, err)
+	configPath := filepath.Join(configDir, "config.yaml")
+
+	tests := []testCase{
+		{
+			name:         "file not found",
+			fileContents: "",
+			setupFile:    false,
+			expectErr:    "failed to read config file for 'host'",
+		},
+		{
+			name:         "malformed yaml",
+			fileContents: ":bad_yaml",
+			setupFile:    true,
+			expectErr:    "failed to unmarshal config for 'host'",
+		},
+		{
+			name:         "missing resource_reporters",
+			fileContents: `resource_type: host`,
+			setupFile:    true,
+			expectErr:    "missing 'resource_reporters' field in config for 'host'",
+		},
+		{
+			name: "success",
+			fileContents: `
+resource_type: host
+resource_reporters:
+  - hbi
+`,
+			setupFile: true,
+			expectErr: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setupFile {
+				// Write test config.yaml
+				err := os.WriteFile(configPath, []byte(tc.fileContents), 0644)
+				assert.NoError(t, err)
+			} else {
+				err := os.Remove(configPath)
+				assert.NoError(t, err)
+			}
+
+			// reset SchemaCache before each test
+			resetSchemaCache()
+
+			config, err := middleware.LoadConfigFile(tmpDir, resourceType)
+
+			if tc.expectErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, "host", config.ResourceType)
+				assert.Equal(t, []string{"hbi"}, config.ResourceReporters)
+			}
+		})
+	}
+}
+func resetSchemaCache() {
+	middleware.SchemaCache = sync.Map{}
 }

--- a/internal/middleware/preload_schema_test.go
+++ b/internal/middleware/preload_schema_test.go
@@ -90,7 +90,6 @@ func TestGetSchemaFromCache_NotFound(t *testing.T) {
 	assert.Empty(t, schema)
 	assert.Contains(t, err.Error(), "schema not found")
 }
-
 func TestLoadConfigFile(t *testing.T) {
 	type testCase struct {
 		name         string
@@ -140,12 +139,13 @@ resource_reporters:
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.setupFile {
-				// Write test config.yaml
 				err := os.WriteFile(configPath, []byte(tc.fileContents), 0644)
 				assert.NoError(t, err)
 			} else {
 				err := os.Remove(configPath)
-				assert.NoError(t, err)
+				if err != nil && !os.IsNotExist(err) {
+					t.Fatalf("failed to remove config file: %v", err)
+				}
 			}
 
 			// reset SchemaCache before each test
@@ -164,6 +164,7 @@ resource_reporters:
 		})
 	}
 }
+
 func resetSchemaCache() {
 	middleware.SchemaCache = sync.Map{}
 }

--- a/internal/middleware/schema_loader.go
+++ b/internal/middleware/schema_loader.go
@@ -63,13 +63,13 @@ func LoadCommonResourceDataSchema(resourceType string, baseSchemaDir string) (st
 // It either loads from the cache (JSON-based) or the filesystem (YAML-based).
 func LoadValidReporters(resourceType string) ([]string, error) {
 	if viper.GetBool("resources.use_cache") {
-		return loadFromCache(resourceType)
+		return LoadFromCache(resourceType)
 	}
-	return loadFromFilesystem(resourceType)
+	return LoadFromFilesystem(resourceType)
 }
 
 // LoadValidReporters Takes the resource_type from the provided config.yaml and compares it to the defined reporter_types
-func loadFromFilesystem(resourceType string) ([]string, error) {
+func LoadFromFilesystem(resourceType string) ([]string, error) {
 	var config struct {
 		ResourceReporters []string `yaml:"resource_reporters"`
 	}
@@ -96,7 +96,7 @@ func loadFromFilesystem(resourceType string) ([]string, error) {
 	return config.ResourceReporters, nil
 }
 
-func loadFromCache(resourceType string) ([]string, error) {
+func LoadFromCache(resourceType string) ([]string, error) {
 	cacheKey := fmt.Sprintf("config:%s", resourceType)
 
 	cachedConfig, ok := SchemaCache.Load(cacheKey)

--- a/internal/middleware/schema_loader.go
+++ b/internal/middleware/schema_loader.go
@@ -75,7 +75,7 @@ func loadFromFilesystem(resourceType string) ([]string, error) {
 	}
 
 	cacheKey := fmt.Sprintf("config:%s", resourceType)
-	cachedConfig, ok := schemaCache.Load(cacheKey)
+	cachedConfig, ok := SchemaCache.Load(cacheKey)
 	if !ok {
 		return nil, fmt.Errorf("config not found for resource type '%s'", resourceType)
 	}
@@ -99,7 +99,7 @@ func loadFromFilesystem(resourceType string) ([]string, error) {
 func loadFromCache(resourceType string) ([]string, error) {
 	cacheKey := fmt.Sprintf("config:%s", resourceType)
 
-	cachedConfig, ok := schemaCache.Load(cacheKey)
+	cachedConfig, ok := SchemaCache.Load(cacheKey)
 	if !ok {
 		return nil, fmt.Errorf("config not found in cache for resource type '%s'", resourceType)
 	}

--- a/internal/middleware/schema_loader_test.go
+++ b/internal/middleware/schema_loader_test.go
@@ -1,0 +1,119 @@
+package middleware_test
+
+import (
+	"github.com/project-kessel/inventory-api/internal/middleware"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateResourceReporterCombination_Valid(t *testing.T) {
+	viper.Set("resources.use_cache", true)
+	resourceType := "testres"
+	reporterType := "repA"
+	config := map[string]interface{}{"resource_reporters": []string{"repA", "repB"}}
+	middleware.SchemaCache.Store("config:"+resourceType, config)
+
+	err := middleware.ValidateResourceReporterCombination(resourceType, reporterType)
+	assert.NoError(t, err)
+}
+
+func TestValidateResourceReporterCombination_Invalid(t *testing.T) {
+	viper.Set("resources.use_cache", true)
+	resourceType := "testres"
+	reporterType := "repC"
+	config := map[string]interface{}{"resource_reporters": []string{"repA", "repB"}}
+	middleware.SchemaCache.Store("config:"+resourceType, config)
+
+	err := middleware.ValidateResourceReporterCombination(resourceType, reporterType)
+	assert.Contains(t, err.Error(), "invalid reporter_type: repC for resource_type: testres")
+}
+
+func TestValidateResourceReporterCombination_ConfigNotFound(t *testing.T) {
+	viper.Set("resources.use_cache", true)
+	resourceType := "notfound"
+	reporterType := "repA"
+	middleware.SchemaCache.Delete("config:" + resourceType)
+
+	err := middleware.ValidateResourceReporterCombination(resourceType, reporterType)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load valid reporters")
+}
+
+func TestLoadResourceSchema_Valid(t *testing.T) {
+	dir := t.TempDir()
+	resourceType := "foo"
+	reporterType := "bar"
+	path := filepath.Join(dir, resourceType, "reporters", reporterType)
+	err := os.MkdirAll(path, 0755)
+	assert.NoError(t, err)
+	schemaFile := filepath.Join(path, resourceType+".json")
+	expected := `{"type":"object"}`
+	err = os.WriteFile(schemaFile, []byte(expected), 0644)
+	assert.NoError(t, err)
+
+	schema, exists, err := middleware.LoadResourceSchema(resourceType, reporterType, dir)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, expected, schema)
+}
+
+func TestLoadResourceSchema_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	resourceType := "foo"
+	reporterType := "nope"
+
+	schema, exists, err := middleware.LoadResourceSchema(resourceType, reporterType, dir)
+	assert.NoError(t, err)
+	assert.False(t, exists)
+	assert.Equal(t, "", schema)
+}
+
+func TestLoadCommonResourceDataSchema_Valid(t *testing.T) {
+	dir := t.TempDir()
+	resourceType := "foo"
+	err := os.MkdirAll(filepath.Join(dir, resourceType), 0755)
+	assert.NoError(t, err)
+	schemaPath := filepath.Join(dir, resourceType, "common_representation.json")
+	expected := `{"type":"object"}`
+	err = os.WriteFile(schemaPath, []byte(expected), 0644)
+	assert.NoError(t, err)
+
+	schema, err := middleware.LoadCommonResourceDataSchema(resourceType, dir)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, schema)
+}
+
+func TestLoadCommonResourceDataSchema_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	resourceType := "bar"
+
+	schema, err := middleware.LoadCommonResourceDataSchema(resourceType, dir)
+	assert.Error(t, err)
+	assert.Empty(t, schema)
+	assert.Contains(t, err.Error(), "failed to read common resource schema")
+}
+
+func TestLoadValidReporters_FromCache_JSON(t *testing.T) {
+	viper.Set("resources.use_cache", true)
+	resourceType := "jsonres"
+	config := map[string]interface{}{"resource_reporters": []string{"repA"}}
+	middleware.SchemaCache.Store("config:"+resourceType, config)
+	defer middleware.SchemaCache.Delete("config:" + resourceType)
+
+	reporters, err := middleware.LoadValidReporters(resourceType)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"repA"}, reporters)
+}
+
+func TestLoadValidReporters_FromFilesystem_ConfigNotFound(t *testing.T) {
+	viper.Set("resources.use_cache", false)
+	resourceType := "notfound"
+	middleware.SchemaCache.Delete("config:" + resourceType)
+
+	reporters, err := middleware.LoadValidReporters(resourceType)
+	assert.Error(t, err)
+	assert.Nil(t, reporters)
+}

--- a/internal/middleware/util.go
+++ b/internal/middleware/util.go
@@ -88,7 +88,7 @@ func ExtractStringField(data map[string]interface{}, key string) (string, error)
 // ValidateCommonRepresentation Validates the "common" field in ResourceRepresentations using a predefined schema.
 func ValidateCommonRepresentation(resourceType string, commonRepresentation map[string]interface{}) error {
 	commonSchemaKey := fmt.Sprintf("common:%s", strings.ToLower(resourceType))
-	commonSchema, err := getSchemaFromCache(commonSchemaKey)
+	commonSchema, err := GetSchemaFromCache(commonSchemaKey)
 	if err != nil {
 		return fmt.Errorf("failed to load common representation schema for '%s': %w", resourceType, err)
 	}
@@ -104,7 +104,7 @@ func ValidateCommonRepresentation(resourceType string, commonRepresentation map[
 func ValidateReporterRepresentation(resourceType string, reporterType string, reporterRepresentation map[string]interface{}) error {
 	// Construct the schema key using the format: resourceType:reporterType
 	schemaKey := fmt.Sprintf("%s:%s", strings.ToLower(resourceType), strings.ToLower(reporterType))
-	reporterRepresentationSchema, err := getSchemaFromCache(schemaKey)
+	reporterRepresentationSchema, err := GetSchemaFromCache(schemaKey)
 
 	// Case 1: No schema found for resourceType:reporterType
 	if err != nil {

--- a/internal/middleware/util.go
+++ b/internal/middleware/util.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -141,25 +139,4 @@ func ValidateJSONSchema(schemaStr string, jsonData interface{}) error {
 		return fmt.Errorf("validation failed: %s", strings.Join(errMsgs, "; "))
 	}
 	return nil
-}
-
-func GetProjectRootPath() (string, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("failed to get current working directory: %w", err)
-	}
-
-	for {
-		if _, err := os.Stat(filepath.Join(cwd, "go.mod")); err == nil {
-			return cwd, nil
-		}
-
-		parent := filepath.Dir(cwd)
-		if parent == cwd {
-			break
-		}
-		cwd = parent
-	}
-
-	return "", fmt.Errorf("project root not found")
 }

--- a/internal/middleware/util_test.go
+++ b/internal/middleware/util_test.go
@@ -199,3 +199,19 @@ func TestUnmarshalJSONToMap(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateReporterRepresentation_NoSchemaCases(t *testing.T) {
+
+	t.Run("returns error if no schema and data present", func(t *testing.T) {
+		// No schema stored in cache!
+		err := middleware.ValidateReporterRepresentation("host", "hbi", map[string]interface{}{"foo": "bar"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no schema found for 'host:hbi', but reporter representation was provided")
+	})
+
+	t.Run("returns nil if no schema and data is empty", func(t *testing.T) {
+		// No schema stored in cache!
+		err := middleware.ValidateReporterRepresentation("host", "hbi", map[string]interface{}{})
+		assert.NoError(t, err)
+	})
+}

--- a/internal/middleware/util_test.go
+++ b/internal/middleware/util_test.go
@@ -1,0 +1,201 @@
+package middleware_test
+
+import (
+	pbv1beta2 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+	"github.com/project-kessel/inventory-api/internal/middleware"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// Helper functions
+func TestNormalizeResourceTypeCase(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"K8s_CLUSTER", "K8s_CLUSTER"},
+		{"rhel/host", "rhel_host"},
+		{"TEST/RESOURCE", "TEST_RESOURCE"},
+		{"resource", "resource"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := middleware.NormalizeResourceType(tt.input)
+			assert.Equal(t, tt.expected, result, "Normalized resource type doesn't match")
+		})
+	}
+}
+
+func TestValidateJSONSchema(t *testing.T) {
+	schema := `{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"type": "object",
+		"properties": {
+			"workspace_id": { "type": "string" }
+		},
+		"required": ["workspace_id"]
+	}`
+
+	tests := []struct {
+		name          string
+		jsonInput     interface{}
+		expectErr     bool
+		expectedError string
+	}{
+		{
+			name:      "Valid JSON",
+			jsonInput: map[string]interface{}{"workspace_id": "workspace-123"},
+			expectErr: false,
+		},
+		{
+			name:          "Invalid JSON (missing required field)",
+			jsonInput:     map[string]interface{}{"otherKey": "value"},
+			expectErr:     true,
+			expectedError: "validation failed: (root): workspace_id is required",
+		},
+		{
+			name:          "Invalid JSON (wrong data type for workspace_id)",
+			jsonInput:     map[string]interface{}{"workspace_id": 123},
+			expectErr:     true,
+			expectedError: "validation failed: workspace_id: Invalid type. Expected: string, given: integer", // Error due to wrong data type
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := middleware.ValidateJSONSchema(schema, tt.jsonInput)
+			if tt.expectErr {
+				assert.Error(t, err, "Expected error but got nil")
+				assert.Contains(t, err.Error(), tt.expectedError, "Error message mismatch")
+			} else {
+				assert.NoError(t, err, "Expected no error for valid JSON format")
+			}
+		})
+	}
+}
+
+func TestExtractFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     map[string]interface{}
+		key       string
+		expected  interface{}
+		expectErr bool
+		testType  string // "map" or "string"
+	}{
+		// Tests for ExtractMapField
+		{
+			name:      "Valid map extraction",
+			input:     map[string]interface{}{"key": map[string]interface{}{"subkey": "value"}},
+			key:       "key",
+			expected:  map[string]interface{}{"subkey": "value"},
+			expectErr: false,
+			testType:  "map",
+		},
+		{
+			name:      "Invalid map extraction (not a map)",
+			input:     map[string]interface{}{"key": "string_value"},
+			key:       "key",
+			expected:  nil,
+			expectErr: true,
+			testType:  "map",
+		},
+		{
+			name:      "Invalid map extraction (nonexistent key)",
+			input:     map[string]interface{}{},
+			key:       "nonexistent_key",
+			expected:  nil,
+			expectErr: true,
+			testType:  "map",
+		},
+
+		// Tests for ExtractStringField
+		{
+			name:      "Valid string extraction",
+			input:     map[string]interface{}{"key": "value"},
+			key:       "key",
+			expected:  "value",
+			expectErr: false,
+			testType:  "string",
+		},
+		{
+			name:      "Invalid string extraction (not a string)",
+			input:     map[string]interface{}{"key": 123},
+			key:       "key",
+			expected:  "",
+			expectErr: true,
+			testType:  "string",
+		},
+		{
+			name:      "Invalid string extraction (nonexistent key)",
+			input:     map[string]interface{}{},
+			key:       "nonexistent_key",
+			expected:  "",
+			expectErr: true,
+			testType:  "string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result interface{}
+			var err error
+
+			switch tt.testType {
+			case "map":
+				result, err = middleware.ExtractMapField(tt.input, tt.key)
+			case "string":
+				result, err = middleware.ExtractStringField(tt.input, tt.key)
+			}
+
+			if tt.expectErr {
+				assert.Error(t, err, "Expected error but got nil")
+			} else {
+				assert.NoError(t, err, "Unexpected error")
+				assert.Equal(t, tt.expected, result, "Extracted value doesn't match")
+			}
+		})
+	}
+}
+
+func TestMarshalProtoToJSON(t *testing.T) {
+	msg := &pbv1beta2.ReportResourceRequest{
+
+		Type: "k8s_cluster",
+	}
+	jsonData, err := middleware.MarshalProtoToJSON(msg)
+	assert.NoError(t, err, "Expected no error while marshalling protobuf to JSON")
+	assert.Contains(t, string(jsonData), "k8s_cluster", "Expected resource type to be present in JSON")
+}
+
+func TestUnmarshalJSONToMap(t *testing.T) {
+	tests := []struct {
+		input     string
+		expected  map[string]interface{}
+		expectErr bool
+	}{
+		{
+			input:     `{"key": "value"}`,
+			expected:  map[string]interface{}{"key": "value"},
+			expectErr: false,
+		},
+		{
+			input:     `invalid json`,
+			expected:  nil,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := middleware.UnmarshalJSONToMap([]byte(tt.input))
+			if tt.expectErr {
+				assert.Error(t, err, "Expected error but got nil")
+			} else {
+				assert.NoError(t, err, "Unexpected error")
+				assert.Equal(t, tt.expected, result, "Unmarshalled map doesn't match")
+			}
+		})
+	}
+}

--- a/internal/middleware/validation.go
+++ b/internal/middleware/validation.go
@@ -43,7 +43,7 @@ func Validation(validator protovalidate.Validator) middleware.Middleware {
 
 				switch v.(type) {
 				case *pbv1beta2.ReportResourceRequest:
-					if err := validateReportResourceJSON(v); err != nil {
+					if err := ValidateReportResourceJSON(v); err != nil {
 						return nil, errors.BadRequest("REPORT_RESOURCE_JSON_VALIDATOR", err.Error()).WithCause(err)
 					}
 				}
@@ -53,7 +53,7 @@ func Validation(validator protovalidate.Validator) middleware.Middleware {
 	}
 }
 
-func validateReportResourceJSON(msg proto.Message) error {
+func ValidateReportResourceJSON(msg proto.Message) error {
 	data, err := MarshalProtoToJSON(msg)
 	if err != nil {
 		return err

--- a/internal/middleware/validation_test.go
+++ b/internal/middleware/validation_test.go
@@ -175,7 +175,7 @@ func TestValidateReportResourceJSON_FieldExtractionErrors(t *testing.T) {
 			name: "missing common in representations",
 			msg: &pbv1beta2.ReportResourceRequest{
 				Type:         "host",
-				ReporterType: "bar",
+				ReporterType: "hbi",
 				Representations: &pbv1beta2.ResourceRepresentations{
 					Metadata: baseMsg.Representations.Metadata,
 					Reporter: baseMsg.Representations.Reporter,
@@ -183,6 +183,19 @@ func TestValidateReportResourceJSON_FieldExtractionErrors(t *testing.T) {
 				},
 			},
 			expect: "Missing 'common'",
+		},
+		{
+			name: "missing common in representations",
+			msg: &pbv1beta2.ReportResourceRequest{
+				Type:         "host",
+				ReporterType: "bar",
+				Representations: &pbv1beta2.ResourceRepresentations{
+					Metadata: baseMsg.Representations.Metadata,
+					Reporter: baseMsg.Representations.Reporter,
+					Common:   baseMsg.Representations.Common,
+				},
+			},
+			expect: "invalid reporter_type: bar for resource_type: host",
 		},
 	}
 

--- a/internal/middleware/validation_test.go
+++ b/internal/middleware/validation_test.go
@@ -1,12 +1,9 @@
 package middleware_test
 
 import (
-	"fmt"
-	"path/filepath"
-	"strings"
+	"github.com/spf13/viper"
 	"testing"
 
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	pbv1beta2 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
@@ -16,460 +13,184 @@ import (
 	"github.com/project-kessel/inventory-api/internal/middleware"
 )
 
-// Helper functions
-func TestNormalizeResourceTypeCase(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"K8s_CLUSTER", "K8s_CLUSTER"},
-		{"rhel/host", "rhel_host"},
-		{"TEST/RESOURCE", "TEST_RESOURCE"},
-		{"resource", "resource"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			result := middleware.NormalizeResourceType(tt.input)
-			assert.Equal(t, tt.expected, result, "Normalized resource type doesn't match")
-		})
-	}
+func AsStruct(t *testing.T, m map[string]interface{}) *structpb.Struct {
+	s, err := structpb.NewStruct(m)
+	assert.NoError(t, err)
+	return s
 }
 
-func TestValidateJSONSchema(t *testing.T) {
-	schema := `{
-		"$schema": "http://json-schema.org/draft-07/schema#",
-		"type": "object",
-		"properties": {
-			"workspace_id": { "type": "string" }
-		},
-		"required": ["workspace_id"]
-	}`
+func TestValidateReportResourceJSON_Success(t *testing.T) {
+	reporterStruct, err := structpb.NewStruct(map[string]interface{}{
+		"satellite_id":          "2c4196f1-0371-4f4c-8913-e113cfaa6e67",
+		"sub_manager_id":        "af94f92b-0b65-4cac-b449-6b77e665a08f",
+		"insights_inventory_id": "05707922-7b0a-4fe6-982d-6adbc7695b8f",
+		"ansible_host":          "host-1",
+	})
+	assert.NoError(t, err)
 
-	tests := []struct {
-		name          string
-		jsonInput     interface{}
-		expectErr     bool
-		expectedError string
-	}{
-		{
-			name:      "Valid JSON",
-			jsonInput: map[string]interface{}{"workspace_id": "workspace-123"},
-			expectErr: false,
-		},
-		{
-			name:          "Invalid JSON (missing required field)",
-			jsonInput:     map[string]interface{}{"otherKey": "value"},
-			expectErr:     true,
-			expectedError: "validation failed: (root): workspace_id is required",
-		},
-		{
-			name:          "Invalid JSON (wrong data type for workspace_id)",
-			jsonInput:     map[string]interface{}{"workspace_id": 123},
-			expectErr:     true,
-			expectedError: "validation failed: workspace_id: Invalid type. Expected: string, given: integer", // Error due to wrong data type
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := middleware.ValidateJSONSchema(schema, tt.jsonInput)
-			if tt.expectErr {
-				assert.Error(t, err, "Expected error but got nil")
-				assert.Contains(t, err.Error(), tt.expectedError, "Error message mismatch")
-			} else {
-				assert.NoError(t, err, "Expected no error for valid JSON format")
-			}
-		})
-	}
-}
-
-func TestExtractFields(t *testing.T) {
-	tests := []struct {
-		name      string
-		input     map[string]interface{}
-		key       string
-		expected  interface{}
-		expectErr bool
-		testType  string // "map" or "string"
-	}{
-		// Tests for ExtractMapField
-		{
-			name:      "Valid map extraction",
-			input:     map[string]interface{}{"key": map[string]interface{}{"subkey": "value"}},
-			key:       "key",
-			expected:  map[string]interface{}{"subkey": "value"},
-			expectErr: false,
-			testType:  "map",
-		},
-		{
-			name:      "Invalid map extraction (not a map)",
-			input:     map[string]interface{}{"key": "string_value"},
-			key:       "key",
-			expected:  nil,
-			expectErr: true,
-			testType:  "map",
-		},
-		{
-			name:      "Invalid map extraction (nonexistent key)",
-			input:     map[string]interface{}{},
-			key:       "nonexistent_key",
-			expected:  nil,
-			expectErr: true,
-			testType:  "map",
-		},
-
-		// Tests for ExtractStringField
-		{
-			name:      "Valid string extraction",
-			input:     map[string]interface{}{"key": "value"},
-			key:       "key",
-			expected:  "value",
-			expectErr: false,
-			testType:  "string",
-		},
-		{
-			name:      "Invalid string extraction (not a string)",
-			input:     map[string]interface{}{"key": 123},
-			key:       "key",
-			expected:  "",
-			expectErr: true,
-			testType:  "string",
-		},
-		{
-			name:      "Invalid string extraction (nonexistent key)",
-			input:     map[string]interface{}{},
-			key:       "nonexistent_key",
-			expected:  "",
-			expectErr: true,
-			testType:  "string",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var result interface{}
-			var err error
-
-			switch tt.testType {
-			case "map":
-				result, err = middleware.ExtractMapField(tt.input, tt.key)
-			case "string":
-				result, err = middleware.ExtractStringField(tt.input, tt.key)
-			}
-
-			if tt.expectErr {
-				assert.Error(t, err, "Expected error but got nil")
-			} else {
-				assert.NoError(t, err, "Unexpected error")
-				assert.Equal(t, tt.expected, result, "Extracted value doesn't match")
-			}
-		})
-	}
-}
-
-func TestMarshalProtoToJSON(t *testing.T) {
+	commonStruct, err := structpb.NewStruct(map[string]interface{}{
+		"workspace_id": "12",
+	})
+	assert.NoError(t, err)
 	msg := &pbv1beta2.ReportResourceRequest{
-
-		Type: "k8s_cluster",
-	}
-	jsonData, err := middleware.MarshalProtoToJSON(msg)
-	assert.NoError(t, err, "Expected no error while marshalling protobuf to JSON")
-	assert.Contains(t, string(jsonData), "k8s_cluster", "Expected resource type to be present in JSON")
-}
-
-func TestUnmarshalJSONToMap(t *testing.T) {
-	tests := []struct {
-		input     string
-		expected  map[string]interface{}
-		expectErr bool
-	}{
-		{
-			input:     `{"key": "value"}`,
-			expected:  map[string]interface{}{"key": "value"},
-			expectErr: false,
-		},
-		{
-			input:     `invalid json`,
-			expected:  nil,
-			expectErr: true,
+		Type:         "host",
+		ReporterType: "hbi",
+		Representations: &pbv1beta2.ResourceRepresentations{
+			Metadata: &pbv1beta2.RepresentationMetadata{
+				LocalResourceId: "id",
+				ApiHref:         "url",
+			},
+			Reporter: reporterStruct,
+			Common:   commonStruct,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			result, err := middleware.UnmarshalJSONToMap([]byte(tt.input))
-			if tt.expectErr {
-				assert.Error(t, err, "Expected error but got nil")
-			} else {
-				assert.NoError(t, err, "Unexpected error")
-				assert.Equal(t, tt.expected, result, "Unmarshalled map doesn't match")
-			}
-		})
-	}
+	viper.Set("resources.use_cache", true)
+	middleware.SchemaCache.Store("config:host", map[string]interface{}{
+		"resource_reporters": []string{"hbi"},
+	})
+
+	middleware.SchemaCache.Store("host:hbi", `{
+	  "$schema": "http://json-schema.org/draft-07/schema#",
+	  "type": "object",
+	  "properties": {
+		"satellite_id": { "type": "string", "format": "uuid" },
+		"sub_manager_id": { "type": "string", "format": "uuid" },
+		"insights_inventory_id": { "type": "string", "format": "uuid" },
+		"ansible_host": { "type": "string", "maxLength": 255 }
+	  },
+	  "required": []
+	}`)
+
+	middleware.SchemaCache.Store("common:host", `{
+	  "$schema": "http://json-schema.org/draft-07/schema#",
+	  "type": "object",
+	  "properties": {
+		"workspace_id": { "type": "string" }
+	  },
+	  "required": [
+		"workspace_id"
+	  ]
+	}`)
+	err = middleware.ValidateReportResourceJSON(msg)
+	assert.NoError(t, err)
 }
 
-func runValidationTest(
-	t *testing.T,
-	tt struct {
-	name      string
-	request   *pbv1beta2.ReportResourceRequest
-	expectErr bool
-	expectMsg string
-},
-	validateFunc func(*pbv1beta2.ReportResourceRequest) error,
-) {
-	err := validateFunc(tt.request)
+func TestValidateReportResourceJSON_FieldExtractionErrors(t *testing.T) {
 
-	if tt.expectErr {
-		assert.Error(t, err, "Expected error but got nil")
-		if tt.expectMsg != "" {
-			assert.Contains(t, err.Error(), tt.expectMsg, "Expected error message mismatch")
-		}
-	} else {
-		assert.NoError(t, err, "Unexpected error occurred")
-	}
-}
-
-// ValidateResourceRequest validates the structure of a ReportResourceRequest
-func ValidateResourceRequest(req *pbv1beta2.ReportResourceRequest) error {
-	if req == nil {
-		return fmt.Errorf("resource request is nil or missing")
+	// Good base case
+	baseMsg := &pbv1beta2.ReportResourceRequest{
+		Type:               "host",
+		ReporterType:       "hbi",
+		ReporterInstanceId: "2c4196f1-0371-4f4c-8913-e113cfaa6e68",
+		Representations: &pbv1beta2.ResourceRepresentations{
+			Metadata: &pbv1beta2.RepresentationMetadata{
+				LocalResourceId: "id",
+				ApiHref:         "url",
+			},
+			Reporter: AsStruct(t, map[string]interface{}{
+				"satellite_id":          "2c4196f1-0371-4f4c-8913-e113cfaa6e67",
+				"sub_manager_id":        "af94f92b-0b65-4cac-b449-6b77e665a08f",
+				"insights_inventory_id": "05707922-7b0a-4fe6-982d-6adbc7695b8f",
+				"ansible_host":          "host-1",
+			}),
+			Common: AsStruct(t, map[string]interface{}{
+				"workspace_id": "a64d17d0-aec3-410a-acd0-e0b85b22c076",
+			}),
+		},
 	}
 
-	if strings.TrimSpace(req.Type) == "" {
-		return fmt.Errorf("resource_type is required")
-	}
-	if strings.TrimSpace(req.ReporterType) == "" {
-		return fmt.Errorf("reporter_type is required")
-	}
-	if strings.TrimSpace(req.ReporterInstanceId) == "" {
-		return fmt.Errorf("reporter_instance_id is required")
-	}
+	viper.Set("resources.use_cache", true)
+	middleware.SchemaCache.Store("config:host", map[string]interface{}{
+		"resource_reporters": []string{"hbi"},
+	})
 
-	repr := req.Representations
-	if repr == nil || repr.Metadata == nil {
-		return fmt.Errorf("representation_metadata is required")
-	}
+	middleware.SchemaCache.Store("host:hbi", `{
+	  "$schema": "http://json-schema.org/draft-07/schema#",
+	  "type": "object",
+	  "properties": {
+		"satellite_id": { "type": "string", "format": "uuid" },
+		"sub_manager_id": { "type": "string", "format": "uuid" },
+		"insights_inventory_id": { "type": "string", "format": "uuid" },
+		"ansible_host": { "type": "string", "maxLength": 255 }
+	  },
+	  "required": []
+	}`)
 
-	if strings.TrimSpace(repr.Metadata.LocalResourceId) == "" {
-		return fmt.Errorf("local_resource_id is required")
-	}
-	if strings.TrimSpace(repr.Metadata.ApiHref) == "" {
-		return fmt.Errorf("api_href is required")
-	}
-	if strings.TrimSpace(repr.Metadata.GetConsoleHref()) == "" {
-		return fmt.Errorf("console_href is required")
-	}
-
-	// Validate common data
-	if err := validateCommonRepresentation(repr.GetCommon()); err != nil {
-		return fmt.Errorf("invalid common_resource_data: %w", err)
-	}
-
-	return nil
-}
-
-// validateCommonRepresentation checks for required fields in the common data block
-func validateCommonRepresentation(common *structpb.Struct) error {
-	if common == nil {
-		return fmt.Errorf("common_resource_data is required")
-	}
-	if val, ok := common.Fields["workspace_id"]; !ok || val.GetStringValue() == "" {
-		return fmt.Errorf("workspace_id is required in common_resource_data")
-	}
-	return nil
-}
-
-func TestSchemaValidation(t *testing.T) {
-	projectRoot, err := middleware.GetProjectRootPath()
-	if err != nil {
-		t.Fatalf("Failed to determine project root: %v", err)
-	}
-
-	schemaDir := filepath.Join(projectRoot, "data", "schema", "resources")
-	if err := middleware.PreloadAllSchemas(schemaDir); err != nil {
-		t.Fatalf("Failed to preload schemas: %v", err)
-	}
+	middleware.SchemaCache.Store("common:host", `{
+	  "$schema": "http://json-schema.org/draft-07/schema#",
+	  "type": "object",
+	  "properties": {
+		"workspace_id": { "type": "string" }
+	  },
+	  "required": [
+		"workspace_id"
+	  ]
+	}`)
 
 	tests := []struct {
-		name      string
-		request   *pbv1beta2.ReportResourceRequest
-		expectErr bool
-		expectMsg string
+		name   string
+		msg    *pbv1beta2.ReportResourceRequest
+		expect string // part of expected error
 	}{
 		{
-			name: "Missing ReporterType",
-			request: &pbv1beta2.ReportResourceRequest{
-
-				Type:               "k8s_cluster",
-				ReporterType:       "", // Intentionally invalid
-				ReporterInstanceId: "user@example.com",
-				Representations: &pbv1beta2.ResourceRepresentations{
-					Metadata: &pbv1beta2.RepresentationMetadata{
-						LocalResourceId: "0123",
-						ApiHref:         "https://api.example.com",
-						ConsoleHref:     proto.String("https://console.example.com"),
-					},
-					Common: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							"workspace_id": structpb.NewStringValue("workspace-123"),
-						},
-					},
-				},
+			name: "missing type",
+			msg: &pbv1beta2.ReportResourceRequest{
+				ReporterType:    "hbi",
+				Representations: baseMsg.Representations,
 			},
-			expectErr: true,
-			expectMsg: "reporter_type is required",
-		},
-
-		{
-			name: "Valid RHEL Host with Resource Data",
-			request: &pbv1beta2.ReportResourceRequest{
-
-				Type:               "host",
-				ReporterType:       "HBI",
-				ReporterInstanceId: "org-123",
-				Representations: &pbv1beta2.ResourceRepresentations{
-					Metadata: &pbv1beta2.RepresentationMetadata{
-						LocalResourceId: "rhel-host-001",
-						ApiHref:         "https://api.rhel.example.com",
-						ConsoleHref:     proto.String("https://console.rhel.example.com"),
-					},
-					Common: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							"workspace_id": structpb.NewStringValue("workspace-123"),
-						},
-					},
-					Reporter: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							"satellite_id":          structpb.NewStringValue("550e8400-e29b-41d4-a716-446655440000"),
-							"sub_manager_id":        structpb.NewStringValue("550e8400-e29b-41d4-a716-446655440000"),
-							"insights_inventory_id": structpb.NewStringValue("550e8400-e29b-41d4-a716-446655440000"),
-							"ansible_host":          structpb.NewStringValue("abc"),
-						},
-					},
-				},
-			},
-			expectErr: false,
+			expect: "missing 'type'",
 		},
 		{
-			name: "Valid K8s Policy",
-			request: &pbv1beta2.ReportResourceRequest{
-
-				Type:               "k8s_policy",
-				ReporterType:       "ACM",
-				ReporterInstanceId: "org-123",
-				Representations: &pbv1beta2.ResourceRepresentations{
-					Metadata: &pbv1beta2.RepresentationMetadata{
-						LocalResourceId: "k8s-policy-001",
-						ApiHref:         "https://api.k8s.example.com",
-						ConsoleHref:     proto.String("https://console.k8s.example.com"),
-					},
-					Common: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							"workspace_id": structpb.NewStringValue("workspace-123"),
-						},
-					},
-					Reporter: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							"disabled": structpb.NewBoolValue(true),
-							"severity": structpb.NewStringValue("MEDIUM"),
-						},
-					},
-				},
+			name: "missing reporterType",
+			msg: &pbv1beta2.ReportResourceRequest{
+				Type:            "host",
+				Representations: baseMsg.Representations,
 			},
-			expectErr: false,
+			expect: "missing 'reporterType'",
 		},
 		{
-			name: "Valid Notifications Integration (No schema expected)",
-			request: &pbv1beta2.ReportResourceRequest{
-
-				Type:               "notifications_integration",
-				ReporterType:       "NOTIFICATIONS",
-				ReporterInstanceId: "1",
-				Representations: &pbv1beta2.ResourceRepresentations{
-					Metadata: &pbv1beta2.RepresentationMetadata{
-						LocalResourceId: "notifications-001",
-						ApiHref:         "https://api.notifications.example.com",
-						ConsoleHref:     proto.String("https://console.notifications.example.com"),
-					},
-					Common: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							"workspace_id": structpb.NewStringValue("workspace-123"),
-						},
-					},
-				},
+			name: "missing representations",
+			msg: &pbv1beta2.ReportResourceRequest{
+				Type:            "host",
+				ReporterType:    "hbi",
+				Representations: nil,
 			},
-			expectErr: false,
-		},
-
-		// Bad test cases
-		{
-			name: "K8s Cluster with incorrect data types (simulate type error)",
-			request: &pbv1beta2.ReportResourceRequest{
-
-				Type:               "k8s_cluster",
-				ReporterType:       "OCM",
-				ReporterInstanceId: "user@example.com",
-				Representations: &pbv1beta2.ResourceRepresentations{
-					Metadata: &pbv1beta2.RepresentationMetadata{
-						LocalResourceId: "cluster-123",
-						ApiHref:         "www.example.com",
-						ConsoleHref:     proto.String("www.example.com"),
-					},
-					Common: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							"workspace_id": structpb.NewStringValue("workspace-123"),
-						},
-					},
-					Reporter: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							// We're using a string instead of an int due to structpb limitations
-							"external_cluster_id": structpb.NewStringValue("1234"),
-							"cluster_status":      structpb.NewStringValue("READY"),
-							"cluster_reason":      structpb.NewStringValue("All systems operational"),
-							"kube_version":        structpb.NewStringValue("1.31"),
-							"kube_vendor":         structpb.NewStringValue("OPENSHIFT"),
-							"vendor_version":      structpb.NewStringValue("4.16"),
-							"cloud_platform":      structpb.NewStringValue("AWS_UPI"),
-						},
-					},
-				},
-			},
-			expectErr: false, // Can't enforce type mismatch directly with structpb
+			expect: "Missing 'representations'",
 		},
 		{
-			name: "Notifications Integration with unexpected reporter data",
-			request: &pbv1beta2.ReportResourceRequest{
-				
-				Type:               "notifications_integration",
-				ReporterType:       "NOTIFICATIONS",
-				ReporterInstanceId: "1",
+			name: "missing reporter in representations",
+			msg: &pbv1beta2.ReportResourceRequest{
+				Type:         "host",
+				ReporterType: "hbi",
 				Representations: &pbv1beta2.ResourceRepresentations{
-					Metadata: &pbv1beta2.RepresentationMetadata{
-						LocalResourceId: "notifications-001",
-						ApiHref:         "https://api.notifications.example.com",
-						ConsoleHref:     proto.String("https://console.notifications.example.com"),
-					},
-					Common: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							"workspace_id": structpb.NewStringValue("workspace-123"),
-						},
-					},
-					Reporter: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							"unexpected_key": structpb.NewStringValue("unexpected_value"),
-						},
-					},
+					Metadata: baseMsg.Representations.Metadata,
+					Common:   baseMsg.Representations.Common,
+					// No Reporter
 				},
 			},
-			expectErr: false, // If schema validation is NOT enforced in ValidateResourceRequest
+			expect: "Missing 'reporter'",
+		},
+		{
+			name: "missing common in representations",
+			msg: &pbv1beta2.ReportResourceRequest{
+				Type:         "host",
+				ReporterType: "bar",
+				Representations: &pbv1beta2.ResourceRepresentations{
+					Metadata: baseMsg.Representations.Metadata,
+					Reporter: baseMsg.Representations.Reporter,
+					// No Common
+				},
+			},
+			expect: "Missing 'common'",
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			runValidationTest(t, tt, ValidateResourceRequest)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := middleware.ValidateReportResourceJSON(tc.msg)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.expect)
 		})
 	}
 }


### PR DESCRIPTION
### PR Template:

## Describe your changes

## Summary by Sourcery

Improve test coverage of the internal/middleware package by adding comprehensive unit tests for validation, schema loading, and caching utilities, and refactor the schema cache API and validation entry point for consistent exporting and naming.

Enhancements:
- Export the schema cache and accessor (SchemaCache and GetSchemaFromCache) and rename ValidateReportResourceJSON for external use
- Consolidate and refactor middleware validation helpers and caching functions for consistent naming and visibility

Tests:
- Add unit tests for JSON schema validation, field extraction, and protobuf JSON (Marshal/Unmarshal) utilities
- Add success and error scenario tests for ValidateReportResourceJSON
- Add tests for schema loader functions (LoadResourceSchema, LoadCommonResourceDataSchema, LoadValidReporters, ValidateResourceReporterCombination)
- Add tests for preload schema functionality (PreloadAllSchemas, LoadSchemaCacheFromJSON, GetSchemaFromCache)

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?