### PR TITLE
adds monitoring only target for compose plus doc updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,14 @@ inventory-up-sso:
 inventory-up-kind:
 	./scripts/start-inventory-kind.sh
 
+.PHONY: monitoring-only
+monitoring-only:
+	./scripts/start-inventory.sh monitoring-only 8000 9000
+
+.PHONY: monitoring-down
+monitoring-down:
+	./scripts/stop-inventory.sh
+
 .PHONY: get-token
 get-token:
 	./scripts/get-token.sh

--- a/development/configs/monitoring/prometheus.yml
+++ b/development/configs/monitoring/prometheus.yml
@@ -5,3 +5,15 @@ scrape_configs:
    static_configs:
     - targets:
        - development-inventory-api-1:8081
+       # for ephemeral only - requires port forwarding
+       - host.containers.internal:8000
+# for ephemeral only - requires port forwarding
+ - job_name: kessel-inventory-consumer
+   static_configs:
+    - targets:
+       - host.containers.internal:9000
+ - job_name: kessel-kafka-connect
+   static_configs:
+    - targets:
+       - host.containers.internal:9404
+

--- a/development/docker-compose.yaml
+++ b/development/docker-compose.yaml
@@ -71,6 +71,17 @@ services:
       - kessel
     restart: on-failure
 
+  monitoring-only:
+    image: bash:3.1-alpine3.21
+    command: ["echo", "starting monitoring-only"]
+    depends_on:
+    - prometheus
+    - grafana
+    - alertmanager
+    networks:
+      - kessel
+    restart: on-failure
+
 ### Individual services
   inventory-api:
     depends_on:

--- a/docs/dev-guides/docker-compose-options.md
+++ b/docs/dev-guides/docker-compose-options.md
@@ -148,3 +148,29 @@ To stop use:
 ```shell
 make inventory-down
 ```
+
+## Monitoring Stack Only
+
+If you need just the monitoring stack for any other metrics related testing (such as monitoring other dependencies like the Kessel Inventory Consumer or Kessel Kafka Connect), this setup provides just Prometheus, Grafana, and Alertmanager. The Prometheus config includes extra scrape targets for capturing metrics from Kessel Inventory, Kessel Inventory Consumer, and Kessel Kafka Connect, when running locally through localhost or via port-forwarding when deployed in Ephemeral (See related [doc](https://github.com/project-kessel/inventory-consumer/blob/main/README.md#monitoring-in-ephemeral-using-podman-compose))  Grafana is also pre-loaded with the local prometheus data source and loads our current dashboards which were extracted from our [dashboards folder](../../dashboards/)
+
+To start Inventory and the monitoring stack:
+```shell
+make monitoring-only
+```
+
+To stop the monitoring stack:
+```shell
+make monitoring-down
+```
+
+> Note: If it's your first time spinning up Grafana, there is an initial login configured that you'll need to reset.
+> username: `admin`
+> password: `admin`.
+> You will be prompted to reset it afterwards.
+> The local running Prometheus is configured by default as a datasource so no other work is needed other than adding your own dashboards
+
+Grafana URL: http://localhost:3000
+
+Prometheus URL: http://localhost:9050
+
+Alertmanager URL: http://localhost:9093


### PR DESCRIPTION
### PR Template:

## Describe your changes

* Adds new monitoring-only target in docker compose to spin up just the monitoring stack
* Adds update to docker compose doc for the new option
* updates prometheus scrape config to also support scraping metrics for pods running in ephemeral (currently inventory api, KIC, and kessel kafka connect)