### PR TITLE
Fix create log to use returned resource

### DIFF
--- a/internal/biz/usecase/resources/resources.go
+++ b/internal/biz/usecase/resources/resources.go
@@ -168,7 +168,7 @@ func (uc *Usecase) Upsert(ctx context.Context, m *model.Resource, write_visibili
 		}
 	}
 
-	uc.log.WithContext(ctx).Infof("Created Resource: %v(%v)", m.ID, m.ResourceType)
+	uc.log.WithContext(ctx).Infof("Upserted Resource: %v(%v)", ret.ID, ret.ResourceType)
 	return ret, nil
 }
 


### PR DESCRIPTION
- Use the returned resource from the data layer for logging

## Summary by Sourcery

Bug Fixes:
- Update Create usecase to log the ID and type from the returned resource instead of the input model