### PR TITLE
Capture validation errors for metrics

### DIFF
--- a/internal/server/grpc/grpc.go
+++ b/internal/server/grpc/grpc.go
@@ -48,11 +48,11 @@ func New(c CompletedConfig, authn middleware.Middleware, authnConfig authn.Compl
 		kgrpc.Middleware(
 			recovery.Recovery(),
 			logging.Server(logger),
-			m.Validation(validator),
 			metrics.Server(
 				metrics.WithRequests(requests),
 				metrics.WithSeconds(seconds),
 			),
+			m.Validation(validator),
 			selector.Server(
 				authn,
 			).Match(NewWhiteListMatcher).Build(),

--- a/internal/server/http/http.go
+++ b/internal/server/http/http.go
@@ -35,11 +35,11 @@ func New(c CompletedConfig, authn middleware.Middleware, meter metric.Meter, log
 		http.Middleware(
 			recovery.Recovery(),
 			logging.Server(logger),
-			m.Validation(validator),
 			metrics.Server(
 				metrics.WithSeconds(seconds),
 				metrics.WithRequests(requests),
 			),
+			m.Validation(validator),
 			selector.Server(
 				authn,
 			).Match(NewWhiteListMatcher).Build(),


### PR DESCRIPTION
- Moves validation middleware after metrics bootstrapping to make sure we are capturing validation error codes