### PR TITLE
Fix null uuid return value

### DIFF
--- a/internal/biz/usecase/resources/resources.go
+++ b/internal/biz/usecase/resources/resources.go
@@ -132,9 +132,9 @@ func (uc *Usecase) Upsert(ctx context.Context, m *model.Resource, write_visibili
 		}
 
 		log.Info("Creating resource: ", m)
-		ret, err2 := createNewReporterResource(ctx, m, uc, txidStr)
-		if err2 != nil {
-			return ret, err2
+		ret, err = createNewReporterResource(ctx, m, uc, txidStr)
+		if err != nil {
+			return ret, err
 		}
 
 		if readAfterWriteEnabled && uc.Config.ConsumerEnabled {


### PR DESCRIPTION
* Fixes null UUID in `ret` resource for v1beta2
* Adds test to ensure the `ret` value has a valid UUID

## Summary by Sourcery

Fix null UUID bug in Upsert by properly assigning the error from createNewReporterResource and add a test to validate non-null UUID.

Bug Fixes:
- Fix null UUID being returned by Upsert by correctly capturing the error from createNewReporterResource.

Tests:
- Add TestUpsertCreatesNewResourceWithCorrectUUID to verify that Upsert returns a valid non-null UUID.