### PR TITLE
replacing stream interceptor to match with oidc implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ go 1.24.4
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250717185734-6c6e0d3c608e.1
 	buf.build/go/protovalidate v0.14.0
-	github.com/MicahParks/keyfunc/v3 v3.4.0
 	github.com/authzed/grpcutil v0.0.0-20250221190651-1985b19b35b8
 	github.com/cloudevents/sdk-go/protocol/kafka_confluent/v2 v2.0.0-20250721101952-1c64656a6859
 	github.com/cloudevents/sdk-go/v2 v2.16.1
@@ -44,7 +43,6 @@ require (
 
 require (
 	cel.dev/expr v0.24.0 // indirect
-	github.com/MicahParks/jwkset v0.9.6 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d // indirect
@@ -101,6 +99,5 @@ require (
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
-	golang.org/x/time v0.12.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250721164621-a45f3dfb1074 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,6 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
-github.com/MicahParks/jwkset v0.9.6 h1:Tf8l2/MOby5Kh3IkrqzThPQKfLytMERoAsGZKlyYZxg=
-github.com/MicahParks/jwkset v0.9.6/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
-github.com/MicahParks/keyfunc/v3 v3.4.0 h1:g03TXq6NjhZyO/UkODl//abm4KiLLNRi0VhW7vGOHyg=
-github.com/MicahParks/keyfunc/v3 v3.4.0/go.mod h1:y6Ed3dMgNKTcpxbaQHD8mmrYDUZWJAxteddA6OQj+ag=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.11.5 h1:haEcLNpj9Ka1gd3B3tAEs9CpE0c+1IhoL59w/exYU38=


### PR DESCRIPTION
### PR Template:

## Describe your changes

### Replaced JWT Libraries:
* Removed: github.com/golang-jwt/jwt/v5 and github.com/MicahParks/keyfunc/v3
* Added: github.com/coreos/go-oidc/v3/oidc (same as OIDC authenticator)

### Updated Configuration Structure:

* Removed: Manual JWKS handling, signing method, and custom claims function
*Added: OIDC provider context and verifier (matching OIDC authenticator)

### Unified Token Verification:
* Before: Manual JWT parsing with jwtv5.ParseWithClaims()
* After: OIDC provider verification with verifier.Verify() (same as OIDC authenticator)

### Standardized Claims Structure:
* Before: Generic jwtv5.Claims interface
* After: Custom Claims struct with same fields as OIDC authenticator

### Consistent Provider Setup:
* Before: Manual JWKS fetching from /protocol/openid-connect/certs
* After: OIDC provider discovery with coreosoidc.NewProvider() (same as OIDC authenticator)

Key Benefits:
✅ Consistency: Both components (odic, stream interceptor) now use identical OIDC verification logic
✅ Standards Compliance: Full OIDC compliance instead of generic JWT handling
✅ Simplified Maintenance: Single verification approach across the codebase
✅ Reduced Dependencies: Eliminated manual JWKS management
✅ Better Error Handling: OIDC-specific error messages
- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Use the coreos/go-oidc library for token verification in the gRPC stream interceptor to align with the existing OIDC authenticator, replacing custom JWT parsing and JWKS management.

Enhancements:
- Replace manual JWT parsing and JWKS handling in the stream interceptor with coreos/go-oidc provider and verifier
- Update StreamAuthConfig to include OIDC context and IDTokenVerifier while removing signing method, keyfunc, and custom claims options
- Use verifier.Verify and a new Claims struct to extract OIDC-compliant claims, enforce audience checks, and construct principals
- Remove custom FetchJwks logic and related JWT dependencies from go.mod