### PR TITLE
Make common and reporter optional and enforce required constraint based on schema

### DIFF
--- a/internal/middleware/schema_loader.go
+++ b/internal/middleware/schema_loader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
@@ -17,9 +18,9 @@ func ValidateResourceReporterCombination(resourceType, reporterType string) erro
 		return fmt.Errorf("failed to load valid reporters for '%s': %w", resourceType, err)
 	}
 
-	// check if the resources reporter_type exists in the list of resource_reporters
+	// do a case insensitive check if reporter_type exists in the list of resource_reporters
 	for _, validReporter := range resourceReporters {
-		if reporterType == validReporter {
+		if strings.EqualFold(reporterType, validReporter) {
 			return nil
 		}
 	}

--- a/internal/middleware/validation.go
+++ b/internal/middleware/validation.go
@@ -64,27 +64,12 @@ func ValidateReportResourceJSON(msg proto.Message) error {
 		return err
 	}
 
-	resourceType, err := ExtractStringField(reportResourceMap, "type")
+	resourceType, err := ExtractStringField(reportResourceMap, "type", ValidateFieldExists())
 	if err != nil {
 		return err
 	}
 
-	reporterType, err := ExtractStringField(reportResourceMap, "reporterType")
-	if err != nil {
-		return err
-	}
-
-	resourceRepresentation, err := ExtractMapField(reportResourceMap, "representations")
-	if err != nil {
-		return err
-	}
-
-	reporterRepresentation, err := ExtractMapField(resourceRepresentation, "reporter")
-	if err != nil {
-		return err
-	}
-
-	commonRepresentation, err := ExtractMapField(resourceRepresentation, "common")
+	reporterType, err := ExtractStringField(reportResourceMap, "reporterType", ValidateFieldExists())
 	if err != nil {
 		return err
 	}
@@ -94,8 +79,23 @@ func ValidateReportResourceJSON(msg proto.Message) error {
 		return err
 	}
 
+	representations, err := ExtractMapField(reportResourceMap, "representations", ValidateFieldExists())
+	if err != nil {
+		return err
+	}
+
+	reporterRepresentation, err := ExtractMapField(representations, "reporter")
+	if err != nil {
+		return err
+	}
+
 	// Validate reporter-specific data
 	if err := ValidateReporterRepresentation(resourceType, reporterType, reporterRepresentation); err != nil {
+		return err
+	}
+
+	commonRepresentation, err := ExtractMapField(representations, "common")
+	if err != nil {
 		return err
 	}
 

--- a/internal/middleware/validation_test.go
+++ b/internal/middleware/validation_test.go
@@ -115,7 +115,9 @@ func TestValidateReportResourceJSON_FieldExtractionErrors(t *testing.T) {
 		"insights_inventory_id": { "type": "string", "format": "uuid" },
 		"ansible_host": { "type": "string", "maxLength": 255 }
 	  },
-	  "required": []
+	  "required": [
+		"subscription_manager_id"
+		]
 	}`)
 
 	middleware.SchemaCache.Store("common:host", `{


### PR DESCRIPTION
### PR Template:

## Describe your changes

- In v1beta2, we cannot impose required constraint of reporter or common representation, without taking the schema into account.
- This is so we can allow for usecases where reporters can only report reporter or common representations sometimes, but not both. More details are documented in this [DDR](https://docs.google.com/document/d/10FcI3uppt8MJcDKvlHQCQ7h_ujBTw-HvrgEABdxEVbs/edit?tab=t.0#heading=h.v29f3ct0fjjn) under validation.
- Something else to keep in mind is that the current validation rules do not take the state of the existing Resource into account and I will change that in a follow on PR. 
- This PR is only to relax the rules from the API perspective, so I can test the full proposed algorithm (being implemented in [this PR](https://github.com/project-kessel/inventory-api/pull/685)
- Also trying to keep PR size small, so I am making small upfront changes where possible

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

