### PR TITLE
RHCLOUD-42146: update iic metrics conventions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ inventory-up-split-relations-ready:
 
 .PHONY: inventory-up-sso
 inventory-up-sso:
-	./scripts/start-inventory-kc.sh full-setup-w-sso 8081 9081
+	./scripts/start-inventory.sh full-setup-w-sso 8081 9081
 
 .PHONY: inventory-up-kind
 inventory-up-kind:

--- a/dashboards/grafana-dashboard-kessel-inventory-api.configmap.yaml
+++ b/dashboards/grafana-dashboard-kessel-inventory-api.configmap.yaml
@@ -176,7 +176,7 @@ data:
                   },
                   "editorMode": "code",
                   "exemplar": true,
-                  "expr": "(\n    sum(rate(server_requests_code_total{job=\"kessel-inventory-api\", code=\"0\"}[10m]))\n+\n    sum(rate(server_requests_code_total{ job=\"kessel-inventory-api\", code=\"200\"}[10m]))\n)\n /\nsum(rate(server_requests_seconds_bucket_seconds_count{job=\"kessel-inventory-api\"}[10m]))",
+                  "expr": "(\n    sum(rate(server_requests_code_total_total{job=\"kessel-inventory-api\", code=\"0\"}[10m]))\n+\n    sum(rate(server_requests_code_total_total{ job=\"kessel-inventory-api\", code=\"200\"}[10m]))\n)\n /\nsum(rate(server_requests_seconds_bucket_seconds_count{job=\"kessel-inventory-api\"}[10m]))",
                   "instant": false,
                   "legendFormat": "",
                   "range": true,
