### PR TITLE
RHCLOUD-41476: update satellite_id to be type of string, dropping uuid requirement

### DIFF
--- a/data/schema/resources/host/reporters/hbi/host.json
+++ b/data/schema/resources/host/reporters/hbi/host.json
@@ -2,7 +2,12 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "satellite_id": { "type": "string" },
+    "satellite_id": {
+      "oneOf": [
+        { "type": "string", "format": "uuid" },
+        { "type": "string", "pattern": "^\\d{10}$" }
+      ]
+    },
     "subscription_manager_id": { "type": "string", "format": "uuid" },
     "insights_inventory_id": { "type": "string", "format": "uuid" },
     "ansible_host": { "type": "string", "maxLength": 255 }

--- a/data/schema/resources/host/reporters/hbi/host.json
+++ b/data/schema/resources/host/reporters/hbi/host.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "satellite_id": { "type": "string", "format": "uuid" },
+    "satellite_id": { "type": "string" },
     "subscription_manager_id": { "type": "string", "format": "uuid" },
     "insights_inventory_id": { "type": "string", "format": "uuid" },
     "ansible_host": { "type": "string", "maxLength": 255 }


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Part of the HBI work has revealed that the satellite_id value is erroring on schema validation, after further investigating it looks like HBI allows `satellite_id` to be either a UUID or a 10 digit string [source](https://github.com/RedHatInsights/insights-host-inventory/blob/39b5af074e4c757471ec6933b9ff0c34820e6066/app/validators.py#L85)


## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

