### PR TITLE
V1beta2 check for update

### DIFF
--- a/internal/authz/allow/allow.go
+++ b/internal/authz/allow/allow.go
@@ -10,8 +10,6 @@ import (
 	"github.com/go-kratos/kratos/v2/log"
 	kesselv1 "github.com/project-kessel/relations-api/api/kessel/relations/v1"
 	"github.com/project-kessel/relations-api/api/kessel/relations/v1beta1"
-
-	"github.com/project-kessel/inventory-api/internal/biz/model_legacy"
 )
 
 type AllowAllAuthz struct {
@@ -34,7 +32,7 @@ func (a *AllowAllAuthz) Check(context.Context, string, string, string, string, s
 	return v1beta1.CheckResponse_ALLOWED_TRUE, nil, nil
 }
 
-func (a *AllowAllAuthz) CheckForUpdate(context.Context, string, string, *model_legacy.Resource, *v1beta1.SubjectReference) (v1beta1.CheckForUpdateResponse_Allowed, *v1beta1.ConsistencyToken, error) {
+func (a *AllowAllAuthz) CheckForUpdate(context.Context, string, string, string, string, *v1beta1.SubjectReference) (v1beta1.CheckForUpdateResponse_Allowed, *v1beta1.ConsistencyToken, error) {
 	return v1beta1.CheckForUpdateResponse_ALLOWED_TRUE, nil, nil
 }
 

--- a/internal/authz/api/authz-service.go
+++ b/internal/authz/api/authz-service.go
@@ -7,8 +7,6 @@ import (
 
 	kesselv1 "github.com/project-kessel/relations-api/api/kessel/relations/v1"
 	kessel "github.com/project-kessel/relations-api/api/kessel/relations/v1beta1"
-
-	"github.com/project-kessel/inventory-api/internal/biz/model_legacy"
 )
 
 // Authorizer defines the interface for authorization and access control operations.
@@ -16,7 +14,7 @@ import (
 type Authorizer interface {
 	Health(ctx context.Context) (*kesselv1.GetReadyzResponse, error)
 	Check(context.Context, string, string, string, string, string, *kessel.SubjectReference) (kessel.CheckResponse_Allowed, *kessel.ConsistencyToken, error)
-	CheckForUpdate(context.Context, string, string, *model_legacy.Resource, *kessel.SubjectReference) (kessel.CheckForUpdateResponse_Allowed, *kessel.ConsistencyToken, error)
+	CheckForUpdate(context.Context, string, string, string, string, *kessel.SubjectReference) (kessel.CheckForUpdateResponse_Allowed, *kessel.ConsistencyToken, error)
 	LookupResources(ctx context.Context, in *kessel.LookupResourcesRequest) (grpc.ServerStreamingClient[kessel.LookupResourcesResponse], error)
 	CreateTuples(context.Context, *kessel.CreateTuplesRequest) (*kessel.CreateTuplesResponse, error)
 	DeleteTuples(context.Context, *kessel.DeleteTuplesRequest) (*kessel.DeleteTuplesResponse, error)

--- a/internal/biz/usecase/resources/resource_service.go
+++ b/internal/biz/usecase/resources/resource_service.go
@@ -537,7 +537,7 @@ func (uc *Usecase) CheckForUpdate(ctx context.Context, permission, namespace str
 		}
 	}
 
-	allowed, consistency, err := uc.Authz.CheckForUpdate(ctx, namespace, permission, res, sub)
+	allowed, consistency, err := uc.Authz.CheckForUpdate(ctx, namespace, permission, res.ResourceType, res.ReporterResourceId, sub)
 	if err != nil {
 		return false, err
 	}

--- a/internal/biz/usecase/resources/resource_service.go
+++ b/internal/biz/usecase/resources/resource_service.go
@@ -197,6 +197,19 @@ func (uc *Usecase) Check(ctx context.Context, permission, namespace string, sub 
 	return false, nil
 }
 
+// CheckForUpdate forwards the request to Relations CheckForUpdate
+func (uc *Usecase) CheckForUpdate(ctx context.Context, permission, namespace string, sub *kessel.SubjectReference, reporterResourceKey model.ReporterResourceKey) (bool, error) {
+	allowed, _, err := uc.Authz.CheckForUpdate(ctx, namespace, permission, reporterResourceKey.ResourceType().Serialize(), reporterResourceKey.LocalResourceId().Serialize(), sub)
+	if err != nil {
+		return false, err
+	}
+
+	if allowed == kessel.CheckForUpdateResponse_ALLOWED_TRUE {
+		return true, nil
+	}
+	return false, nil
+}
+
 func (uc *Usecase) createResource(tx *gorm.DB, request *v1beta2.ReportResourceRequest, txidStr string) error {
 	resourceId, err := uc.resourceRepository.NextResourceId()
 	if err != nil {

--- a/internal/biz/usecase/resources/resource_service.go
+++ b/internal/biz/usecase/resources/resource_service.go
@@ -520,9 +520,9 @@ func (uc *Usecase) CheckLegacy(ctx context.Context, permission, namespace string
 	return false, nil
 }
 
-// CheckForUpdate verifies if a subject has the specified permission to update a resource,
+// CheckForUpdateLegacy verifies if a subject has the specified permission to update a resource,
 // and records the consistency token if the check passes and the resource exists.
-func (uc *Usecase) CheckForUpdate(ctx context.Context, permission, namespace string, sub *kessel.SubjectReference, id model_legacy.ReporterResourceId) (bool, error) {
+func (uc *Usecase) CheckForUpdateLegacy(ctx context.Context, permission, namespace string, sub *kessel.SubjectReference, id model_legacy.ReporterResourceId) (bool, error) {
 	res, err := uc.LegacyReporterResourceRepository.FindByReporterResourceId(ctx, id)
 	recordToken := true
 	if err != nil {

--- a/internal/biz/usecase/resources/resource_service_test.go
+++ b/internal/biz/usecase/resources/resource_service_test.go
@@ -838,7 +838,7 @@ func TestCheckForUpdate_ErrorWithKessel(t *testing.T) {
 	m := &mocks.MockAuthz{}
 
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return(&model_legacy.Resource{}, nil)
-	m.On("CheckForUpdate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_FALSE, &v1beta1.ConsistencyToken{}, errors.New("failed during call to relations"))
+	m.On("CheckForUpdate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_FALSE, &v1beta1.ConsistencyToken{}, errors.New("failed during call to relations"))
 
 	useCase := New(nil, repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	allowed, err := useCase.CheckForUpdate(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model_legacy.ReporterResourceId{})
@@ -858,7 +858,7 @@ func TestCheckForUpdate_WorkspaceAllowed(t *testing.T) {
 	m := &mocks.MockAuthz{}
 
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return(resource, nil)
-	m.On("CheckForUpdate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
+	m.On("CheckForUpdate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
 
 	useCase := New(nil, repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	allowed, err := useCase.CheckForUpdate(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model_legacy.ReporterResourceId{ResourceType: "workspace"})
@@ -877,7 +877,7 @@ func TestCheckForUpdate_MissingResource_Allowed(t *testing.T) {
 	m := &mocks.MockAuthz{}
 
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return(&model_legacy.Resource{}, gorm.ErrRecordNotFound)
-	m.On("CheckForUpdate", mock.Anything, mock.Anything, "notifications_integration_view", mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
+	m.On("CheckForUpdate", mock.Anything, mock.Anything, "notifications_integration_view", mock.Anything, mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
 
 	useCase := New(nil, repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	allowed, err := useCase.CheckForUpdate(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model_legacy.ReporterResourceId{})
@@ -900,7 +900,7 @@ func TestCheckForUpdate_Allowed(t *testing.T) {
 	m := &mocks.MockAuthz{}
 
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return(resource, nil)
-	m.On("CheckForUpdate", mock.Anything, mock.Anything, "notifications_integration_view", mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
+	m.On("CheckForUpdate", mock.Anything, mock.Anything, "notifications_integration_view", mock.Anything, mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
 
 	repo.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&model_legacy.Resource{}, nil)
 
@@ -911,7 +911,7 @@ func TestCheckForUpdate_Allowed(t *testing.T) {
 	assert.True(t, allowed)
 
 	// check negative case
-	m.On("CheckForUpdate", mock.Anything, mock.Anything, "notifications_integration_write", mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_FALSE, &v1beta1.ConsistencyToken{}, nil)
+	m.On("CheckForUpdate", mock.Anything, mock.Anything, "notifications_integration_write", mock.Anything, mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_FALSE, &v1beta1.ConsistencyToken{}, nil)
 
 	allowed, err = useCase.CheckForUpdate(ctx, "notifications_integration_write", "rbac", &v1beta1.SubjectReference{}, model_legacy.ReporterResourceId{})
 

--- a/internal/biz/usecase/resources/resource_service_test.go
+++ b/internal/biz/usecase/resources/resource_service_test.go
@@ -822,7 +822,7 @@ func TestCheckForUpdate_ResourceExistsError(t *testing.T) {
 	repo.On("FindByReporterResourceId", mock.Anything, mock.Anything).Return(&model_legacy.Resource{}, gorm.ErrUnsupportedDriver) // some random error
 
 	useCase := New(nil, repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
-	allowed, err := useCase.CheckForUpdate(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model_legacy.ReporterResourceId{})
+	allowed, err := useCase.CheckForUpdateLegacy(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model_legacy.ReporterResourceId{})
 
 	assert.NotNil(t, err)
 	assert.False(t, allowed)
@@ -841,7 +841,7 @@ func TestCheckForUpdate_ErrorWithKessel(t *testing.T) {
 	m.On("CheckForUpdate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_FALSE, &v1beta1.ConsistencyToken{}, errors.New("failed during call to relations"))
 
 	useCase := New(nil, repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
-	allowed, err := useCase.CheckForUpdate(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model_legacy.ReporterResourceId{})
+	allowed, err := useCase.CheckForUpdateLegacy(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model_legacy.ReporterResourceId{})
 
 	assert.NotNil(t, err)
 	assert.False(t, allowed)
@@ -861,7 +861,7 @@ func TestCheckForUpdate_WorkspaceAllowed(t *testing.T) {
 	m.On("CheckForUpdate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
 
 	useCase := New(nil, repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
-	allowed, err := useCase.CheckForUpdate(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model_legacy.ReporterResourceId{ResourceType: "workspace"})
+	allowed, err := useCase.CheckForUpdateLegacy(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model_legacy.ReporterResourceId{ResourceType: "workspace"})
 
 	assert.Nil(t, err)
 	assert.True(t, allowed)
@@ -880,7 +880,7 @@ func TestCheckForUpdate_MissingResource_Allowed(t *testing.T) {
 	m.On("CheckForUpdate", mock.Anything, mock.Anything, "notifications_integration_view", mock.Anything, mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_TRUE, &v1beta1.ConsistencyToken{}, nil)
 
 	useCase := New(nil, repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
-	allowed, err := useCase.CheckForUpdate(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model_legacy.ReporterResourceId{})
+	allowed, err := useCase.CheckForUpdateLegacy(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model_legacy.ReporterResourceId{})
 
 	// no consistency token being written.
 
@@ -905,7 +905,7 @@ func TestCheckForUpdate_Allowed(t *testing.T) {
 	repo.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&model_legacy.Resource{}, nil)
 
 	useCase := New(nil, repo, inventoryRepo, m, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
-	allowed, err := useCase.CheckForUpdate(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model_legacy.ReporterResourceId{})
+	allowed, err := useCase.CheckForUpdateLegacy(ctx, "notifications_integration_view", "rbac", &v1beta1.SubjectReference{}, model_legacy.ReporterResourceId{})
 
 	assert.Nil(t, err)
 	assert.True(t, allowed)
@@ -913,7 +913,7 @@ func TestCheckForUpdate_Allowed(t *testing.T) {
 	// check negative case
 	m.On("CheckForUpdate", mock.Anything, mock.Anything, "notifications_integration_write", mock.Anything, mock.Anything, mock.Anything).Return(v1beta1.CheckForUpdateResponse_ALLOWED_FALSE, &v1beta1.ConsistencyToken{}, nil)
 
-	allowed, err = useCase.CheckForUpdate(ctx, "notifications_integration_write", "rbac", &v1beta1.SubjectReference{}, model_legacy.ReporterResourceId{})
+	allowed, err = useCase.CheckForUpdateLegacy(ctx, "notifications_integration_write", "rbac", &v1beta1.SubjectReference{}, model_legacy.ReporterResourceId{})
 
 	assert.Nil(t, err)
 	assert.False(t, allowed)

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -75,8 +75,8 @@ func (m *MockAuthz) Check(ctx context.Context, namespace string, permission stri
 	return args.Get(0).(v1beta1.CheckResponse_Allowed), args.Get(1).(*v1beta1.ConsistencyToken), args.Error(2)
 }
 
-func (m *MockAuthz) CheckForUpdate(ctx context.Context, namespace string, permission string, res *model_legacy.Resource, sub *v1beta1.SubjectReference) (v1beta1.CheckForUpdateResponse_Allowed, *v1beta1.ConsistencyToken, error) {
-	args := m.Called(ctx, namespace, permission, res, sub)
+func (m *MockAuthz) CheckForUpdate(ctx context.Context, namespace string, permission string, resourceType string, localResourceId string, sub *v1beta1.SubjectReference) (v1beta1.CheckForUpdateResponse_Allowed, *v1beta1.ConsistencyToken, error) {
+	args := m.Called(ctx, namespace, permission, resourceType, localResourceId, sub)
 	return args.Get(0).(v1beta1.CheckForUpdateResponse_Allowed), args.Get(1).(*v1beta1.ConsistencyToken), args.Error(2)
 }
 

--- a/internal/service/resources/kesselcheckservice.go
+++ b/internal/service/resources/kesselcheckservice.go
@@ -63,7 +63,7 @@ func (s *KesselCheckServiceService) CheckForUpdate(ctx context.Context, req *pb.
 	}
 
 	if resource, err := authzFromRequest(identity, req.Parent); err == nil {
-		if resp, err := s.Ctl.CheckForUpdate(ctx, req.GetRelation(), req.Parent.Type.GetNamespace(), &v1beta1.SubjectReference{
+		if resp, err := s.Ctl.CheckForUpdateLegacy(ctx, req.GetRelation(), req.Parent.Type.GetNamespace(), &v1beta1.SubjectReference{
 			Relation: req.GetSubject().Relation,
 			Subject: &v1beta1.ObjectReference{
 				Type: &v1beta1.ObjectType{

--- a/internal/service/resources/kesselinventoryservice.go
+++ b/internal/service/resources/kesselinventoryservice.go
@@ -129,7 +129,7 @@ func (s *InventoryService) CheckForUpdate(ctx context.Context, req *pb.CheckForU
 	}
 
 	if resource, err := authzFromRequestV1beta2(identity, req.Object); err == nil {
-		if resp, err := s.Ctl.CheckForUpdate(ctx, req.GetRelation(), req.Object.Reporter.GetType(), subjectReferenceFromSubject(req.GetSubject()), *resource); err == nil {
+		if resp, err := s.Ctl.CheckForUpdateLegacy(ctx, req.GetRelation(), req.Object.Reporter.GetType(), subjectReferenceFromSubject(req.GetSubject()), *resource); err == nil {
 			return updateResponseFromAuthzRequestV1beta2(resp), nil
 		} else {
 			return nil, err

--- a/internal/service/resources/kesselinventoryservice_test.go
+++ b/internal/service/resources/kesselinventoryservice_test.go
@@ -535,7 +535,8 @@ func TestInventoryService_CheckForUpdate_Allowed(t *testing.T) {
 			mock.Anything,
 			"hbi",
 			"view",
-			mock.AnythingOfType("*model_legacy.Resource"),
+			mock.Anything,
+			mock.Anything,
 			mock.Anything,
 		).
 		Return(relationsV1beta1.CheckForUpdateResponse_ALLOWED_TRUE, &relationsV1beta1.ConsistencyToken{}, nil).
@@ -653,7 +654,8 @@ func TestInventoryService_CheckForUpdate_Denied(t *testing.T) {
 			mock.Anything,
 			"hbi",
 			"view",
-			mock.AnythingOfType("*model_legacy.Resource"),
+			mock.Anything,
+			mock.Anything,
 			mock.Anything,
 		).
 		Return(relationsV1beta1.CheckForUpdateResponse_ALLOWED_FALSE, &relationsV1beta1.ConsistencyToken{}, nil).


### PR DESCRIPTION
### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Implement versioned CheckForUpdate support by branching logic on v1beta2 versus legacy v1beta1 paths across the service, usecase, and authz layers and update corresponding tests and mocks to match the new method signature.

New Features:
- Add support for v1beta2 database path for CheckForUpdate in InventoryService and Usecase

Bug Fixes:
- Return proper Unauthenticated gRPC status when identity retrieval fails

Enhancements:
- Refactor Authz.CheckForUpdate signature to accept resourceType and localResourceId instead of legacy Resource object
- Introduce Usecase.CheckForUpdate for v1beta2 and rename legacy method to CheckForUpdateLegacy
- Update logging in InventoryService to differentiate between v1beta1 and v1beta2 checks

Tests:
- Adjust service and usecase tests to invoke CheckForUpdateLegacy and accommodate the revised CheckForUpdate signature in mocks