### PR TITLE
changes method to POST for v1beta2 on heartbeat fix

### DIFF
--- a/scripts/heartbeat-fix.sh
+++ b/scripts/heartbeat-fix.sh
@@ -6,4 +6,4 @@ SSO_RESP=$(curl "${SSO_URL}" -H 'Content-Type: application/x-www-form-urlencoded
 TOKEN=$(echo $SSO_RESP | awk -F ':"' '{print $2}' | cut -d '"' -f 1);
 INVENTORY_URL="kessel-inventory-api:8000/api/inventory/v1beta2/resources";
 BODY='{"type":"host","reporterType":"HBI","reporterInstanceId":"3088be62-1c60-4884-b133-9200542d0b3f","representations":{"metadata":{"localResourceId":"dbz-issue-workaround-RHCLOUD-40690","apiHref":"https://apiHref.com/","consoleHref":"https://www.console.com/","reporterVersion":"2.7.16"},"common":{"workspace_id":"dbz-issue-workaround-RHCLOUD-40690"},"reporter":{"satellite_id":"2c4196f1-0371-4f4c-8913-e113cfaa6e67","sub_manager_id":"af94f92b-0b65-4cac-b449-6b77e665a08f","insights_inventory_id":"05707922-7b0a-4fe6-982d-6adbc7695b8f","ansible_host":"host-1"}}}';
-curl -X PUT -H "Content-Type: application/json" -H "Authorization: bearer $TOKEN" -d $BODY $INVENTORY_URL
+curl -X POST -H "Content-Type: application/json" -H "Authorization: bearer $TOKEN" -d $BODY $INVENTORY_URL


### PR DESCRIPTION
### PR Template:

## Describe your changes

Updates to use POST instead of PUT as PUT doesnt work

```shell
Dload Upload Total Spent Left Speed
0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0100 577 100 19 100 558 4750 136k --:--:-- --:--:-- --:--
404 page not found
:-- 140k
```

## Summary by Sourcery

Bug Fixes:
- Switch the HTTP method in scripts/heartbeat-fix.sh from PUT to POST to avoid 404 errors when sending heartbeat