### PR TITLE
reverts PR 683 to fix connect issues with e2e

### DIFF
--- a/Dockerfile.connect
+++ b/Dockerfile.connect
@@ -1,4 +1,4 @@
-FROM quay.io/strimzi/kafka:0.46.1-kafka-4.0.0
+FROM quay.io/strimzi/kafka:0.45.0-kafka-3.9.0
 USER root:root
 
 # Notes on ENV settings and variables

--- a/deploy/archived/kessel-inventory-ephem-w-kafka.yaml
+++ b/deploy/archived/kessel-inventory-ephem-w-kafka.yaml
@@ -282,7 +282,7 @@ objects:
           podSpec:
             initContainers:
             - name: copy-resources
-              image: registry.access.redhat.com/ubi9-minimal
+              image: registry.access.redhat.com/ubi9
               imagePullPolicy: Always
               command:
                 - /bin/sh

--- a/deploy/kessel-inventory-ephem.yaml
+++ b/deploy/kessel-inventory-ephem.yaml
@@ -94,7 +94,7 @@ objects:
           podSpec:
             initContainers:
             - name: copy-resources
-              image: registry.access.redhat.com/ubi9-minimal
+              image: registry.access.redhat.com/ubi9
               imagePullPolicy: Always
               command:
                 - /bin/sh

--- a/deploy/kessel-inventory.yaml
+++ b/deploy/kessel-inventory.yaml
@@ -26,7 +26,7 @@ objects:
           podSpec:
             initContainers:
             - name: copy-resources
-              image: registry.access.redhat.com/ubi9-minimal
+              image: registry.access.redhat.com/ubi9
               imagePullPolicy: Always
               command:
                 - /bin/sh

--- a/deploy/kind/inventory/kessel-inventory.yaml
+++ b/deploy/kind/inventory/kessel-inventory.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: copy-resources
-          image: registry.access.redhat.com/ubi9-minimal
+          image: registry.access.redhat.com/ubi9
           command:
             - /bin/sh
             - "-c"


### PR DESCRIPTION
Reverts dockerfile change in https://github.com/project-kessel/inventory-api/pull/683 as it breaks the connect pod for the current kafka version needed

UPDATE: updates the base image for copy-resources made in https://github.com/project-kessel/inventory-api/pull/689 as ubi9-minimal does not have tar installed
## Summary by Sourcery

Bug Fixes:
- Restore previous Dockerfile.connect settings to fix connect pod issues with the required Kafka version.