### PR TITLE
Return proper status codes for delete resource requests

### DIFF
--- a/internal/service/resources/kesselinventoryservice.go
+++ b/internal/service/resources/kesselinventoryservice.go
@@ -66,11 +66,11 @@ func (c *InventoryService) DeleteResource(ctx context.Context, r *pb.DeleteResou
 		log.Error("Failed to delete resource: ", err)
 
 		if errors.Is(err, resources.ErrResourceNotFound) {
-			return nil, status.Errorf(codes.NotFound, "resource not found: %v", err)
+			return nil, status.Errorf(codes.NotFound, "resource not found")
 		}
 
 		// Default to internal error for unknown errors
-		return nil, status.Errorf(codes.Internal, "failed to delete resource: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to delete resource due to an internal error")
 	}
 
 	return ResponseFromDeleteResource(), nil

--- a/internal/service/resources/kesselinventoryservice.go
+++ b/internal/service/resources/kesselinventoryservice.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -14,6 +15,8 @@ import (
 	"github.com/project-kessel/inventory-api/internal/middleware"
 	conv "github.com/project-kessel/inventory-api/internal/service/common"
 	pbv1beta1 "github.com/project-kessel/relations-api/api/kessel/relations/v1beta1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type InventoryService struct {
@@ -49,19 +52,25 @@ func (c *InventoryService) DeleteResource(ctx context.Context, r *pb.DeleteResou
 
 	identity, err := middleware.GetIdentity(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get identity: %w", err)
+		return nil, status.Errorf(codes.Unauthenticated, "failed to get identity: %v", err)
 	}
 
 	reporterResource, err := RequestToDeleteResource(r, identity)
 	if err != nil {
 		log.Error("Failed to build reporter resource ID: ", err)
-		return nil, fmt.Errorf("failed to build reporter resource ID: %w", err)
+		return nil, status.Errorf(codes.InvalidArgument, "failed to build reporter resource ID: %v", err)
 	}
 
 	err = c.Ctl.Delete(ctx, reporterResource)
 	if err != nil {
 		log.Error("Failed to delete resource: ", err)
-		return nil, fmt.Errorf("failed to delete resource: %w", err)
+
+		if errors.Is(err, resources.ErrResourceNotFound) {
+			return nil, status.Errorf(codes.NotFound, "resource not found: %v", err)
+		}
+
+		// Default to internal error for unknown errors
+		return nil, status.Errorf(codes.Internal, "failed to delete resource: %v", err)
 	}
 
 	return ResponseFromDeleteResource(), nil

--- a/internal/service/resources/kesselinventoryservice_test.go
+++ b/internal/service/resources/kesselinventoryservice_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/project-kessel/inventory-api/internal/middleware"
 	"github.com/project-kessel/inventory-api/internal/mocks"
 	svc "github.com/project-kessel/inventory-api/internal/service/resources"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type MockRepo = mocks.MockedReporterResourceRepository
@@ -325,6 +327,11 @@ func TestInventoryService_DeleteResource_NoIdentity(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 	assert.Contains(t, err.Error(), "failed to get identity")
+
+	// Check that it returns the correct gRPC status code
+	grpcStatus, ok := status.FromError(err)
+	assert.True(t, ok)
+	assert.Equal(t, codes.Unauthenticated, grpcStatus.Code())
 }
 
 func TestInventoryService_DeleteResource_InvalidRequest(t *testing.T) {
@@ -343,6 +350,60 @@ func TestInventoryService_DeleteResource_InvalidRequest(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 	assert.Contains(t, err.Error(), "failed to build reporter resource ID")
+
+	// Check that it returns the correct gRPC status code
+	grpcStatus, ok := status.FromError(err)
+	assert.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, grpcStatus.Code())
+}
+
+func TestInventoryService_DeleteResource_ResourceNotFound(t *testing.T) {
+	id := &authnapi.Identity{Principal: "sarah", Type: "rbac"}
+	ctx := context.WithValue(context.Background(), middleware.IdentityRequestKey, id)
+
+	req := &pb.DeleteResourceRequest{
+		Reference: &pb.ResourceReference{
+			ResourceId:   "nonexistent-resource",
+			ResourceType: "host",
+			Reporter:     &pb.ReporterReference{Type: "hbi"},
+		},
+	}
+
+	mockRepo := new(MockRepo)
+
+	// Mock the repository to return ErrResourceNotFound
+	mockRepo.
+		On("FindByReporterData", mock.Anything, "sarah", "nonexistent-resource").
+		Return((*model_legacy.Resource)(nil), gorm.ErrRecordNotFound).
+		Once()
+
+	mockRepo.
+		On("FindByReporterResourceId", mock.Anything, mock.Anything).
+		Return((*model_legacy.Resource)(nil), gorm.ErrRecordNotFound).
+		Once()
+
+	cfg := &usecase.UsecaseConfig{}
+	uc := &usecase.Usecase{
+		ReporterResourceRepository: mockRepo,
+		Config:                     cfg,
+		Namespace:                  "rbac",
+		Log:                        krlog.NewHelper(krlog.NewStdLogger(io.Discard)),
+	}
+
+	service := svc.NewKesselInventoryServiceV1beta2(uc)
+
+	resp, err := service.DeleteResource(ctx, req)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "resource not found")
+
+	// Check that it returns the correct gRPC status code
+	grpcStatus, ok := status.FromError(err)
+	assert.True(t, ok)
+	assert.Equal(t, codes.NotFound, grpcStatus.Code())
+
+	mockRepo.AssertExpectations(t)
 }
 
 func TestInventoryService_Check_Allowed(t *testing.T) {


### PR DESCRIPTION
- Updates `DeleteResource` to return proper status codes
- Add tests to capture status codes

## Summary by Sourcery

Refine DeleteResource error handling to use proper gRPC status codes and add corresponding unit tests

Enhancements:
- Return specific gRPC status codes (Unauthenticated, InvalidArgument, NotFound, Internal) in DeleteResource instead of generic errors

Tests:
- Add unit tests to verify gRPC status codes for unauthenticated, invalid request, and resource not found error cases in DeleteResource