### PR TITLE
RHCLOUD-42006 - CheckReq: only try to serialize consistencyToken on valid request

### DIFF
--- a/internal/biz/usecase/resources/resource_service.go
+++ b/internal/biz/usecase/resources/resource_service.go
@@ -182,7 +182,7 @@ func (uc *Usecase) Check(ctx context.Context, permission, namespace string, sub 
 			return false, err
 		}
 		consistencyToken = ""
-	} else {
+	} else if res != nil {
 		consistencyToken = res.ConsistencyToken().Serialize()
 	}
 

--- a/internal/biz/usecase/resources/resource_service.go
+++ b/internal/biz/usecase/resources/resource_service.go
@@ -122,7 +122,11 @@ func (uc *Usecase) ReportResource(ctx context.Context, request *v1beta2.ReportRe
 	err = uc.resourceRepository.GetTransactionManager().HandleSerializableTransaction(uc.resourceRepository.GetDB(), func(tx *gorm.DB) error {
 		existingResource, err := uc.resourceRepository.FindResourceByKeys(tx, reporterResourceKey)
 		if err != nil {
-			return fmt.Errorf("failed to lookup existing resource: %w", err)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				existingResource = nil
+			} else {
+				return fmt.Errorf("failed to lookup existing resource: %w", err)
+			}
 		}
 
 		if existingResource != nil {

--- a/internal/data/resource_repository.go
+++ b/internal/data/resource_repository.go
@@ -1,7 +1,6 @@
 package data
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -210,13 +209,14 @@ func (r *resourceRepository) FindResourceByKeys(tx *gorm.DB, key bizmodel.Report
 	err := query.Find(&results).Error // Use Find since it returns multiple rows
 
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, nil
-		}
 		return nil, fmt.Errorf("failed to find resource by keys: %w", err)
 	}
 
 	resourceSnapshot, reporterResourceSnapshots := ToSnapshotsFromResults(results)
+	if resourceSnapshot == nil {
+		return nil, gorm.ErrRecordNotFound
+	}
+
 	resource := bizmodel.DeserializeResource(resourceSnapshot, reporterResourceSnapshots, nil, nil)
 
 	return resource, nil


### PR DESCRIPTION
### PR Template:

## Describe your changes

- when testing in ephemeral i ran into this error:

```sh
INFO ts=2025-08-28T13:47:10Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= service.id=kessel-inventory-api-68988db6b-cds9n msg=Check using v1beta2 db
ERROR ts=2025-08-28T13:47:10Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= service.id=kessel-inventory-api-68988db6b-cds9n msg=runtime error: invalid memory address or nil pointer dereference: object:{resource_type:"host" resource_id:"445b3961-487b-4682-b319-7a2c882680f2" reporter:{type:"hbi" instance_id:"3c4e2382-26c1-11f0-8e5c-ce0194e9e144"}} relation:"view" subject:{resource:{resource_type:"principal" resource_id:"redhat/12345" reporter:{type:"rbac"}}}
goroutine 1290 [running]:
github.com/go-kratos/kratos/v2/middleware/recovery.Recovery.func2.1.1()
	pkg/mod/github.com/go-kratos/kratos/v2@v2.8.4/middleware/recovery/recovery.go:52 +0xbb
panic({0x1affec0?, 0x2e5b920?})
	/usr/lib/golang/src/runtime/panic.go:792 +0x132
github.com/project-kessel/inventory-api/internal/biz/usecase/resources.(*Usecase).Check(0xc0006b0680, {0x202c9c0, 0xc000e1c4b0}, {0xc0010824f4, 0x4}, {0xc0010824f0, 0x3}, 0xc000bbd0c0, {{0xc000b5a450, 0x24}, ...})
	/workspace/internal/biz/usecase/resources/resource_service.go:186 +0xa5
github.com/project-kessel/inventory-api/internal/service/resources.(*InventoryService).Check(0xc0001255a0, {0x202c9c0, 0xc000e1c4b0}, 0xc0009b6f50)
	/workspace/internal/service/resources/kesselinventoryservice.go:103 +0x41e
github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2._KesselInventoryService_Check_Handler.func1({0x202c9c0?, 0xc000e1c4b0?}, {0x1c7d280?, 0xc0009b6f50?})
	/workspace/api/kessel/inventory/v1beta2/inventory_service_grpc.pb.go:318 +0xcb
github.com/go-kratos/kratos/v2/transport/grpc.NewServer.(*Server).unaryServerInterceptor.func1.1({0x202c9c0?, 0xc000e1c4b0?}, {0x1c7d280?, 0xc0009b6f50?})
	pkg/mod/github.com/go-kratos/kratos/v2@v2.8.4/transport/grpc/interceptor.go:37 +0x2b
github.com/project-kessel/inventory-api/cmd/serve.NewCommand.func1.Authentication.7.1({0x202c9f8, 0xc0009fc550}, {0x1c7d280, 0xc0009b6f50})
	/workspace/internal/middleware/authn.go:31 +0xed
github.com/project-kessel/inventory-api/internal/server/grpc.New.(*Builder).Build.selector.func8.1({0x202c9f8, 0xc0009fc550}, {0x1c7d280, 0xc0009b6f50})
	pkg/mod/github.com/go-kratos/kratos/v2@v2.8.4/middleware/selector/selector.go:125 +0xa8
github.com/go-kratos/kratos/v2/middleware/metrics.Server.func1.1({0x202c9f8, 0xc0009fc550}, {0x1c7d280, 0xc0009b6f50})
	pkg/mod/github.com/go-kratos/kratos/v2@v2.8.4/middleware/metrics/metrics.go:129 +0x186
github.com/project-kessel/inventory-api/internal/middleware.Validation.func1.1({0x202c9f8, 0xc0009fc550}, {0x1c7d280, 0xc0009b6f50})
	/workspace/internal/middleware/validation.go:53 +0x2fc
github.com/project-kessel/inventory-api/internal/server/grpc.New.Server.func2.1({0x202c9f8, 0xc0009fc550}, {0x1c7d280, 0xc0009b6f50})
	pkg/mod/github.com/go-kratos/kratos/v2@v2.8.4/middleware/logging/logging.go:41 +0x142
github.com/go-kratos/kratos/v2/middleware/recovery.Recovery.func2.1({0x202c9f8, 0xc0009fc550}, {0x1c7d280, 0xc0009b6f50})
	pkg/mod/github.com/go-kratos/kratos/v2@v2.8.4/middleware/recovery/recovery.go:59 +0x110
github.com/go-kratos/kratos/v2/transport/grpc.NewServer.(*Server).unaryServerInterceptor.func1({0x202c9c0?, 0xc000f82420?}, {0x1c7d280, 0xc0009b6f50}, 0xc000a4e380, 0xc000d48c78)
	pkg/mod/github.com/go-kratos/kratos/v2@v2.8.4/transport/grpc/interceptor.go:42 +0x26f
github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2._KesselInventoryService_Check_Handler({0x1c7c9c0, 0xc0001255a0}, {0x202c9c0, 0xc000f82420}, 0xc000b45a80, 0xc000801560)
	/workspace/api/kessel/inventory/v1beta2/inventory_service_grpc.pb.go:320 +0x143
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0004b7000, {0x202c9c0, 0xc000f82390}, 0xc000a6d080, 0xc0005ed950, 0x2e87f60, 0x0)
	pkg/mod/google.golang.org/grpc@v1.74.2/server.go:1431 +0x1036
google.golang.org/grpc.(*Server).handleStream(0xc0004b7000, {0x202dac8, 0xc000ba61a0}, 0xc000a6d080)
	pkg/mod/google.golang.org/grpc@v1.74.2/server.go:1841 +0xb88
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	pkg/mod/google.golang.org/grpc@v1.74.2/server.go:1061 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 1245
	pkg/mod/google.golang.org/grpc@v1.74.2/server.go:1072 +0x11d

```


Tested fix using `make inventory-up-split-relations-ready` while also having relations and spicedb setup


```sh
INFO ts=2025-09-02T11:20:23+01:00 caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= service.id=fedora msg=Check using v1beta2 db
INFO ts=2025-09-02T11:20:23+01:00 caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= service.id=fedora msg=Check: on resourceType=host, localResourceId=445b3961-487b-4682-b319-7a2c882680f2
INFO ts=2025-09-02T11:20:23+01:00 caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= service.id=fedora msg=CheckForView resp: allowed:ALLOWED_FALSE consistency_token:{token:"GgYKBENKRUk="} err: <nil>
INFO ts=2025-09-02T11:20:23+01:00 caller=log/helper.go:85 service.name=inventory-api service.version=0.1.0 trace.id= span.id= kind=server component=http operation=/kessel.inventory.v1beta2.KesselInventoryService/Check args=object:{resource_type:"host" resource_id:"445b3961-487b-4682-b319-7a2c882680f2" reporter:{type:"hbi" instance_id:"3c4e2382-26c1-11f0-8e5c-ce0194e9e144"}} relation:"view" subject:{resource:{resource_type:"principal" resource_id:"redhat/12345" reporter:{type:"rbac"}}} code=200 reason= stack= latency=0.010784869

```

Also used the same CURL request this failed on previously to make sure it works:
```sh
 curl -sS -X POST http://localhost:8081/api/inventory/v1beta2/check \
  -H "Content-Type: application/json" \
  -d '{
    "object": {
      "resourceType": "host",
      "resourceId": "445b3961-487b-4682-b319-7a2c882680f2",
      "reporter": {
        "type": "hbi",
        "instanceId": "3c4e2382-26c1-11f0-8e5c-ce0194e9e144"
      }
    },
    "relation": "view",
    "subject": {
      "resource": {
        "resourceType": "principal",
        "resourceId": "redhat/12345",
        "reporter": {
          "type": "rbac"
        }
      }
    }
  }'

{"allowed":"ALLOWED_FALSE"}%        
```

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Fix a nil pointer panic in Check by only serializing the consistency token on valid responses and unify repository error handling for missing resources.

Bug Fixes:
- Guard consistencyToken serialization in Check to avoid nil pointer dereference when no result is returned

Enhancements:
- Remove special-case suppression of gorm.ErrRecordNotFound in FindResourceByKeys to propagate errors consistently
- Handle gorm.ErrRecordNotFound explicitly in ReportResource by treating missing records as non-existent resources