@@ -1804,7 +1804,7 @@ data:
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum by(code) (server_requests_code_total{operation=~\"$operation\", job=\"kessel-inventory-api\"})",
+              "expr": "sum by(code) (server_requests_code_total_total{operation=~\"$operation\", job=\"kessel-inventory-api\"})",
               "format": "table",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -1904,7 +1904,7 @@ data:
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum by(operation) (server_requests_code_total{code!=\"0\", job=\"kessel-inventory-api\"})",
+              "expr": "sum by(operation) (server_requests_code_total_total{code!=\"0\", job=\"kessel-inventory-api\"})",
               "format": "table",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -2009,7 +2009,7 @@ data:
                 "uid": "$datasource"
               },
               "editorMode": "code",
-              "expr": "sum(increase(server_requests_code_total{job=\"kessel-inventory-api\"}[1m])) by (code)",
+              "expr": "sum(increase(server_requests_code_total_total{job=\"kessel-inventory-api\"}[1m])) by (code)",
               "format": "time_series",
               "instant": false,
               "interval": "15s",
@@ -2428,7 +2428,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "count(kessel_inventory_consumer_state{state=\"up\"})",
+              "expr": "count(consumer_stats_state{state=\"up\", job=\"kessel-inventory-api\"})",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -2502,7 +2502,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "max(kessel_inventory_consumer_replyq)",
+              "expr": "max(consumer_stats_replyq{job=\"kessel-inventory-api\"})",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -2569,7 +2569,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "min(kessel_inventory_consumer_rebalance_age)",
+              "expr": "min(consumer_stats_rebalance_age{job=\"kessel-inventory-api\"})",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -2916,7 +2916,7 @@ data:
               "disableTextWrap": false,
               "editorMode": "builder",
               "exemplar": false,
-              "expr": "changes(kessel_inventory_consumer_rebalance_cnt_total[$__interval])",
+              "expr": "changes(consumer_stats_rebalance_cnt_total{job=\"kessel-inventory-api\"}[$__interval])",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": true,
@@ -3011,7 +3011,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(kessel_inventory_consumer_msgs_processed_total[$__rate_interval]))",
+              "expr": "sum(rate(consumer_msgs_processed_total{job=\"kessel-inventory-api\"}[$__rate_interval]))",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -3102,7 +3102,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(kessel_inventory_consumer_msg_process_failures_total[$__rate_interval])) / sum(rate(kessel_inventory_consumer_msgs_processed_total[$__rate_interval])) or sum(up{job=\"kessel-inventory-api\"}) * 0",
+              "expr": "sum(rate(consumer_msg_process_failures_total{job=\"kessel-inventory-api\"}[$__rate_interval])) / sum(rate(consumer_msgs_processed_total{job=\"kessel-inventory-api\"}[$__rate_interval])) or sum(up{job=\"kessel-inventory-api\"}) * 0",
               "format": "time_series",
               "instant": false,
               "legendFormat": "__auto",
@@ -3196,7 +3196,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(kessel_inventory_consumer_consumer_errors_total[$__rate_interval])) / sum(rate(kessel_inventory_consumer_msgs_processed_total[$__rate_interval])) or sum(up{job=\"kessel-inventory-api\"}) * 0",
+              "expr": "sum(rate(consumer_consumer_errors_total{job=\"kessel-inventory-api\"}[$__rate_interval])) / sum(rate(consumer_msgs_processed_total{job=\"kessel-inventory-api\"}[$__rate_interval])) or sum(up{job=\"kessel-inventory-api\"}) * 0",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -3265,7 +3265,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "kessel_inventory_consumer_kafka_error_events_total",
+              "expr": "consumer_kafka_error_events_total{job=\"kessel-inventory-api\"}",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -3299,7 +3299,7 @@ data:
                     "aggregations": [],
                     "operation": "groupby"
                   },
-                  "kessel_inventory_consumer_kafka_error_events_total": {
+                  "consumer_kafka_error_events_total{job=\"kessel-inventory-api\"}": {
                     "aggregations": []
                   }
                 }
@@ -3443,7 +3443,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(kessel_inventory_consumer_msgs_processed_total[$__range]))",
+              "expr": "sum(increase(consumer_msgs_processed_total{job=\"kessel-inventory-api\"}[$__range]))",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -3541,7 +3541,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(kessel_inventory_outbox_event_writes_total[3m])) - sum(rate(kessel_inventory_consumer_msgs_processed_total[3m]))",
+              "expr": "sum(rate(kessel_inventory_outbox_event_writes_total[3m])) - sum(rate(consumer_msgs_processed_total{job=\"kessel-inventory-api\"}[3m]))",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,

--- a/development/configs/monitoring/dashboards/grafana-dashboard-kessel-inventory-api.configmap.json
+++ b/development/configs/monitoring/dashboards/grafana-dashboard-kessel-inventory-api.configmap.json
@@ -173,7 +173,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "(\n    sum(rate(server_requests_code_total{job=\"kessel-inventory-api\", code=\"0\"}[10m]))\n+\n    sum(rate(server_requests_code_total{ job=\"kessel-inventory-api\", code=\"200\"}[10m]))\n)\n /\nsum(rate(server_requests_seconds_bucket_seconds_count{job=\"kessel-inventory-api\"}[10m]))",
+              "expr": "(\n    sum(rate(server_requests_code_total_total{job=\"kessel-inventory-api\", code=\"0\"}[10m]))\n+\n    sum(rate(server_requests_code_total_total{ job=\"kessel-inventory-api\", code=\"200\"}[10m]))\n)\n /\nsum(rate(server_requests_seconds_bucket_seconds_count{job=\"kessel-inventory-api\"}[10m]))",
               "instant": false,
               "legendFormat": "",
               "range": true,
@@ -257,6 +257,486 @@
             }
           ],
           "title": "Latency P95",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "index": 0,
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 0,
+            "y": 6
+          },
+          "id": 29,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "text": {},
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "histogram_quantile(0.50, \n  sum(rate(server_requests_seconds_bucket_seconds_bucket{job=\"kessel-inventory-api\",operation=~\".*Report.*\"}[10m])) by (le)\n)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "50%",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Report Resource P50",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "index": 0,
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 3,
+            "y": 6
+          },
+          "id": 30,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "text": {},
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "histogram_quantile(0.95, \n  sum(rate(server_requests_seconds_bucket_seconds_bucket{job=\"kessel-inventory-api\",operation=~\".*Report.*\"}[10m])) by (le)\n)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "95%",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Report Resource P95",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "index": 0,
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 6,
+            "y": 6
+          },
+          "id": 31,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "text": {},
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "histogram_quantile(0.99, \n  sum(rate(server_requests_seconds_bucket_seconds_bucket{job=\"kessel-inventory-api\",operation=~\".*Report.*\"}[10m])) by (le)\n)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99%",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Report Resource P99",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "index": 0,
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 0,
+            "y": 11
+          },
+          "id": 32,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "text": {},
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "histogram_quantile(0.50, \n  sum(rate(server_requests_seconds_bucket_seconds_bucket{job=\"kessel-inventory-api\",operation=~\".*StreamedListObjects.*\"}[10m])) by (le)\n)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "50%",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "List Objects P50",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "index": 0,
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 3,
+            "y": 11
+          },
+          "id": 33,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "text": {},
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "histogram_quantile(0.95, \n  sum(rate(server_requests_seconds_bucket_seconds_bucket{job=\"kessel-inventory-api\",operation=~\".*StreamedListObjects.*\"}[10m])) by (le)\n)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "95%",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "List Objects P95",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "index": 0,
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 6,
+            "y": 11
+          },
+          "id": 34,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "text": {},
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "histogram_quantile(0.99, \n  sum(rate(server_requests_seconds_bucket_seconds_bucket{job=\"kessel-inventory-api\",operation=~\".*StreamedListObjects.*\"}[10m])) by (le)\n)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99%",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "List Objects P99",
           "type": "stat"
         },
         {
@@ -539,486 +1019,6 @@
             "x": 18,
             "y": 1
           },
