### PR TITLE
Update go toolset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,6 @@ RUN VERSION=${VERSION} make build
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1752587672
 
-# installs RHEL fork of go to be able to validate with go tools for FIPS -- likely not needed long term
-RUN microdnf install -y go-toolset
-
 COPY --from=builder /workspace/bin/inventory-api /usr/local/bin/
 
 EXPOSE 8081

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/project-kessel/inventory-api
 
 // Tke care to bump versions with FIPS compliance in mind
-go 1.23.9
+go 1.24.4
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250625184727-c923a0c2a132.1

--- a/internal/authn/interceptor/streamInterceptor.go
+++ b/internal/authn/interceptor/streamInterceptor.go
@@ -196,7 +196,7 @@ func FromContext(ctx context.Context) (jwtv5.Claims, bool) {
 }
 
 func FetchJwks(authServerUrl string) (keyfunc.Keyfunc, error) {
-	jwksURL := fmt.Sprintf(authServerUrl + "/protocol/openid-connect/certs")
+	jwksURL := fmt.Sprint(authServerUrl, "/protocol/openid-connect/certs")
 	jwks, err := keyfunc.NewDefault([]string{jwksURL})
 	if err != nil {
 		log.Fatalf("Failed to create JWK Set from resource at the given URL: %s.\nError: %s", authServerUrl, err)


### PR DESCRIPTION
### PR Template:

## Describe your changes

* Updates go.mod for latest available go version provided by go-toolset (go 1.24.4)
* Removes adding go-toolset from the final inventory container to reduce any CVE potential (we dont need it for now, it was for validating FIPS)
* Minor code change to address linting failure

## Summary by Sourcery

Update Go toolset version and streamline final container image

Enhancements:
- Bump Go version in go.mod to 1.24.4
- Remove installation of go-toolset from final Docker container to reduce CVE surface