### PR TITLE
Allow null satellite_id on HBI hosts

### DIFF
--- a/data/schema/resources/host/reporters/hbi/host.json
+++ b/data/schema/resources/host/reporters/hbi/host.json
@@ -5,7 +5,8 @@
     "satellite_id": {
       "oneOf": [
         { "type": "string", "format": "uuid" },
-        { "type": "string", "pattern": "^\\d{10}$" }
+        { "type": "string", "pattern": "^\\d{10}$" },
+        { "type": "null" }
       ]
     },
     "subscription_manager_id": { "type": "string", "format": "uuid" },


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Add type "null" to allowed types for satellite_id on the HBI host schema

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

