### PR TITLE
Add goimports to golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,11 +13,10 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: '1.23.x'
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
+          version: v2.1
           args: --timeout=10m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,16 @@
+version: "2" 
+linters:
+  enable:
+    # Start: Defaults
+    - govet
+    - errcheck
+    - ineffassign
+    - staticcheck
+    - unused
+    # End: Defaults
+formatters:
+  enable:
+    - goimports
+issues:
+  # Maximum count of issues with the same text (0 = no limit)
+  max-same-issues: 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+## Pull Requests
+All pull requests should be made against the `main` branch from your own fork of the repository. Please ensure that your pull request includes a clear description of the changes made and all CI checks pass.
+
+## Linting & Formatting
+
+[golangci-lint](https://github.com/golangci/golangci-lint) should be used to lint this project. CI will automatically run this, but you can run linting locally by running:
+
+```bash
+make lint # requires docker/podman to be installed
+```
+
+### IDE Formatting
+
+It is recommended to have `goimports` installed locally and have your IDE set to auto-format on save. You can install it by running:
+
+```bash
+go install golang.org/x/tools/cmd/goimports@latest
+```
+
+For vscode users, you can set up your editor to use `goimports` for auto-formatting by adding the following to your workspace or user settings:
+
+```json
+{
+  ...
+  "go.formatTool": "goimports"
+}
+```
+
+For jetbrains users see https://www.jetbrains.com/help/go/integration-with-go-tools.html#goimports

--- a/Makefile
+++ b/Makefile
@@ -154,8 +154,8 @@ all:
 .PHONY: lint
 # run go linter with the repositories lint config
 lint:
-	@echo "Linting code."
-	@$(DOCKER) run -t --rm -v $(PWD):/app -w /app golangci/golangci-lint golangci-lint run -v
+	@echo "Running golangci-lint"
+	@$(DOCKER) run -t --rm -v $(PWD):/app -w /app golangci/golangci-lint:v2.1 golangci-lint run -v
 
 .PHONY: pr-check
 # generate pr-check

--- a/README.md
+++ b/README.md
@@ -359,12 +359,3 @@ openssl list -providers | grep -A 3 fips
     version: 3.0.7-395c1a240fbfffd8
     status: active
 ```
-
-## Contributing
-
-Follow the steps below to contribute:
-
-- Fork the project
-- Create a new branch for your feature
-- Run tests and Pr check
-- Submit a pull request

--- a/api/kessel/inventory/v1beta2/check_for_update_request.pb_test.go
+++ b/api/kessel/inventory/v1beta2/check_for_update_request.pb_test.go
@@ -2,9 +2,10 @@ package v1beta2
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
-	"testing"
 )
 
 func TestCheckForUpdateRequest_FullRoundTrip(t *testing.T) {

--- a/api/kessel/inventory/v1beta2/check_for_update_response.pb_test.go
+++ b/api/kessel/inventory/v1beta2/check_for_update_response.pb_test.go
@@ -1,9 +1,10 @@
 package v1beta2
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
-	"testing"
 )
 
 func TestCheckForUpdateResponse_GetAllowed_Nil(t *testing.T) {

--- a/api/kessel/inventory/v1beta2/check_request.pb_test.go
+++ b/api/kessel/inventory/v1beta2/check_request.pb_test.go
@@ -2,9 +2,10 @@ package v1beta2
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
-	"testing"
 )
 
 func TestCheckRequest_FullRoundTrip(t *testing.T) {

--- a/api/kessel/inventory/v1beta2/check_response.pb_test.go
+++ b/api/kessel/inventory/v1beta2/check_response.pb_test.go
@@ -1,9 +1,10 @@
 package v1beta2
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
-	"testing"
 )
 
 func TestCheckResponse_GetAllowed_Nil(t *testing.T) {

--- a/api/kessel/inventory/v1beta2/consistency_token.pb_test.go
+++ b/api/kessel/inventory/v1beta2/consistency_token.pb_test.go
@@ -2,8 +2,9 @@ package v1beta2
 
 import (
 	"encoding/json"
-	"google.golang.org/protobuf/proto"
 	"testing"
+
+	"google.golang.org/protobuf/proto"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/api/kessel/inventory/v1beta2/delete_resource_request.pb_test.go
+++ b/api/kessel/inventory/v1beta2/delete_resource_request.pb_test.go
@@ -2,8 +2,9 @@ package v1beta2_test
 
 import (
 	"encoding/json"
-	"google.golang.org/protobuf/proto"
 	"testing"
+
+	"google.golang.org/protobuf/proto"
 
 	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
 	"github.com/stretchr/testify/assert"

--- a/api/kessel/inventory/v1beta2/report_resource_response.pb_test.go
+++ b/api/kessel/inventory/v1beta2/report_resource_response.pb_test.go
@@ -1,8 +1,9 @@
 package v1beta2
 
 import (
-	"google.golang.org/protobuf/proto"
 	"testing"
+
+	"google.golang.org/protobuf/proto"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/api/kessel/inventory/v1beta2/representation_type.pb_test.go
+++ b/api/kessel/inventory/v1beta2/representation_type.pb_test.go
@@ -2,8 +2,9 @@ package v1beta2
 
 import (
 	"encoding/json"
-	"google.golang.org/protobuf/proto"
 	"testing"
+
+	"google.golang.org/protobuf/proto"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/api/kessel/inventory/v1beta2/request_pagination.pb_test.go
+++ b/api/kessel/inventory/v1beta2/request_pagination.pb_test.go
@@ -2,8 +2,9 @@ package v1beta2
 
 import (
 	"encoding/json"
-	"google.golang.org/protobuf/proto"
 	"testing"
+
+	"google.golang.org/protobuf/proto"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/api/kessel/inventory/v1beta2/resource_reference.pb_test.go
+++ b/api/kessel/inventory/v1beta2/resource_reference.pb_test.go
@@ -2,8 +2,9 @@ package v1beta2_test
 
 import (
 	"encoding/json"
-	"google.golang.org/protobuf/proto"
 	"testing"
+
+	"google.golang.org/protobuf/proto"
 
 	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
 	"github.com/stretchr/testify/assert"

--- a/api/kessel/inventory/v1beta2/resource_representations.pb_test.go
+++ b/api/kessel/inventory/v1beta2/resource_representations.pb_test.go
@@ -2,8 +2,9 @@ package v1beta2_test
 
 import (
 	"encoding/json"
-	"google.golang.org/protobuf/proto"
 	"testing"
+
+	"google.golang.org/protobuf/proto"
 
 	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
 	"github.com/stretchr/testify/assert"

--- a/api/kessel/inventory/v1beta2/streamed_list_objects_request.pb_test.go
+++ b/api/kessel/inventory/v1beta2/streamed_list_objects_request.pb_test.go
@@ -2,8 +2,9 @@ package v1beta2
 
 import (
 	"encoding/json"
-	"google.golang.org/protobuf/proto"
 	"testing"
+
+	"google.golang.org/protobuf/proto"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/api/kessel/inventory/v1beta2/streamed_list_objects_response.pb_test.go
+++ b/api/kessel/inventory/v1beta2/streamed_list_objects_response.pb_test.go
@@ -2,8 +2,9 @@ package v1beta2
 
 import (
 	"encoding/json"
-	"google.golang.org/protobuf/proto"
 	"testing"
+
+	"google.golang.org/protobuf/proto"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/api/kessel/inventory/v1beta2/subject_reference.pb_test.go
+++ b/api/kessel/inventory/v1beta2/subject_reference.pb_test.go
@@ -2,8 +2,9 @@ package v1beta2
 
 import (
 	"encoding/json"
-	"google.golang.org/protobuf/proto"
 	"testing"
+
+	"google.golang.org/protobuf/proto"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/api/kessel/inventory/v1beta2/write_visibility.pb_test.go
+++ b/api/kessel/inventory/v1beta2/write_visibility.pb_test.go
@@ -1,9 +1,10 @@
 package v1beta2
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/reflect/protoreflect"
-	"testing"
 )
 
 func TestWriteVisibility_Enum(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
+	"testing"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"testing"
 )
 
 type MockedCommandRun struct {

--- a/cmd/schema/schema.go
+++ b/cmd/schema/schema.go
@@ -4,13 +4,14 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/project-kessel/inventory-api/cmd/common"
 	"github.com/project-kessel/inventory-api/internal/middleware"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
-	"os"
-	"path/filepath"
 )
 
 var schemaDir = "data/schema/resources"

--- a/internal/data/health/healthrepository_test.go
+++ b/internal/data/health/healthrepository_test.go
@@ -3,9 +3,10 @@ package health
 import (
 	"context"
 	"errors"
+	"testing"
+
 	"github.com/project-kessel/inventory-api/internal/mocks"
 	kesselv1 "github.com/project-kessel/relations-api/api/kessel/relations/v1"
-	"testing"
 
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/stretchr/testify/assert"

--- a/internal/middleware/preload_schema_test.go
+++ b/internal/middleware/preload_schema_test.go
@@ -1,13 +1,14 @@
 package middleware_test
 
 import (
-	"github.com/project-kessel/inventory-api/internal/middleware"
-	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
+
+	"github.com/project-kessel/inventory-api/internal/middleware"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPreloadAllSchemas_UsesCachePath(t *testing.T) {

--- a/internal/middleware/schema_loader_test.go
+++ b/internal/middleware/schema_loader_test.go
@@ -1,12 +1,13 @@
 package middleware_test
 
 import (
-	"github.com/project-kessel/inventory-api/internal/middleware"
-	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/project-kessel/inventory-api/internal/middleware"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateResourceReporterCombination_Valid(t *testing.T) {

--- a/internal/middleware/util_test.go
+++ b/internal/middleware/util_test.go
@@ -1,10 +1,11 @@
 package middleware_test
 
 import (
+	"testing"
+
 	pbv1beta2 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
 	"github.com/project-kessel/inventory-api/internal/middleware"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // Helper functions

--- a/internal/middleware/validation_test.go
+++ b/internal/middleware/validation_test.go
@@ -1,8 +1,9 @@
 package middleware_test
 
 import (
-	"github.com/spf13/viper"
 	"testing"
+
+	"github.com/spf13/viper"
 
 	"google.golang.org/protobuf/types/known/structpb"
 

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -2,10 +2,11 @@ package mocks
 
 import (
 	"context"
+	"io"
+
 	"github.com/google/uuid"
 	"github.com/project-kessel/inventory-api/internal/pubsub"
 	"google.golang.org/grpc/metadata"
-	"io"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 

--- a/internal/storage/config_test.go
+++ b/internal/storage/config_test.go
@@ -1,9 +1,10 @@
 package storage
 
 import (
+	"testing"
+
 	"github.com/project-kessel/inventory-api/internal/storage/postgres"
 	"github.com/project-kessel/inventory-api/internal/storage/sqlite3"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/test/e2e/grpc/inventory_grpc_test.go
+++ b/test/e2e/grpc/inventory_grpc_test.go
@@ -3,6 +3,10 @@ package grpc
 import (
 	"context"
 	"fmt"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/go-kratos/kratos/v2/log"
 	v1 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1"
 	"github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1/resources"
@@ -10,9 +14,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"os"
-	"testing"
-	"time"
 )
 
 type insecuregRPCMetadataCreds map[string]string


### PR DESCRIPTION
* Adds `CONTRIBUTING.md`
* Bumps go version used for golangci-lint github action
* Pins our golangci-lint version to 2.1.X to hedge against schema changes or incompatibilities
* Adds golangci.yaml config file for golangci-lint
* Fixes out of order imports for existing files

## Summary by Sourcery

Integrate goimports into the linting workflow, standardize import ordering, and formalize contribution guidelines while updating CI and build tooling

Enhancements:
- Add .golangci.yaml to configure linters including goimports
- Reorder imports across the codebase using goimports

Build:
- Update Makefile lint command to use golangci-lint v2.1 Docker image

CI:
- Pin golangci-lint to v2.1 and bump Go version to 1.23.x in GitHub Actions

Documentation:
- Extract Contributing guidelines to new CONTRIBUTING.md and remove from README