### PR TITLE
updates connect image in compose to match whats used everywhere else

### DIFF
--- a/development/docker-compose.yaml
+++ b/development/docker-compose.yaml
@@ -209,7 +209,7 @@ services:
       - zookeeper
       - kafka
       - invdatabase
-    image: quay.io/debezium/connect:2.5
+    image: quay.io/debezium/connect:2.7
     restart: "always"
     networks:
       - kessel


### PR DESCRIPTION
### PR Template:

## Describe your changes
updates the debezium connect base image to 2.7 to match the version of debezium everywhere else

## Summary by Sourcery

Enhancements:
- Bump Debezium connect image from 2.5 to 2.7 in docker-compose.yaml