-          "id": 29,
-          "maxDataPoints": 100,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "text": {},
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "pluginVersion": "11.2.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "histogram_quantile(0.50, \n  sum(rate(server_requests_seconds_bucket_seconds_bucket{job=\"kessel-inventory-api\",operation=~\".*Report.*\"}[10m])) by (le)\n)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "50%",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Report Resource P50",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [
-                {
-                  "options": {
-                    "match": "null",
-                    "result": {
-                      "index": 0,
-                      "text": "N/A"
-                    }
-                  },
-                  "type": "special"
-                }
-              ],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 3,
-            "x": 21,
-            "y": 1
-          },
-          "id": 30,
-          "maxDataPoints": 100,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "text": {},
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "pluginVersion": "11.2.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "histogram_quantile(0.95, \n  sum(rate(server_requests_seconds_bucket_seconds_bucket{job=\"kessel-inventory-api\",operation=~\".*Report.*\"}[10m])) by (le)\n)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "95%",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Report Resource P95",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [
-                {
-                  "options": {
-                    "match": "null",
-                    "result": {
-                      "index": 0,
-                      "text": "N/A"
-                    }
-                  },
-                  "type": "special"
-                }
-              ],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 3,
-            "x": 0,
-            "y": 6
-          },
-          "id": 31,
-          "maxDataPoints": 100,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "text": {},
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "pluginVersion": "11.2.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "histogram_quantile(0.99, \n  sum(rate(server_requests_seconds_bucket_seconds_bucket{job=\"kessel-inventory-api\",operation=~\".*Report.*\"}[10m])) by (le)\n)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "99%",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Report Resource P99",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [
-                {
-                  "options": {
-                    "match": "null",
-                    "result": {
-                      "index": 0,
-                      "text": "N/A"
-                    }
-                  },
-                  "type": "special"
-                }
-              ],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 3,
-            "x": 3,
-            "y": 6
-          },
-          "id": 32,
-          "maxDataPoints": 100,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "text": {},
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "pluginVersion": "11.2.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "histogram_quantile(0.50, \n  sum(rate(server_requests_seconds_bucket_seconds_bucket{job=\"kessel-inventory-api\",operation=~\".*StreamedListObjects.*\"}[10m])) by (le)\n)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "50%",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "List Objects P50",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [
-                {
-                  "options": {
-                    "match": "null",
-                    "result": {
-                      "index": 0,
-                      "text": "N/A"
-                    }
-                  },
-                  "type": "special"
-                }
-              ],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 3,
-            "x": 6,
-            "y": 6
-          },
-          "id": 33,
-          "maxDataPoints": 100,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "text": {},
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "pluginVersion": "11.2.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "histogram_quantile(0.95, \n  sum(rate(server_requests_seconds_bucket_seconds_bucket{job=\"kessel-inventory-api\",operation=~\".*StreamedListObjects.*\"}[10m])) by (le)\n)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "95%",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "List Objects P95",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [
-                {
-                  "options": {
-                    "match": "null",
-                    "result": {
-                      "index": 0,
-                      "text": "N/A"
-                    }
-                  },
-                  "type": "special"
-                }
-              ],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 3,
-            "x": 9,
-            "y": 6
-          },
-          "id": 34,
-          "maxDataPoints": 100,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "text": {},
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "pluginVersion": "11.2.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "histogram_quantile(0.99, \n  sum(rate(server_requests_seconds_bucket_seconds_bucket{job=\"kessel-inventory-api\",operation=~\".*StreamedListObjects.*\"}[10m])) by (le)\n)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "99%",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "List Objects P99",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [
-                {
-                  "options": {
-                    "match": "null",
-                    "result": {
-                      "index": 0,
-                      "text": "N/A"
-                    }
-                  },
-                  "type": "special"
-                }
-              ],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 3,
-            "x": 12,
-            "y": 6
-          },
           "id": 38,
           "maxDataPoints": 100,
           "options": {
@@ -1096,8 +1096,8 @@
           "gridPos": {
             "h": 5,
             "w": 3,
-            "x": 15,
-            "y": 6
+            "x": 21,
+            "y": 1
           },
           "id": 39,
           "maxDataPoints": 100,
@@ -1176,7 +1176,7 @@
           "gridPos": {
             "h": 5,
             "w": 3,
-            "x": 18,
+            "x": 9,
             "y": 6
           },
           "id": 40,
@@ -1256,7 +1256,7 @@
           "gridPos": {
             "h": 5,
             "w": 3,
-            "x": 21,
+            "x": 12,
             "y": 6
           },
           "id": 41,
@@ -1336,8 +1336,8 @@
           "gridPos": {
             "h": 5,
             "w": 3,
-            "x": 0,
-            "y": 11
+            "x": 15,
+            "y": 6
           },
           "id": 42,
           "maxDataPoints": 100,
@@ -1416,8 +1416,8 @@
           "gridPos": {
             "h": 5,
             "w": 3,
-            "x": 3,
-            "y": 11
+            "x": 18,
+            "y": 6
           },
           "id": 43,
           "maxDataPoints": 100,
@@ -1496,8 +1496,8 @@
           "gridPos": {
             "h": 5,
             "w": 3,
-            "x": 6,
-            "y": 11
+            "x": 21,
+            "y": 6
           },
           "id": 44,
           "maxDataPoints": 100,
@@ -1766,7 +1766,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 1
+        "y": 2
       },
       "id": 1,
       "options": {
@@ -1801,7 +1801,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by(code) (server_requests_code_total{operation=~\"$operation\", job=\"kessel-inventory-api\"})",
+          "expr": "sum by(code) (server_requests_code_total_total{operation=~\"$operation\", job=\"kessel-inventory-api\"})",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -1866,7 +1866,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 1
+        "y": 2
       },
       "id": 5,
       "options": {
@@ -1901,7 +1901,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by(operation) (server_requests_code_total{code!=\"0\", job=\"kessel-inventory-api\"})",
+          "expr": "sum by(operation) (server_requests_code_total_total{code!=\"0\", job=\"kessel-inventory-api\"})",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -1980,7 +1980,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 1
+        "y": 2
       },
       "id": 6,
       "options": {
@@ -2006,7 +2006,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(increase(server_requests_code_total{job=\"kessel-inventory-api\"}[1m])) by (code)",
+          "expr": "sum(increase(server_requests_code_total_total{job=\"kessel-inventory-api\"}[1m])) by (code)",
           "format": "time_series",
           "instant": false,
           "interval": "15s",
@@ -2084,7 +2084,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 9
+        "y": 10
       },
       "id": 7,
       "options": {
@@ -2190,7 +2190,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 9
+        "y": 10
       },
       "id": 3,
       "options": {
@@ -2312,7 +2312,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 9
+        "y": 10
       },
       "id": 4,
       "options": {
@@ -2354,7 +2354,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 18
       },
       "id": 11,
       "panels": [],
@@ -2398,7 +2398,7 @@
         "h": 4,
         "w": 8,
         "x": 0,
-        "y": 18
+        "y": 19
       },
       "id": 10,
       "options": {
@@ -2425,7 +2425,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "count(kessel_inventory_consumer_state{state=\"up\"})",
+          "expr": "count(consumer_stats_state{state=\"up\", job=\"kessel-inventory-api\"})",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -2472,7 +2472,7 @@
         "h": 4,
         "w": 8,
         "x": 8,
-        "y": 18
+        "y": 19
       },
       "id": 14,
       "options": {
@@ -2499,7 +2499,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "max(kessel_inventory_consumer_replyq)",
+          "expr": "max(consumer_stats_replyq{job=\"kessel-inventory-api\"})",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -2539,7 +2539,7 @@
         "h": 4,
         "w": 8,
         "x": 16,
-        "y": 18
+        "y": 19
       },
       "id": 15,
       "options": {
@@ -2566,7 +2566,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "min(kessel_inventory_consumer_rebalance_age)",
+          "expr": "min(consumer_stats_rebalance_age{job=\"kessel-inventory-api\"})",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -2641,7 +2641,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 22
+        "y": 23
       },
       "id": 8,
       "options": {
@@ -2761,7 +2761,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 22
+        "y": 23
       },
       "id": 9,
       "options": {
@@ -2888,7 +2888,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 22
+        "y": 23
       },
       "id": 16,
       "options": {
@@ -2913,7 +2913,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "changes(kessel_inventory_consumer_rebalance_cnt_total[$__interval])",
+          "expr": "changes(consumer_stats_rebalance_cnt_total{job=\"kessel-inventory-api\"}[$__interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -2986,7 +2986,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 30
+        "y": 31
       },
       "id": 18,
       "options": {
@@ -3008,7 +3008,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(kessel_inventory_consumer_msgs_processed_total[$__rate_interval]))",
+          "expr": "sum(rate(consumer_msgs_processed_total{job=\"kessel-inventory-api\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -3077,7 +3077,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 30
+        "y": 31
       },
       "id": 17,
       "options": {
@@ -3099,7 +3099,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(kessel_inventory_consumer_msg_process_failures_total[$__rate_interval])) / sum(rate(kessel_inventory_consumer_msgs_processed_total[$__rate_interval])) or sum(up{job=\"kessel-inventory-api\"}) * 0",
+          "expr": "sum(rate(consumer_msg_process_failures_total{job=\"kessel-inventory-api\"}[$__rate_interval])) / sum(rate(consumer_msgs_processed_total{job=\"kessel-inventory-api\"}[$__rate_interval])) or sum(up{job=\"kessel-inventory-api\"}) * 0",
           "format": "time_series",
           "instant": false,
           "legendFormat": "__auto",
@@ -3170,7 +3170,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 38
+        "y": 39
       },
       "id": 20,
       "options": {
@@ -3193,7 +3193,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(kessel_inventory_consumer_consumer_errors_total[$__rate_interval])) / sum(rate(kessel_inventory_consumer_msgs_processed_total[$__rate_interval])) or sum(up{job=\"kessel-inventory-api\"}) * 0",
+          "expr": "sum(rate(consumer_consumer_errors_total{job=\"kessel-inventory-api\"}[$__rate_interval])) / sum(rate(consumer_msgs_processed_total{job=\"kessel-inventory-api\"}[$__rate_interval])) or sum(up{job=\"kessel-inventory-api\"}) * 0",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -3239,7 +3239,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 38
+        "y": 39
       },
       "id": 19,
       "options": {
@@ -3262,7 +3262,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "kessel_inventory_consumer_kafka_error_events_total",
+          "expr": "consumer_kafka_error_events_total{job=\"kessel-inventory-api\"}",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -3296,7 +3296,7 @@
                 "aggregations": [],
                 "operation": "groupby"
               },
-              "kessel_inventory_consumer_kafka_error_events_total": {
+              "consumer_kafka_error_events_total{job=\"kessel-inventory-api\"}": {
                 "aggregations": []
               }
             }
@@ -3311,7 +3311,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 47
       },
       "id": 21,
       "panels": [],
@@ -3347,7 +3347,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 47
+        "y": 48
       },
       "id": 22,
       "options": {
@@ -3413,7 +3413,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 47
+        "y": 48
       },
       "id": 23,
       "options": {
@@ -3440,7 +3440,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(kessel_inventory_consumer_msgs_processed_total[$__range]))",
+          "expr": "sum(increase(consumer_msgs_processed_total{job=\"kessel-inventory-api\"}[$__range]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -3516,7 +3516,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 47
+        "y": 48
       },
       "id": 24,
       "options": {
@@ -3538,7 +3538,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(kessel_inventory_outbox_event_writes_total[3m])) - sum(rate(kessel_inventory_consumer_msgs_processed_total[3m]))",
+          "expr": "sum(rate(kessel_inventory_outbox_event_writes_total[3m])) - sum(rate(consumer_msgs_processed_total{job=\"kessel-inventory-api\"}[3m]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,

--- a/development/configs/monitoring/dashboards/grafana-dashboard-kessel-inventory-kafka-connect.configmap.json
+++ b/development/configs/monitoring/dashboards/grafana-dashboard-kessel-inventory-kafka-connect.configmap.json
@@ -27,14 +27,9 @@
   "graphTooltip": 0,
   "id": 1007656,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -43,15 +38,6 @@
       },
       "id": 199,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "General",
       "type": "row"
     },
@@ -69,8 +55,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -89,6 +74,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "mean"
@@ -101,7 +87,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -133,8 +119,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -153,6 +138,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "mean"
@@ -165,7 +151,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -197,8 +183,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "orange",
@@ -221,6 +206,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "mean"
@@ -233,7 +219,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -265,8 +251,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -289,6 +274,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -301,7 +287,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -333,8 +319,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "yellow",
@@ -357,6 +342,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "mean"
@@ -369,7 +355,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -401,8 +387,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "purple",
@@ -425,6 +410,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "mean"
@@ -437,7 +423,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -538,11 +524,12 @@
           "values": false
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -697,11 +684,12 @@
           "values": false
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -785,6 +773,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -818,8 +807,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -909,11 +897,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -952,6 +941,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -985,8 +975,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1091,11 +1080,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -1178,10 +1168,6 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1190,15 +1176,6 @@
       },
       "id": 221,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "System",
       "type": "row"
     },
@@ -1219,6 +1196,7 @@
             "axisLabel": "Cores",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1250,8 +1228,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1282,11 +1259,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -1322,6 +1300,7 @@
             "axisLabel": "Memory",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1353,8 +1332,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1385,11 +1363,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -1436,6 +1415,7 @@
             "axisLabel": "% time in GC",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1469,8 +1449,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1501,11 +1480,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -1525,10 +1505,6 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1537,15 +1513,6 @@
       },
       "id": 139,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Source task metrics",
       "type": "row"
     },
@@ -1567,6 +1534,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1598,8 +1566,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1630,11 +1597,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -1673,6 +1641,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1704,8 +1673,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1736,11 +1704,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -1779,6 +1748,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1810,8 +1780,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1842,11 +1811,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -1884,6 +1854,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1915,8 +1886,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1947,11 +1917,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -1989,6 +1960,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -2020,8 +1992,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2052,11 +2023,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -2094,6 +2066,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -2125,8 +2098,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2157,11 +2129,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -2184,10 +2157,6 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2196,15 +2165,6 @@
       },
       "id": 234,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Worker rebalances",
       "type": "row"
     },
@@ -2232,8 +2192,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "#299c46",
-                "value": null
+                "color": "#299c46"
               }
             ]
           },
@@ -2259,6 +2218,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -2271,7 +2231,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -2316,8 +2276,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "#299c46",
-                "value": null
+                "color": "#299c46"
               }
             ]
           },
@@ -2357,6 +2316,7 @@
       },
       "pluginVersion": "10.4.1",
       "repeat": "instance",
+      "repeatDirection": "h",
       "targets": [
         {
           "datasource": {
@@ -2394,6 +2354,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 30,
             "gradientMode": "opacity",
@@ -2426,8 +2387,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2458,11 +2418,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -2485,10 +2446,6 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2497,15 +2454,6 @@
       },
       "id": 112,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Task metrics",
       "type": "row"
     },
@@ -2527,6 +2475,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -2558,8 +2507,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2590,11 +2538,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -2632,6 +2581,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -2663,8 +2613,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2695,11 +2644,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -2737,6 +2687,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -2770,8 +2721,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2802,11 +2752,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -2844,6 +2795,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -2875,8 +2827,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2907,11 +2858,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -2947,6 +2899,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -2980,8 +2933,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3012,11 +2964,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -3039,10 +2992,6 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3051,15 +3000,6 @@
       },
       "id": 201,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Task Errors metrics",
       "type": "row"
     },
@@ -3081,6 +3021,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -3114,8 +3055,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3146,11 +3086,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -3188,6 +3129,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -3221,8 +3163,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3253,11 +3194,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -3295,6 +3237,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -3328,8 +3271,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3360,11 +3302,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -3402,6 +3345,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -3435,8 +3379,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3467,11 +3410,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -3509,6 +3453,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -3542,8 +3487,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3574,11 +3518,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -3616,6 +3561,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -3649,8 +3595,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3681,11 +3626,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -3724,6 +3670,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -3757,8 +3704,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3789,11 +3735,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "11.6.3",
       "targets": [
         {
           "datasource": {
@@ -3815,54 +3762,57 @@
       "type": "timeseries"
     }
   ],
+  "preload": false,
   "refresh": "",
-  "schemaVersion": 39,
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
       {
+        "current": {
+          "text": "kessel-inventory-api-connector",
+          "value": "kessel-inventory-api-connector"
+        },
         "hide": 2,
         "label": "Connector name",
         "name": "connector",
-        "query": "kessel-inventory-source-connector",
-        "skipUrlSync": false,
-        "type": "constant"
-      },
-      {
-        "hide": 2,
-        "label": "job",
-        "name": "job",
-        "query": "openshift-customer-monitoring/kafka-connect-podmonitor",
-        "skipUrlSync": false,
+        "query": "kessel-inventory-api-connector",
+        "skipUrlSync": true,
         "type": "constant"
       },
       {
         "current": {
-          "selected": false,
+          "text": "openshift-customer-monitoring/kessel-kafka-connect-podmonitor",
+          "value": "openshift-customer-monitoring/kessel-kafka-connect-podmonitor"
+        },
+        "hide": 2,
+        "label": "job",
+        "name": "job",
+        "query": "openshift-customer-monitoring/kessel-kafka-connect-podmonitor",
+        "skipUrlSync": true,
+        "type": "constant"
+      },
+      {
+        "current": {
           "text": "crcs02ue1-prometheus",
           "value": "PDD8BE47D10408F45"
         },
-        "hide": 0,
         "includeAll": false,
         "label": "Datasource",
-        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
-        "queryValue": "",
         "refresh": 1,
         "regex": "/(prometheus)/",
-        "skipUrlSync": false,
         "type": "datasource"
       }
     ]
   },
   "time": {
-    "from": "2025-05-06T12:56:00.116Z",
-    "to": "2025-05-06T13:04:14.160Z"
+    "from": "now-30m",
+    "to": "now"
   },
   "timepicker": {
-    "hidden": false,
     "refresh_intervals": [
       "10s",
       "30s",
@@ -3873,22 +3823,10 @@
       "1h",
       "2h",
       "1d"
-    ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
     ]
   },
   "timezone": "",
   "title": "Kessel Inventory - Kafka Connect",
   "uid": "AEaSQ97mq",
-  "version": 1,
-  "weekStart": ""
+  "version": 2
 }

--- a/internal/metricscollector/metricscollector.go
+++ b/internal/metricscollector/metricscollector.go
@@ -10,8 +10,10 @@ import (
 
 const (
 	outboxTopic = "outbox.event.kessel.tuples"
-	// consumerPrefix should be used for all consumer-related metrics
-	consumerPrefix = "kessel_inventory_consumer_"
+	// statsPrefix should be used for all consumer stat-based metrics
+	statsPrefix = "consumer_stats_"
+	// consumerPrefix should be used for all other consumer-related metrics
+	consumerPrefix = "consumer_"
 	// prefix should be used for all other metrics unrelated to the consumer
 	prefix = "kessel_inventory_"
 )
@@ -104,50 +106,50 @@ func (m *MetricsCollector) New(meter metric.Meter) error {
 	var err error
 
 	// create top-level metrics
-	if m.replyq, err = meter.Int64Gauge(consumerPrefix + "replyq"); err != nil {
+	if m.replyq, err = meter.Int64Gauge(statsPrefix + "replyq"); err != nil {
 		return err
 	}
 
 	// create topic.partitions metrics
-	if m.fetchqCnt, err = meter.Int64Gauge(consumerPrefix + "fetchq_cnt"); err != nil {
+	if m.fetchqCnt, err = meter.Int64Gauge(statsPrefix + "fetchq_cnt"); err != nil {
 		return err
 	}
-	if m.fetchqSize, err = meter.Int64Gauge(consumerPrefix + "fetchq_size"); err != nil {
+	if m.fetchqSize, err = meter.Int64Gauge(statsPrefix + "fetchq_size"); err != nil {
 		return err
 	}
-	if m.fetchState, err = meter.Int64Gauge(consumerPrefix + "fetchq_state"); err != nil {
+	if m.fetchState, err = meter.Int64Gauge(statsPrefix + "fetchq_state"); err != nil {
 		return err
 	}
-	if m.loOffset, err = meter.Int64Gauge(consumerPrefix + "lo_offset"); err != nil {
+	if m.loOffset, err = meter.Int64Gauge(statsPrefix + "lo_offset"); err != nil {
 		return err
 	}
-	if m.hiOffset, err = meter.Int64Gauge(consumerPrefix + "hi_offset"); err != nil {
+	if m.hiOffset, err = meter.Int64Gauge(statsPrefix + "hi_offset"); err != nil {
 		return err
 	}
-	if m.lsOffset, err = meter.Int64Gauge(consumerPrefix + "ls_offset"); err != nil {
+	if m.lsOffset, err = meter.Int64Gauge(statsPrefix + "ls_offset"); err != nil {
 		return err
 	}
-	if m.consumerLag, err = meter.Int64Gauge(consumerPrefix + "consumer_lag"); err != nil {
+	if m.consumerLag, err = meter.Int64Gauge(statsPrefix + "consumer_lag"); err != nil {
 		return err
 	}
-	if m.consumerLagStored, err = meter.Int64Gauge(consumerPrefix + "consumer_lag_stored"); err != nil {
+	if m.consumerLagStored, err = meter.Int64Gauge(statsPrefix + "consumer_lag_stored"); err != nil {
 		return err
 	}
 
 	// create cgrp metrics
-	if m.state, err = meter.Int64Gauge(consumerPrefix + "state"); err != nil {
+	if m.state, err = meter.Int64Gauge(statsPrefix + "state"); err != nil {
 		return err
 	}
-	if m.stateAge, err = meter.Int64Gauge(consumerPrefix + "stateage"); err != nil {
+	if m.stateAge, err = meter.Int64Gauge(statsPrefix + "stateage"); err != nil {
 		return err
 	}
-	if m.rebalanceAge, err = meter.Int64Gauge(consumerPrefix + "rebalance_age"); err != nil {
+	if m.rebalanceAge, err = meter.Int64Gauge(statsPrefix + "rebalance_age"); err != nil {
 		return err
 	}
-	if m.rebalanceCnt, err = meter.Int64Counter(consumerPrefix + "rebalance_cnt"); err != nil {
+	if m.rebalanceCnt, err = meter.Int64Counter(statsPrefix + "rebalance_cnt"); err != nil {
 		return err
 	}
-	if m.assignmentSize, err = meter.Int64Gauge(consumerPrefix + "assignment_size"); err != nil {
+	if m.assignmentSize, err = meter.Int64Gauge(statsPrefix + "assignment_size"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### PR Template:

## Describe your changes
* updates consumer metrics prefix to match the same pattern as Kessel Inventory Consumer
  * this allows us to use the same alerting templates and reduce duplication of alert defintions plus ensure cleaner naming convention
* updates dashboards for the new metrics values (validated locally)
* updated local monitoring dashboards
* bug fix on make target for inventory with sso
* bug fix on `server_requests_code_total` metric from Kratos (now shows as `server_requests_code_total_total`)

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Standardize and clean up consumer metrics naming, adjust dashboards to use the new metric conventions, and fix related Makefile and dashboard metric naming issues

Bug Fixes:
- Fix inventory-up-sso Makefile target to use the correct startup script
- Correct Grafana dashboard expressions to use the updated server_requests_code_total_total metric

Enhancements:
- Standardize consumer metrics prefixes by introducing statsPrefix and adjusting consumerPrefix in MetricsCollector
- Update Grafana dashboards to reflect the new metric names and add job label filtering