### PR TITLE
Rename reporter to reporterId and make constructor accept domain types

### DIFF
--- a/internal/biz/model/common_representation.go
+++ b/internal/biz/model/common_representation.go
@@ -29,7 +29,17 @@ func NewCommonRepresentation(
 		return CommonRepresentation{}, fmt.Errorf("CommonRepresentation invalid resource ID: %w", err)
 	}
 
-	reporter, err := NewReporterId(reportedByReporterType, reportedByReporterInstance)
+	reporterType, err := NewReporterType(reportedByReporterType)
+	if err != nil {
+		return CommonRepresentation{}, fmt.Errorf("CommonRepresentation invalid reporter type: %w", err)
+	}
+
+	reporterInstanceId, err := NewReporterInstanceId(reportedByReporterInstance)
+	if err != nil {
+		return CommonRepresentation{}, fmt.Errorf("CommonRepresentation invalid reporter instance: %w", err)
+	}
+
+	reporter, err := NewReporterId(reporterType, reporterInstanceId)
 	if err != nil {
 		return CommonRepresentation{}, fmt.Errorf("CommonRepresentation invalid reporter: %w", err)
 	}

--- a/internal/biz/model/common_representation.go
+++ b/internal/biz/model/common_representation.go
@@ -10,7 +10,7 @@ type CommonRepresentation struct {
 	Representation
 	resourceId ResourceId
 	version    Version
-	reporter   Reporter
+	reporter   ReporterId
 }
 
 func NewCommonRepresentation(
@@ -29,7 +29,7 @@ func NewCommonRepresentation(
 		return CommonRepresentation{}, fmt.Errorf("CommonRepresentation invalid resource ID: %w", err)
 	}
 
-	reporter, err := NewReporter(reportedByReporterType, reportedByReporterInstance)
+	reporter, err := NewReporterId(reportedByReporterType, reportedByReporterInstance)
 	if err != nil {
 		return CommonRepresentation{}, fmt.Errorf("CommonRepresentation invalid reporter: %w", err)
 	}

--- a/internal/biz/model/reporter.go
+++ b/internal/biz/model/reporter.go
@@ -1,23 +1,11 @@
 package model
 
-import "fmt"
-
 type ReporterId struct {
 	reporterType       ReporterType
 	reporterInstanceId ReporterInstanceId
 }
 
-func NewReporterId(reporterTypeVal, reporterInstanceIdVal string) (ReporterId, error) {
-	reporterType, err := NewReporterType(reporterTypeVal)
-	if err != nil {
-		return ReporterId{}, fmt.Errorf("ReporterId invalid type: %w", err)
-	}
-
-	reporterInstanceId, err := NewReporterInstanceId(reporterInstanceIdVal)
-	if err != nil {
-		return ReporterId{}, fmt.Errorf("ReporterId invalid instance ID: %w", err)
-	}
-
+func NewReporterId(reporterType ReporterType, reporterInstanceId ReporterInstanceId) (ReporterId, error) {
 	return ReporterId{
 		reporterType:       reporterType,
 		reporterInstanceId: reporterInstanceId,

--- a/internal/biz/model/reporter.go
+++ b/internal/biz/model/reporter.go
@@ -2,23 +2,23 @@ package model
 
 import "fmt"
 
-type Reporter struct {
+type ReporterId struct {
 	reporterType       ReporterType
 	reporterInstanceId ReporterInstanceId
 }
 
-func NewReporter(reporterTypeVal, reporterInstanceIdVal string) (Reporter, error) {
+func NewReporterId(reporterTypeVal, reporterInstanceIdVal string) (ReporterId, error) {
 	reporterType, err := NewReporterType(reporterTypeVal)
 	if err != nil {
-		return Reporter{}, fmt.Errorf("Reporter invalid type: %w", err)
+		return ReporterId{}, fmt.Errorf("ReporterId invalid type: %w", err)
 	}
 
 	reporterInstanceId, err := NewReporterInstanceId(reporterInstanceIdVal)
 	if err != nil {
-		return Reporter{}, fmt.Errorf("Reporter invalid instance ID: %w", err)
+		return ReporterId{}, fmt.Errorf("ReporterId invalid instance ID: %w", err)
 	}
 
-	return Reporter{
+	return ReporterId{
 		reporterType:       reporterType,
 		reporterInstanceId: reporterInstanceId,
 	}, nil

--- a/internal/biz/model/reporter_resource.go
+++ b/internal/biz/model/reporter_resource.go
@@ -22,7 +22,7 @@ type ReporterResource struct {
 type ReporterResourceKey struct {
 	localResourceID LocalResourceId
 	resourceType    ResourceType
-	reporter        Reporter
+	reporter        ReporterId
 }
 
 func NewReporterResource(idVal uuid.UUID, localResourceIdVal string, resourceTypeVal string, reporterTypeVal string, reporterInstanceIdVal string, resourceIdVal uuid.UUID, apiHrefVal string, consoleHrefVal string) (ReporterResource, error) {
@@ -83,7 +83,7 @@ func NewReporterResourceKey(
 		return ReporterResourceKey{}, fmt.Errorf("ReporterResourceKey invalid resource type: %w", err)
 	}
 
-	reporter, err := NewReporter(reporterTypeVal, reporterInstanceIdVal)
+	reporter, err := NewReporterId(reporterTypeVal, reporterInstanceIdVal)
 	if err != nil {
 		return ReporterResourceKey{}, fmt.Errorf("ReporterResourceKey invalid reporter: %w", err)
 	}

--- a/internal/biz/model/reporter_resource.go
+++ b/internal/biz/model/reporter_resource.go
@@ -83,7 +83,17 @@ func NewReporterResourceKey(
 		return ReporterResourceKey{}, fmt.Errorf("ReporterResourceKey invalid resource type: %w", err)
 	}
 
-	reporter, err := NewReporterId(reporterTypeVal, reporterInstanceIdVal)
+	reporterType, err := NewReporterType(reporterTypeVal)
+	if err != nil {
+		return ReporterResourceKey{}, fmt.Errorf("ReporterResourceKey invalid reporter type: %w", err)
+	}
+
+	reporterInstanceId, err := NewReporterInstanceId(reporterInstanceIdVal)
+	if err != nil {
+		return ReporterResourceKey{}, fmt.Errorf("ReporterResourceKey invalid reporter instance: %w", err)
+	}
+
+	reporter, err := NewReporterId(reporterType, reporterInstanceId)
 	if err != nil {
 		return ReporterResourceKey{}, fmt.Errorf("ReporterResourceKey invalid reporter: %w", err)
 	}

--- a/internal/biz/model/reporter_test.go
+++ b/internal/biz/model/reporter_test.go
@@ -14,7 +14,7 @@ func TestReporter_Initialization(t *testing.T) {
 	t.Run("should create reporter with valid inputs", func(t *testing.T) {
 		t.Parallel()
 
-		reporter, err := NewReporter(fixture.ValidReporterType, fixture.ValidReporterInstanceId)
+		reporter, err := NewReporterId(fixture.ValidReporterType, fixture.ValidReporterInstanceId)
 
 		assertValidReporter(t, reporter, err, fixture.ValidReporterType, fixture.ValidReporterInstanceId)
 	})
@@ -22,7 +22,7 @@ func TestReporter_Initialization(t *testing.T) {
 	t.Run("should create reporter with another valid set of inputs", func(t *testing.T) {
 		t.Parallel()
 
-		reporter, err := NewReporter(fixture.AnotherReporterType, fixture.AnotherReporterInstanceId)
+		reporter, err := NewReporterId(fixture.AnotherReporterType, fixture.AnotherReporterInstanceId)
 
 		assertValidReporter(t, reporter, err, fixture.AnotherReporterType, fixture.AnotherReporterInstanceId)
 	})
@@ -30,53 +30,53 @@ func TestReporter_Initialization(t *testing.T) {
 	t.Run("should reject empty reporter type", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewReporter(fixture.EmptyString, fixture.ValidReporterInstanceId)
+		_, err := NewReporterId(fixture.EmptyString, fixture.ValidReporterInstanceId)
 
-		assertInvalidReporter(t, err, "Reporter invalid type")
+		assertInvalidReporter(t, err, "ReporterId invalid type")
 	})
 
 	t.Run("should reject whitespace-only reporter type", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewReporter(fixture.WhitespaceString, fixture.ValidReporterInstanceId)
+		_, err := NewReporterId(fixture.WhitespaceString, fixture.ValidReporterInstanceId)
 
-		assertInvalidReporter(t, err, "Reporter invalid type")
+		assertInvalidReporter(t, err, "ReporterId invalid type")
 	})
 
 	t.Run("should reject empty reporter instance id", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewReporter(fixture.ValidReporterType, fixture.EmptyString)
+		_, err := NewReporterId(fixture.ValidReporterType, fixture.EmptyString)
 
-		assertInvalidReporter(t, err, "Reporter invalid instance ID")
+		assertInvalidReporter(t, err, "ReporterId invalid instance ID")
 	})
 
 	t.Run("should reject whitespace-only reporter instance id", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewReporter(fixture.ValidReporterType, fixture.WhitespaceString)
+		_, err := NewReporterId(fixture.ValidReporterType, fixture.WhitespaceString)
 
-		assertInvalidReporter(t, err, "Reporter invalid instance ID")
+		assertInvalidReporter(t, err, "ReporterId invalid instance ID")
 	})
 
 	t.Run("should reject both empty inputs", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewReporter(fixture.EmptyString, fixture.EmptyString)
+		_, err := NewReporterId(fixture.EmptyString, fixture.EmptyString)
 
-		assertInvalidReporter(t, err, "Reporter invalid type")
+		assertInvalidReporter(t, err, "ReporterId invalid type")
 	})
 
 	t.Run("should reject both whitespace inputs", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewReporter(fixture.WhitespaceString, fixture.WhitespaceString)
+		_, err := NewReporterId(fixture.WhitespaceString, fixture.WhitespaceString)
 
-		assertInvalidReporter(t, err, "Reporter invalid type")
+		assertInvalidReporter(t, err, "ReporterId invalid type")
 	})
 }
 
-func assertValidReporter(t *testing.T, reporter Reporter, err error, expectedType, expectedInstanceId string) {
+func assertValidReporter(t *testing.T, reporter ReporterId, err error, expectedType, expectedInstanceId string) {
 	t.Helper()
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)

--- a/internal/biz/model/reporter_test.go
+++ b/internal/biz/model/reporter_test.go
@@ -14,7 +14,17 @@ func TestReporter_Initialization(t *testing.T) {
 	t.Run("should create reporter with valid inputs", func(t *testing.T) {
 		t.Parallel()
 
-		reporter, err := NewReporterId(fixture.ValidReporterType, fixture.ValidReporterInstanceId)
+		reporterType, err := NewReporterType(fixture.ValidReporterType)
+		if err != nil {
+			t.Fatalf("Failed to create reporter type: %v", err)
+		}
+
+		reporterInstanceId, err := NewReporterInstanceId(fixture.ValidReporterInstanceId)
+		if err != nil {
+			t.Fatalf("Failed to create reporter instance id: %v", err)
+		}
+
+		reporter, err := NewReporterId(reporterType, reporterInstanceId)
 
 		assertValidReporter(t, reporter, err, fixture.ValidReporterType, fixture.ValidReporterInstanceId)
 	})
@@ -22,7 +32,17 @@ func TestReporter_Initialization(t *testing.T) {
 	t.Run("should create reporter with another valid set of inputs", func(t *testing.T) {
 		t.Parallel()
 
-		reporter, err := NewReporterId(fixture.AnotherReporterType, fixture.AnotherReporterInstanceId)
+		reporterType, err := NewReporterType(fixture.AnotherReporterType)
+		if err != nil {
+			t.Fatalf("Failed to create reporter type: %v", err)
+		}
+
+		reporterInstanceId, err := NewReporterInstanceId(fixture.AnotherReporterInstanceId)
+		if err != nil {
+			t.Fatalf("Failed to create reporter instance id: %v", err)
+		}
+
+		reporter, err := NewReporterId(reporterType, reporterInstanceId)
 
 		assertValidReporter(t, reporter, err, fixture.AnotherReporterType, fixture.AnotherReporterInstanceId)
 	})
@@ -30,49 +50,89 @@ func TestReporter_Initialization(t *testing.T) {
 	t.Run("should reject empty reporter type", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewReporterId(fixture.EmptyString, fixture.ValidReporterInstanceId)
-
-		assertInvalidReporter(t, err, "ReporterId invalid type")
+		_, err := NewReporterType(fixture.EmptyString)
+		if err == nil {
+			t.Error("Expected error for empty reporter type, got none")
+		}
+		if !strings.Contains(err.Error(), "ReporterType cannot be empty") {
+			t.Errorf("Expected error message about empty reporter type, got: %v", err.Error())
+		}
 	})
 
 	t.Run("should reject whitespace-only reporter type", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewReporterId(fixture.WhitespaceString, fixture.ValidReporterInstanceId)
-
-		assertInvalidReporter(t, err, "ReporterId invalid type")
+		_, err := NewReporterType(fixture.WhitespaceString)
+		if err == nil {
+			t.Error("Expected error for whitespace-only reporter type, got none")
+		}
+		if !strings.Contains(err.Error(), "ReporterType cannot be empty") {
+			t.Errorf("Expected error message about empty reporter type, got: %v", err.Error())
+		}
 	})
 
 	t.Run("should reject empty reporter instance id", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewReporterId(fixture.ValidReporterType, fixture.EmptyString)
-
-		assertInvalidReporter(t, err, "ReporterId invalid instance ID")
+		_, err := NewReporterInstanceId(fixture.EmptyString)
+		if err == nil {
+			t.Error("Expected error for empty reporter instance id, got none")
+		}
+		if !strings.Contains(err.Error(), "ReporterInstanceId cannot be empty") {
+			t.Errorf("Expected error message about empty reporter instance id, got: %v", err.Error())
+		}
 	})
 
 	t.Run("should reject whitespace-only reporter instance id", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewReporterId(fixture.ValidReporterType, fixture.WhitespaceString)
-
-		assertInvalidReporter(t, err, "ReporterId invalid instance ID")
+		_, err := NewReporterInstanceId(fixture.WhitespaceString)
+		if err == nil {
+			t.Error("Expected error for whitespace-only reporter instance id, got none")
+		}
+		if !strings.Contains(err.Error(), "ReporterInstanceId cannot be empty") {
+			t.Errorf("Expected error message about empty reporter instance id, got: %v", err.Error())
+		}
 	})
 
 	t.Run("should reject both empty inputs", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewReporterId(fixture.EmptyString, fixture.EmptyString)
+		_, err := NewReporterType(fixture.EmptyString)
+		if err == nil {
+			t.Error("Expected error for empty reporter type, got none")
+		}
+		if !strings.Contains(err.Error(), "ReporterType cannot be empty") {
+			t.Errorf("Expected error message about empty reporter type, got: %v", err.Error())
+		}
 
-		assertInvalidReporter(t, err, "ReporterId invalid type")
+		_, err = NewReporterInstanceId(fixture.EmptyString)
+		if err == nil {
+			t.Error("Expected error for empty reporter instance id, got none")
+		}
+		if !strings.Contains(err.Error(), "ReporterInstanceId cannot be empty") {
+			t.Errorf("Expected error message about empty reporter instance id, got: %v", err.Error())
+		}
 	})
 
 	t.Run("should reject both whitespace inputs", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewReporterId(fixture.WhitespaceString, fixture.WhitespaceString)
+		_, err := NewReporterType(fixture.WhitespaceString)
+		if err == nil {
+			t.Error("Expected error for whitespace-only reporter type, got none")
+		}
+		if !strings.Contains(err.Error(), "ReporterType cannot be empty") {
+			t.Errorf("Expected error message about empty reporter type, got: %v", err.Error())
+		}
 
-		assertInvalidReporter(t, err, "ReporterId invalid type")
+		_, err = NewReporterInstanceId(fixture.WhitespaceString)
+		if err == nil {
+			t.Error("Expected error for whitespace-only reporter instance id, got none")
+		}
+		if !strings.Contains(err.Error(), "ReporterInstanceId cannot be empty") {
+			t.Errorf("Expected error message about empty reporter instance id, got: %v", err.Error())
+		}
 	})
 }
 


### PR DESCRIPTION
### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Rename the Reporter domain model to ReporterId and refactor its constructor to accept strongly-typed ReporterType and ReporterInstanceId values instead of raw strings, updating all related code paths and tests accordingly.

Enhancements:
- Rename Reporter struct to ReporterId and replace string-based constructor with NewReporterId that takes domain types.
- Introduce NewReporterType and NewReporterInstanceId callers in CommonRepresentation and ReporterResource to build reporterId parameters.
- Update unit tests to use the new domain constructors, adjust validation expectations, and rename helper functions to work with ReporterId.