### PR TITLE
RHCLOUD-40345 -- update to use new kafka connect

### DIFF
--- a/deploy/kessel-inventory-ephem.yaml
+++ b/deploy/kessel-inventory-ephem.yaml
@@ -220,7 +220,7 @@ objects:
         status.storage.topic: connect-cluster-status
         config.providers: secrets
         config.providers.secrets.class: io.strimzi.kafka.KubernetesSecretConfigProvider
-      image: quay.io/cloudservices/kafka-connect:latest
+      image: quay.io/cloudservices/insights-kafka-connect:latest
       replicas: 1
       resources:
         limits:


### PR DESCRIPTION
### PR Template:

## Describe your changes
Ephemeral deployments of inventory-api are failing due to no quay image available for cloudservices kafka-connect.

Update to use insights-kafka-connect which is available

Used this bonfire config to test locally and deploy....
```
apps:
- name: kessel
  components:
    - name: kessel-inventory
      host: local
      repo: ~/git/inventory-api
      path: /deploy/kessel-inventory-ephem.yaml
      parameters:
        FAIL_FAST_ON_DEPENDENCIES: false                                              
```

Deployment worked...
```
(iqe-kessel-inventory-plugin) jarice:~/iqe/iqe-kessel-inventory-plugin/iqe_kessel_inventory/tools>oc get pods
NAME                                                             READY   STATUS    RESTARTS       AGE
env-ephemeral-ivahpi-c5cdabc7-connect-0                          1/1     Running   0              3h5m
env-ephemeral-ivahpi-c5cdabc7-entity-operator-849b7d47fc-7zm75   2/2     Running   0              3h6m
env-ephemeral-ivahpi-c5cdabc7-kafka-0                            1/1     Running   0              3h6m
env-ephemeral-ivahpi-c5cdabc7-zookeeper-0                        1/1     Running   0              3h7m
env-ephemeral-ivahpi-featureflags-7669f958f6-zgfhd               1/1     Running   2 (3h5m ago)   3h5m
env-ephemeral-ivahpi-featureflags-edge-54fc4754bc-gsqmw          1/1     Running   0              3h5m
env-ephemeral-ivahpi-keycloak-649b795bf7-fr65s                   1/1     Running   0              3h7m
env-ephemeral-ivahpi-mbop-8655c8fdfb-qlghg                       2/2     Running   0              3h5m
env-ephemeral-ivahpi-minio-5d585ccbd6-ptqbg                      1/1     Running   0              3h5m
env-ephemeral-ivahpi-mocktitlements-dd96db6d4-nhdtp              2/2     Running   0              3h5m
featureflags-db-7775459486-jw52d                                 1/1     Running   0              3h5m
inventory-kafka-connect-connect-0                                1/1     Running   0              4m5s
inventory-kafka-entity-operator-9b96cc6db-4s7v6                  2/2     Running   0              4m53s
inventory-kafka-kafka-0                                          1/1     Running   0              5m15s
inventory-kafka-zookeeper-0                                      1/1     Running   0              5m41s
iqe-10af6e0e-iqe-jj6a4bi-r6lbq                                   1/1     Running   0              2m33s
kessel-inventory-api-5dbf4f8d6c-v54tb                            2/2     Running   0              5m39s
kessel-inventory-db-74656f4c7f-xqfgx                             1/1     Running   0              5m39s
```
## Ticket reference (if applicable)

https://issues.redhat.com/browse/RHCLOUD-40345
Fixes #

## Checklist

* [X ] Are the agreed upon acceptance criteria fulfilled?

* [ X] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

