### PR TITLE
Handle optional instance_id for Check

### DIFF
--- a/internal/service/resources/kesselinventoryservice.go
+++ b/internal/service/resources/kesselinventoryservice.go
@@ -263,10 +263,19 @@ func reporterKeyFromResourceReference(resource *pb.ResourceReference) (model.Rep
 	if err != nil {
 		return model.ReporterResourceKey{}, err
 	}
-	reporterInstanceId, err := model.NewReporterInstanceId(resource.GetReporter().GetInstanceId())
-	if err != nil {
-		return model.ReporterResourceKey{}, err
+
+	// Handle reporterInstanceId being absent/empty
+	var reporterInstanceId model.ReporterInstanceId
+	if instanceId := resource.GetReporter().GetInstanceId(); instanceId != "" {
+		reporterInstanceId, err = model.NewReporterInstanceId(instanceId)
+		if err != nil {
+			return model.ReporterResourceKey{}, err
+		}
+	} else {
+		// Use zero value for empty/absent reporterInstanceId
+		reporterInstanceId = model.ReporterInstanceId("")
 	}
+
 	return model.NewReporterResourceKey(localResourceId, resourceType, reporterType, reporterInstanceId)
 }
 


### PR DESCRIPTION
### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Allow optional reporter_instance_id by omitting its query filter when absent and defaulting missing instance IDs to zero value

Enhancements:
- Dynamically add reporter_instance_id WHERE clause only if the key’s ReporterInstanceId is non‐empty
- Default ReporterInstanceId to zero value when instance_id is absent in resource references