### PR TITLE
Revert "RHCLOUD-41508: use guest ip address instead of guest User-Agent header"

### DIFF
--- a/internal/authn/guest/guest.go
+++ b/internal/authn/guest/guest.go
@@ -2,13 +2,8 @@ package guest
 
 import (
 	"context"
-	"strings"
 
 	"github.com/go-kratos/kratos/v2/transport"
-	kgrpc "github.com/go-kratos/kratos/v2/transport/grpc"
-	khttp "github.com/go-kratos/kratos/v2/transport/http"
-
-	"google.golang.org/grpc/peer"
 
 	"github.com/project-kessel/inventory-api/internal/authn/api"
 )
@@ -21,28 +16,13 @@ func New() *GuestAuthenticator {
 	return &GuestAuthenticator{}
 }
 
-// Authenticate creates a guest identity using the ip-address and always allows the request.
+// Authenticate creates a guest identity using the User-Agent header and always allows the request.
 func (a *GuestAuthenticator) Authenticate(ctx context.Context, t transport.Transporter) (*api.Identity, api.Decision) {
 
-	var principal string
-
-	switch tr := t.(type) {
-	case *khttp.Transport:
-		if addr := tr.Request().RemoteAddr; addr != "" {
-			principal = strings.Split(addr, ":")[0]
-		}
-	case *kgrpc.Transport:
-		if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {
-			principal = strings.Split(p.Addr.String(), ":")[0]
-		}
-	}
-
-	if principal == "" {
-		principal = "guest"
-	}
-
+	// TODO: should we use something else? ip address?
+	ua := t.RequestHeader().Get("User-Agent")
 	identity := &api.Identity{
-		Principal: principal,
+		Principal: ua,
 		IsGuest:   true,
 	}
 


### PR DESCRIPTION
Reverts project-kessel/inventory-api#764