### PR TITLE
Make resource accept domain types instead of primitives

### DIFF
--- a/internal/biz/model/resource.go
+++ b/internal/biz/model/resource.go
@@ -2,8 +2,6 @@ package model
 
 import (
 	"fmt"
-
-	"github.com/google/uuid"
 )
 
 const initialCommonVersion = 0
@@ -16,24 +14,14 @@ type Resource struct {
 	reporterResources []ReporterResource
 }
 
-func NewResource(id uuid.UUID, resourceType string, reporterResources []ReporterResource) (Resource, error) {
+func NewResource(id ResourceId, resourceType ResourceType, reporterResources []ReporterResource) (Resource, error) {
 	if len(reporterResources) == 0 {
 		return Resource{}, fmt.Errorf("Resource must have at least one ReporterResource")
 	}
 
-	resourceTypeObj, err := NewResourceType(resourceType)
-	if err != nil {
-		return Resource{}, fmt.Errorf("Resource invalid type: %w", err)
-	}
-
-	resourceId, err := NewResourceId(id)
-	if err != nil {
-		return Resource{}, fmt.Errorf("Resource invalid ID: %w", err)
-	}
-
 	resource := Resource{
-		id:                resourceId,
-		resourceType:      resourceTypeObj,
+		id:                id,
+		resourceType:      resourceType,
 		commonVersion:     NewVersion(initialCommonVersion),
 		reporterResources: reporterResources,
 	}

--- a/internal/biz/model/resource_test.go
+++ b/internal/biz/model/resource_test.go
@@ -9,6 +9,18 @@ import (
 	"github.com/google/uuid"
 )
 
+func createResourceWithFixture(fixture ResourceTestFixture, id uuid.UUID, resourceType string, reporterResources []ReporterResource) (Resource, error) {
+	resourceId, err := NewResourceId(id)
+	if err != nil {
+		return Resource{}, err
+	}
+	resourceTypeObj, err := NewResourceType(resourceType)
+	if err != nil {
+		return Resource{}, err
+	}
+	return NewResource(resourceId, resourceTypeObj, reporterResources)
+}
+
 func TestResource_Initialization(t *testing.T) {
 	t.Parallel()
 	fixture := NewResourceTestFixture()
@@ -16,9 +28,12 @@ func TestResource_Initialization(t *testing.T) {
 	t.Run("should create resource with single reporter resource", func(t *testing.T) {
 		t.Parallel()
 
+		resourceId, _ := NewResourceId(fixture.ValidId)
+		resourceType, _ := NewResourceType(fixture.ValidResourceType)
+
 		resource, err := NewResource(
-			fixture.ValidId,
-			fixture.ValidResourceType,
+			resourceId,
+			resourceType,
 			[]ReporterResource{fixture.ValidReporterResource},
 		)
 
@@ -29,9 +44,12 @@ func TestResource_Initialization(t *testing.T) {
 	t.Run("should create resource with multiple reporter resources", func(t *testing.T) {
 		t.Parallel()
 
+		resourceId, _ := NewResourceId(fixture.ValidId)
+		resourceType, _ := NewResourceType(fixture.ValidResourceType)
+
 		resource, err := NewResource(
-			fixture.ValidId,
-			fixture.ValidResourceType,
+			resourceId,
+			resourceType,
 			fixture.MultipleReporterResources,
 		)
 


### PR DESCRIPTION
### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Refactor the Resource model to accept its domain types directly and update tests to match the new API

Enhancements:
- Refactor NewResource to take ResourceId and ResourceType instead of raw uuid.UUID and string
- Remove internal ID and type conversions from the Resource constructor
- Update tests to construct ResourceId and ResourceType via their respective constructors
- Add createResourceWithFixture helper to streamline test setup