### PR TITLE
Publish new tuples message

### DIFF
--- a/internal/biz/model/common.go
+++ b/internal/biz/model/common.go
@@ -10,7 +10,7 @@ import (
 
 const initialReporterRepresentationVersion = 0
 const initialGeneration = 0
-const initialTombstone = true
+const initialTombstone = false
 
 // Generic serialization interfaces
 type Serializable[T any] interface {

--- a/internal/biz/model/common_representation.go
+++ b/internal/biz/model/common_representation.go
@@ -92,6 +92,10 @@ func DeserializeCommonRepresentation(snapshot *CommonRepresentationSnapshot) Com
 	}
 }
 
+func (cr CommonRepresentation) Version() Version {
+	return cr.version
+}
+
 // CreateSnapshot creates a snapshot of the CommonRepresentation
 func (cr CommonRepresentation) CreateSnapshot() (CommonRepresentationSnapshot, error) {
 	return cr.Serialize(), nil

--- a/internal/biz/model/reporter_representation.go
+++ b/internal/biz/model/reporter_representation.go
@@ -140,3 +140,7 @@ func DeserializeReporterDataRepresentation(snapshot *ReporterRepresentationSnaps
 		},
 	}
 }
+
+func (rr ReporterRepresentation) CommonVersion() Version {
+	return rr.commonVersion
+}

--- a/internal/biz/model/reporter_representation.go
+++ b/internal/biz/model/reporter_representation.go
@@ -60,8 +60,6 @@ func NewReporterDeleteRepresentation(
 	reporterResourceID ReporterResourceId,
 	version Version,
 	generation Generation,
-	commonVersion Version,
-	reporterVersion *ReporterVersion,
 ) (ReporterDeleteRepresentation, error) {
 	if reporterResourceID.UUID() == uuid.Nil {
 		return ReporterDeleteRepresentation{}, fmt.Errorf("%w: ReporterResourceId", ErrInvalidUUID)
@@ -73,8 +71,6 @@ func NewReporterDeleteRepresentation(
 			reporterResourceID: reporterResourceID,
 			version:            version,
 			generation:         generation,
-			commonVersion:      commonVersion,
-			reporterVersion:    reporterVersion,
 			tombstone:          NewTombstone(true),
 		},
 	}, nil

--- a/internal/biz/model/reporter_representation_test.go
+++ b/internal/biz/model/reporter_representation_test.go
@@ -183,8 +183,6 @@ func TestReporterDeleteRepresentation_Initialization(t *testing.T) {
 			fixture.ValidReporterResourceIdType(),
 			fixture.ValidVersionType(),
 			fixture.ValidGenerationType(),
-			fixture.ValidCommonVersionType(),
-			fixture.ValidReporterVersionType(),
 		)
 
 		assertValidReporterDeleteRepresentation(t, deleteRep, err, "valid inputs")
@@ -197,8 +195,6 @@ func TestReporterDeleteRepresentation_Initialization(t *testing.T) {
 			fixture.ValidReporterResourceIdType(),
 			fixture.ValidVersionType(),
 			fixture.ValidGenerationType(),
-			fixture.ValidCommonVersionType(),
-			fixture.NilReporterVersionType(),
 		)
 
 		assertValidReporterDeleteRepresentation(t, deleteRep, err, "nil reporter version")
@@ -211,8 +207,6 @@ func TestReporterDeleteRepresentation_Initialization(t *testing.T) {
 			fixture.EmptyReporterResourceIdType(),
 			fixture.ValidVersionType(),
 			fixture.ValidGenerationType(),
-			fixture.ValidCommonVersionType(),
-			fixture.ValidReporterVersionType(),
 		)
 
 		assertInvalidReporterDeleteRepresentation(t, deleteRep, err, ErrInvalidUUID)
@@ -225,8 +219,6 @@ func TestReporterDeleteRepresentation_Initialization(t *testing.T) {
 			fixture.WhitespaceReporterResourceIdType(),
 			fixture.ValidVersionType(),
 			fixture.ValidGenerationType(),
-			fixture.ValidCommonVersionType(),
-			fixture.ValidReporterVersionType(),
 		)
 
 		assertInvalidReporterDeleteRepresentation(t, deleteRep, err, ErrInvalidUUID)
@@ -239,8 +231,6 @@ func TestReporterDeleteRepresentation_Initialization(t *testing.T) {
 			fixture.InvalidReporterResourceIdType(),
 			fixture.ValidVersionType(),
 			fixture.ValidGenerationType(),
-			fixture.ValidCommonVersionType(),
-			fixture.ValidReporterVersionType(),
 		)
 
 		assertInvalidReporterDeleteRepresentation(t, deleteRep, err, ErrInvalidUUID)
@@ -278,8 +268,6 @@ func TestReporterRepresentation_BusinessRules(t *testing.T) {
 			fixture.ValidReporterResourceIdType(),
 			fixture.ValidVersionType(),
 			fixture.ValidGenerationType(),
-			fixture.ValidCommonVersionType(),
-			fixture.ValidReporterVersionType(),
 		)
 
 		if err != nil {
@@ -298,8 +286,6 @@ func TestReporterRepresentation_BusinessRules(t *testing.T) {
 			fixture.ValidReporterResourceIdType(),
 			fixture.ValidVersionType(),
 			fixture.ValidGenerationType(),
-			fixture.ValidCommonVersionType(),
-			fixture.ValidReporterVersionType(),
 		)
 
 		if err != nil {

--- a/internal/biz/model/reporter_resource.go
+++ b/internal/biz/model/reporter_resource.go
@@ -85,6 +85,11 @@ func (rr *ReporterResource) Update(
 	rr.representationVersion = rr.representationVersion.Increment()
 }
 
+func (rr *ReporterResource) Delete() {
+	rr.representationVersion = rr.representationVersion.Increment()
+	rr.tombstone = true
+}
+
 // Add getters only where needed
 func (rrk ReporterResourceKey) LocalResourceId() LocalResourceId {
 	return rrk.localResourceID

--- a/internal/biz/model/resource.go
+++ b/internal/biz/model/resource.go
@@ -3,8 +3,6 @@ package model
 import (
 	"fmt"
 	"time"
-
-	"github.com/go-kratos/kratos/v2/log"
 )
 
 const initialCommonVersion = 0
@@ -119,17 +117,12 @@ func (r *Resource) Update(
 func (r *Resource) Delete(
 	key ReporterResourceKey,
 ) error {
-
-	log.Info("Key", key)
 	reporterResource, err := r.findReporterResourceToUpdateByKey(key)
-	log.Info("ReporterResource before calling delete", reporterResource)
 	if err != nil {
 		return err
 	}
 
 	reporterResource.Delete()
-	log.Info("ReporterResource after calling delete", reporterResource)
-
 	resourceDeleteEvent, err := deleteEventAndRepresentations(
 		reporterResource.resourceID,
 		key.ResourceType(),
@@ -140,7 +133,6 @@ func (r *Resource) Delete(
 		reporterResource.representationVersion,
 		reporterResource.generation)
 
-	log.Infof("ResourceDeleteEvent: %+v", resourceDeleteEvent)
 	if err != nil {
 		return fmt.Errorf("failed to create ResourceDeleteEvent: %w", err)
 	}
@@ -223,8 +215,6 @@ func deleteEventAndRepresentations(resourceId ResourceId,
 	if err != nil {
 		return ResourceDeleteEvent{}, fmt.Errorf("invalid ReporterRepresentation: %w", err)
 	}
-
-	log.Infof("ReporterDeleteRepresentation: %+v", reporterDeleteRepresentation)
 
 	resourceDeleteEvent, err := NewResourceDeleteEvent(
 		resourceId,

--- a/internal/biz/model/resource_delete_event.go
+++ b/internal/biz/model/resource_delete_event.go
@@ -1,0 +1,68 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type ResourceDeleteEvent struct {
+	id                     ResourceId
+	resourceType           ResourceType
+	reporterId             ReporterId
+	localResourceId        LocalResourceId
+	reporterRepresentation ReporterDeleteRepresentation
+	createdAt              time.Time
+	updatedAt              time.Time
+}
+
+func NewResourceDeleteEvent(
+	resourceId ResourceId,
+	resourceType ResourceType,
+	reporterType ReporterType,
+	reporterInstanceId ReporterInstanceId,
+	localResourceId LocalResourceId,
+	reporterRepresentation ReporterDeleteRepresentation,
+) (ResourceDeleteEvent, error) {
+	reporterId := NewReporterId(reporterType, reporterInstanceId)
+
+	return ResourceDeleteEvent{
+		id:                     resourceId,
+		resourceType:           resourceType,
+		reporterId:             reporterId,
+		localResourceId:        localResourceId,
+		reporterRepresentation: reporterRepresentation,
+	}, nil
+}
+
+func (re ResourceDeleteEvent) CreatedAt() *time.Time {
+	return &re.createdAt
+}
+
+func (re ResourceDeleteEvent) UpdatedAt() *time.Time {
+	return &re.updatedAt
+}
+
+func (re ResourceDeleteEvent) ResourceType() string {
+	return re.resourceType.String()
+}
+
+func (re ResourceDeleteEvent) ReporterType() string {
+	return re.reporterId.reporterType.String()
+}
+
+func (re ResourceDeleteEvent) ReporterInstanceId() string {
+	return re.reporterId.reporterInstanceId.String()
+}
+
+func (re ResourceDeleteEvent) Id() ResourceId {
+	return re.id
+}
+
+func (re ResourceDeleteEvent) LocalResourceId() string {
+	return re.localResourceId.String()
+}
+
+func (re ResourceDeleteEvent) ResourceId() uuid.UUID {
+	return uuid.UUID(re.id)
+}

--- a/internal/biz/model/resource_delete_event.go
+++ b/internal/biz/model/resource_delete_event.go
@@ -66,3 +66,7 @@ func (re ResourceDeleteEvent) LocalResourceId() string {
 func (re ResourceDeleteEvent) ResourceId() uuid.UUID {
 	return uuid.UUID(re.id)
 }
+
+func (re ResourceDeleteEvent) WorkspaceId() string {
+	return ""
+}

--- a/internal/biz/model/resource_delete_event.go
+++ b/internal/biz/model/resource_delete_event.go
@@ -67,6 +67,35 @@ func (re ResourceDeleteEvent) ResourceId() uuid.UUID {
 	return uuid.UUID(re.id)
 }
 
+// TODO: These fields do not really belong on the delete event, need to figure out a better way to model these
 func (re ResourceDeleteEvent) WorkspaceId() string {
 	return ""
+}
+
+func (re ResourceDeleteEvent) CommonVersion() Version {
+	return re.reporterRepresentation.CommonVersion()
+}
+
+func (re ResourceDeleteEvent) ReporterResourceKey() (ReporterResourceKey, error) {
+	localResourceId, err := NewLocalResourceId(re.LocalResourceId())
+	if err != nil {
+		return ReporterResourceKey{}, err
+	}
+
+	resourceType, err := NewResourceType(re.ResourceType())
+	if err != nil {
+		return ReporterResourceKey{}, err
+	}
+
+	reporterType, err := NewReporterType(re.ReporterType())
+	if err != nil {
+		return ReporterResourceKey{}, err
+	}
+
+	reporterInstanceId, err := NewReporterInstanceId(re.ReporterInstanceId())
+	if err != nil {
+		return ReporterResourceKey{}, err
+	}
+
+	return NewReporterResourceKey(localResourceId, resourceType, reporterType, reporterInstanceId)
 }

--- a/internal/biz/model/resource_delete_event_test.go
+++ b/internal/biz/model/resource_delete_event_test.go
@@ -1,0 +1,90 @@
+//go:build test
+
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResourceDeleteEvent_Initialization(t *testing.T) {
+	t.Parallel()
+	fixture := NewResourceEventTestFixture()
+
+	t.Run("should create resource delete event with valid inputs", func(t *testing.T) {
+		t.Parallel()
+
+		deleteRepresentation, err := NewReporterDeleteRepresentation(
+			fixture.ValidReporterResourceIdType(),
+			fixture.ValidReporterVersionType(),
+			fixture.ValidReporterGenerationType(),
+		)
+		if err != nil {
+			t.Fatalf("Failed to create delete representation: %v", err)
+		}
+
+		event, err := NewResourceDeleteEvent(
+			fixture.ValidResourceIdType(),
+			fixture.ValidResourceTypeType(),
+			fixture.ValidReporterTypeType(),
+			fixture.ValidReporterInstanceIdType(),
+			fixture.ValidReporterDataType(),
+			deleteRepresentation,
+		)
+
+		assertValidResourceDeleteEvent(t, event, err, "valid inputs")
+	})
+
+	t.Run("should create resource delete event with different values", func(t *testing.T) {
+		t.Parallel()
+
+		deleteRepresentation, err := NewReporterDeleteRepresentation(
+			fixture.ValidReporterResourceIdType(),
+			fixture.ValidReporterVersionType(),
+			fixture.ValidReporterGenerationType(),
+		)
+		if err != nil {
+			t.Fatalf("Failed to create delete representation: %v", err)
+		}
+
+		event, err := NewResourceDeleteEvent(
+			fixture.AnotherResourceIdType(),
+			fixture.AnotherResourceTypeType(),
+			fixture.ValidReporterTypeType(),
+			fixture.ValidReporterInstanceIdType(),
+			fixture.AnotherReporterDataType(),
+			deleteRepresentation,
+		)
+
+		assertValidResourceDeleteEvent(t, event, err, "different values")
+	})
+}
+
+func assertValidResourceDeleteEvent(t *testing.T, event ResourceDeleteEvent, err error, context string) {
+	t.Helper()
+	if err != nil {
+		t.Errorf("Expected no error for %s, got %v", context, err)
+	}
+	if event.id.String() == "" {
+		t.Errorf("Expected valid resource ID for %s", context)
+	}
+	if event.resourceType.String() == "" {
+		t.Errorf("Expected valid resource type for %s", context)
+	}
+	if event.reporterId.reporterType.String() == "" {
+		t.Errorf("Expected valid reporter type for %s", context)
+	}
+	if event.reporterId.reporterInstanceId.String() == "" {
+		t.Errorf("Expected valid reporter instance ID for %s", context)
+	}
+}
+
+func assertInvalidResourceDeleteEvent(t *testing.T, err error, expectedErrorSubstring string) {
+	t.Helper()
+	if err == nil {
+		t.Error("Expected error, got none")
+	}
+	if !strings.Contains(err.Error(), expectedErrorSubstring) {
+		t.Errorf("Expected error containing %s, got %v", expectedErrorSubstring, err)
+	}
+}

--- a/internal/biz/model/resource_event.go
+++ b/internal/biz/model/resource_event.go
@@ -7,4 +7,6 @@ type ResourceEvent interface {
 	ReporterInstanceId() string
 	LocalResourceId() string
 	WorkspaceId() string
+	CommonVersion() Version
+	ReporterResourceKey() (ReporterResourceKey, error)
 }

--- a/internal/biz/model/resource_event.go
+++ b/internal/biz/model/resource_event.go
@@ -1,0 +1,10 @@
+package model
+
+type ResourceEvent interface {
+	Id() ResourceId
+	ResourceType() string
+	ReporterType() string
+	ReporterInstanceId() string
+	LocalResourceId() string
+	WorkspaceId() string
+}

--- a/internal/biz/model/resource_report_event.go
+++ b/internal/biz/model/resource_report_event.go
@@ -107,6 +107,34 @@ func (re ResourceReportEvent) WorkspaceId() string {
 	return ""
 }
 
+func (re ResourceReportEvent) CommonVersion() Version {
+	return re.commonRepresentation.Version()
+}
+
+func (re ResourceReportEvent) ReporterResourceKey() (ReporterResourceKey, error) {
+	localResourceId, err := NewLocalResourceId(re.LocalResourceId())
+	if err != nil {
+		return ReporterResourceKey{}, err
+	}
+
+	resourceType, err := NewResourceType(re.ResourceType())
+	if err != nil {
+		return ReporterResourceKey{}, err
+	}
+
+	reporterType, err := NewReporterType(re.ReporterType())
+	if err != nil {
+		return ReporterResourceKey{}, err
+	}
+
+	reporterInstanceId, err := NewReporterInstanceId(re.ReporterInstanceId())
+	if err != nil {
+		return ReporterResourceKey{}, err
+	}
+
+	return NewReporterResourceKey(localResourceId, resourceType, reporterType, reporterInstanceId)
+}
+
 // DeserializeResourceEvent creates a ResourceReportEvent from representation snapshots - direct initialization without validation
 func DeserializeResourceEvent(
 	reporterRepresentationSnapshot *ReporterRepresentationSnapshot,

--- a/internal/biz/model/resource_test.go
+++ b/internal/biz/model/resource_test.go
@@ -192,7 +192,7 @@ func TestResource_Update(t *testing.T) {
 		}
 
 		// Verify resource event was created
-		resourceEvents := original.ResourceEvents()
+		resourceEvents := original.ResourceReportEvents()
 		if len(resourceEvents) != 2 { // Original + updated
 			t.Fatalf("Expected 2 resource events, got %d", len(resourceEvents))
 		}
@@ -370,8 +370,8 @@ func TestResource_Update(t *testing.T) {
 		}
 
 		// Should succeed without error
-		if len(original.ResourceEvents()) != 2 {
-			t.Errorf("Expected 2 resource events, got %d", len(original.ResourceEvents()))
+		if len(original.ResourceReportEvents()) != 2 {
+			t.Errorf("Expected 2 resource events, got %d", len(original.ResourceReportEvents()))
 		}
 	})
 }

--- a/internal/biz/model/snapshots_test.go
+++ b/internal/biz/model/snapshots_test.go
@@ -166,10 +166,7 @@ func TestIndividualSnapshotMethods(t *testing.T) {
 	deleteRep, err := NewReporterDeleteRepresentation(
 		resourceFixture.ValidReporterResourceIdType(),
 		versionOne,
-		genOne,
-		versionOne,
-		nil, // reporterVersion
-	)
+		genOne)
 	if err != nil {
 		t.Fatalf("Failed to create ReporterDeleteRepresentation: %v", err)
 	}

--- a/internal/biz/model/tuple_event.go
+++ b/internal/biz/model/tuple_event.go
@@ -1,0 +1,21 @@
+package model
+
+type TupleEvent struct {
+	commonVersion       Version
+	reporterResourceKey ReporterResourceKey
+}
+
+func NewTupleEvent(version Version, reporterResourceKey ReporterResourceKey) (TupleEvent, error) {
+	return TupleEvent{
+		commonVersion:       version,
+		reporterResourceKey: reporterResourceKey,
+	}, nil
+}
+
+func (te TupleEvent) Version() Version {
+	return te.commonVersion
+}
+
+func (te TupleEvent) ReporterResourceKey() ReporterResourceKey {
+	return te.reporterResourceKey
+}

--- a/internal/biz/model_legacy/outboxevents.go
+++ b/internal/biz/model_legacy/outboxevents.go
@@ -218,6 +218,20 @@ func convertResourceToSetTupleEvent(resourceEvent bizmodel.ResourceReportEvent) 
 	return payload, nil
 }
 
+func convertToJsonObject(resourceEvent bizmodel.ResourceDeleteEvent) (internal.JsonObject, error) {
+	payload := internal.JsonObject{}
+	marshalledJson, err := json.Marshal(resourceEvent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal resource to json: %w", err)
+	}
+	err = json.Unmarshal(marshalledJson, &payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json to payload: %w", err)
+	}
+
+	return payload, nil
+}
+
 func convertResourceToUnsetTupleEvent(resourceEvent bizmodel.ResourceReportEvent) (internal.JsonObject, error) {
 	payload := internal.JsonObject{}
 	namespace := strings.ToLower(resourceEvent.ReporterType())

--- a/internal/biz/model_legacy/outboxevents.go
+++ b/internal/biz/model_legacy/outboxevents.go
@@ -218,21 +218,7 @@ func convertResourceToSetTupleEvent(resourceEvent bizmodel.ResourceReportEvent) 
 	return payload, nil
 }
 
-func convertToJsonObject(resourceEvent bizmodel.ResourceDeleteEvent) (internal.JsonObject, error) {
-	payload := internal.JsonObject{}
-	marshalledJson, err := json.Marshal(resourceEvent)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal resource to json: %w", err)
-	}
-	err = json.Unmarshal(marshalledJson, &payload)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal json to payload: %w", err)
-	}
-
-	return payload, nil
-}
-
-func convertResourceToUnsetTupleEvent(resourceEvent bizmodel.ResourceReportEvent) (internal.JsonObject, error) {
+func convertResourceToUnsetTupleEvent(resourceEvent bizmodel.ResourceDeleteEvent) (internal.JsonObject, error) {
 	payload := internal.JsonObject{}
 	namespace := strings.ToLower(resourceEvent.ReporterType())
 
@@ -255,12 +241,31 @@ func convertResourceToUnsetTupleEvent(resourceEvent bizmodel.ResourceReportEvent
 	return payload, nil
 }
 
-func NewOutboxEventsFromResourceEvent(domainResourceEvent bizmodel.ResourceReportEvent, operationType EventOperationType, txid string) (*OutboxEvent, *OutboxEvent, error) {
+func NewOutboxEventsFromResourceEvent(domainResourceEvent bizmodel.ResourceEvent, operationType EventOperationType, txid string) (*OutboxEvent, *OutboxEvent, error) {
+	var payload internal.JsonObject
 	var tuplePayload internal.JsonObject
-	var tupleEvent *OutboxEvent
+	var err error
 
-	// Build resource event
-	payload, err := convertResourceToResourceEvent(domainResourceEvent, operationType)
+	switch operationType.OperationType() {
+	case OperationTypeDeleted:
+		//TODO: Not publishing anything for resource event right now so we can decide what to publish correctly
+		payload = internal.JsonObject{}
+		if deleteEvent, ok := domainResourceEvent.(bizmodel.ResourceDeleteEvent); ok {
+			tuplePayload, err = convertResourceToUnsetTupleEvent(deleteEvent)
+		} else {
+			return nil, nil, fmt.Errorf("expected ResourceDeleteEvent for delete operation, got %T", domainResourceEvent)
+		}
+	default:
+		if reportEvent, ok := domainResourceEvent.(bizmodel.ResourceReportEvent); ok {
+			payload, err = convertResourceToResourceEvent(reportEvent, operationType)
+			if err == nil {
+				tuplePayload, err = convertResourceToSetTupleEvent(reportEvent)
+			}
+		} else {
+			return nil, nil, fmt.Errorf("expected ResourceReportEvent for create/update operation, got %T", domainResourceEvent)
+		}
+	}
+
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to convert resource to payload: %w", err)
 	}
@@ -273,19 +278,7 @@ func NewOutboxEventsFromResourceEvent(domainResourceEvent bizmodel.ResourceRepor
 		Payload:       payload,
 	}
 
-	// Build tuple event
-	switch operationType.OperationType() {
-	case OperationTypeDeleted:
-		tuplePayload, err = convertResourceToUnsetTupleEvent(domainResourceEvent)
-	default:
-		tuplePayload, err = convertResourceToSetTupleEvent(domainResourceEvent)
-	}
-
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to convert resource to payload: %w", err)
-	}
-
-	tupleEvent = &OutboxEvent{
+	tupleEvent := &OutboxEvent{
 		Operation:     operationType,
 		AggregateType: TupleAggregateType,
 		AggregateID:   domainResourceEvent.Id().String(),

--- a/internal/biz/usecase/resources/resource_service.go
+++ b/internal/biz/usecase/resources/resource_service.go
@@ -188,7 +188,7 @@ func (uc *Usecase) Delete(reporterResourceKey model.ReporterResourceKey) error {
 				if err != nil {
 					return fmt.Errorf("failed to delete resource: %w", err)
 				}
-				return uc.resourceRepository.Save(tx, *res, model_legacy.OperationTypeUpdated, txidStr)
+				return uc.resourceRepository.Save(tx, *res, model_legacy.OperationTypeDeleted, txidStr)
 			} else {
 				return err
 			}

--- a/internal/biz/usecase/resources/resource_service.go
+++ b/internal/biz/usecase/resources/resource_service.go
@@ -750,7 +750,7 @@ func (uc *Usecase) Update(ctx context.Context, m *model_legacy.Resource, id mode
 }
 
 // Delete removes a resource from the database identified by the reporter resource ID.
-func (uc *Usecase) Delete(ctx context.Context, id model_legacy.ReporterResourceId) error {
+func (uc *Usecase) DeleteLegacy(ctx context.Context, id model_legacy.ReporterResourceId) error {
 	m := &model_legacy.Resource{}
 
 	// check if the resource exists

--- a/internal/biz/usecase/resources/resource_service.go
+++ b/internal/biz/usecase/resources/resource_service.go
@@ -183,8 +183,9 @@ func (uc *Usecase) Delete(reporterResourceKey model.ReporterResourceKey) error {
 			res, err := uc.resourceRepository.FindResourceByKeys(tx, reporterResourceKey)
 
 			if err == nil && res != nil {
-				log.Info("Found Resource, deleting: ")
+				log.Info("Found Resource, deleting: ", res)
 				err := res.Delete(reporterResourceKey)
+				log.Infof("Deleted Resource to save : %+v", res)
 				if err != nil {
 					return fmt.Errorf("failed to delete resource: %w", err)
 				}

--- a/internal/biz/usecase/resources/resource_service_test.go
+++ b/internal/biz/usecase/resources/resource_service_test.go
@@ -560,7 +560,7 @@ func TestDeleteReturnsDbError(t *testing.T) {
 	useCase := New(nil, repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
-	err := useCase.Delete(ctx, model_legacy.ReporterResourceId{})
+	err := useCase.DeleteLegacy(ctx, model_legacy.ReporterResourceId{})
 	assert.ErrorIs(t, err, ErrDatabaseError)
 	repo.AssertExpectations(t)
 }
@@ -576,7 +576,7 @@ func TestDeleteReturnsDbErrorBackwardsCompatible(t *testing.T) {
 	useCase := New(nil, repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
-	err := useCase.Delete(ctx, model_legacy.ReporterResourceId{})
+	err := useCase.DeleteLegacy(ctx, model_legacy.ReporterResourceId{})
 	assert.ErrorIs(t, err, ErrDatabaseError)
 	repo.AssertExpectations(t)
 }
@@ -592,7 +592,7 @@ func TestDeleteNonexistentResource(t *testing.T) {
 	useCase := New(nil, repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 	ctx := context.TODO()
 
-	err := useCase.Delete(ctx, model_legacy.ReporterResourceId{})
+	err := useCase.DeleteLegacy(ctx, model_legacy.ReporterResourceId{})
 	assert.ErrorIs(t, err, ErrResourceNotFound)
 	repo.AssertExpectations(t)
 }
@@ -612,7 +612,7 @@ func TestDeleteResource(t *testing.T) {
 
 	useCase := New(nil, repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 
-	err = useCase.Delete(ctx, model_legacy.ReporterResourceId{})
+	err = useCase.DeleteLegacy(ctx, model_legacy.ReporterResourceId{})
 	assert.Nil(t, err)
 
 	repo.AssertExpectations(t)
@@ -635,7 +635,7 @@ func TestDeleteResourceBackwardsCompatible(t *testing.T) {
 
 	useCase := New(nil, repo, inventoryRepo, nil, nil, "", log.DefaultLogger, nil, cb, defaultUseCaseConfig)
 
-	err = useCase.Delete(ctx, model_legacy.ReporterResourceId{})
+	err = useCase.DeleteLegacy(ctx, model_legacy.ReporterResourceId{})
 	assert.Nil(t, err)
 
 	repo.AssertExpectations(t)

--- a/internal/data/outboxeventsrepository.go
+++ b/internal/data/outboxeventsrepository.go
@@ -13,8 +13,8 @@ func PublishOutboxEvent(tx *gorm.DB, event *model_legacy.OutboxEvent) error {
 	if err := tx.Create(event).Error; err != nil {
 		return err
 	}
-	if err := tx.Delete(event).Error; err != nil {
+	/*if err := tx.Delete(event).Error; err != nil {
 		return err
-	}
+	}*/
 	return nil
 }

--- a/internal/data/outboxeventsrepository.go
+++ b/internal/data/outboxeventsrepository.go
@@ -13,8 +13,8 @@ func PublishOutboxEvent(tx *gorm.DB, event *model_legacy.OutboxEvent) error {
 	if err := tx.Create(event).Error; err != nil {
 		return err
 	}
-	/*if err := tx.Delete(event).Error; err != nil {
+	if err := tx.Delete(event).Error; err != nil {
 		return err
-	}*/
+	}
 	return nil
 }

--- a/internal/data/resource_repository.go
+++ b/internal/data/resource_repository.go
@@ -157,17 +157,17 @@ func (r *resourceRepository) Save(tx *gorm.DB, resource bizmodel.Resource, opera
 }
 
 func (r *resourceRepository) handleOutboxEvents(tx *gorm.DB, resourceEvent bizmodel.ResourceEvent, operationType model_legacy.EventOperationType, txid string) error {
-	resourceMessage, tupleMessage, err := model_legacy.NewOutboxEventsFromResourceEvent(resourceEvent, operationType, txid)
+	resourceMessage, _, tupleMessagev2, err := model_legacy.NewOutboxEventsFromResourceEvent(resourceEvent, operationType, txid)
 	if err != nil {
 		return err
 	}
-	
+
 	err = PublishOutboxEvent(tx, resourceMessage)
 	if err != nil {
 		return err
 	}
 
-	err = PublishOutboxEvent(tx, tupleMessage)
+	err = PublishOutboxEvent(tx, tupleMessagev2)
 	if err != nil {
 		return err
 	}

--- a/internal/data/resource_repository.go
+++ b/internal/data/resource_repository.go
@@ -3,7 +3,6 @@ package data
 import (
 	"fmt"
 
-	"github.com/go-kratos/kratos/v2/log"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
@@ -162,10 +161,7 @@ func (r *resourceRepository) handleOutboxEvents(tx *gorm.DB, resourceEvent bizmo
 	if err != nil {
 		return err
 	}
-
-	log.Info("Resource Message", resourceMessage)
-	log.Info("Tuple Message", tupleMessage)
-
+	
 	err = PublishOutboxEvent(tx, resourceMessage)
 	if err != nil {
 		return err

--- a/internal/service/resources/k8sclusters/k8scluster.go
+++ b/internal/service/resources/k8sclusters/k8scluster.go
@@ -72,7 +72,7 @@ func (c *K8sClustersService) DeleteK8SCluster(ctx context.Context, r *pb.DeleteK
 	}
 
 	if resourceId, err := fromDeleteRequest(r, identity); err == nil {
-		if err := c.Ctl.Delete(ctx, resourceId); err == nil {
+		if err := c.Ctl.DeleteLegacy(ctx, resourceId); err == nil {
 			return toDeleteResponse(), nil
 		} else {
 			return nil, err

--- a/internal/service/resources/k8spolicies/k8spolicies.go
+++ b/internal/service/resources/k8spolicies/k8spolicies.go
@@ -74,7 +74,7 @@ func (c *K8sPolicyService) DeleteK8SPolicy(ctx context.Context, r *pb.DeleteK8SP
 	}
 
 	if resourceId, err := fromDeleteRequest(r, identity); err == nil {
-		if err := c.Ctl.Delete(ctx, resourceId); err == nil {
+		if err := c.Ctl.DeleteLegacy(ctx, resourceId); err == nil {
 			return toDeleteResponse(), nil
 		} else {
 			return nil, err

--- a/internal/service/resources/kesselinventoryservice.go
+++ b/internal/service/resources/kesselinventoryservice.go
@@ -76,7 +76,7 @@ func (c *InventoryService) DeleteResource(ctx context.Context, r *pb.DeleteResou
 		return nil, status.Errorf(codes.InvalidArgument, "failed to build reporter resource ID: %v", err)
 	}
 
-	err = c.Ctl.Delete(ctx, reporterResource)
+	err = c.Ctl.DeleteLegacy(ctx, reporterResource)
 	if err != nil {
 		log.Error("Failed to delete resource: ", err)
 


### PR DESCRIPTION
### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Introduce support for resource deletion events and publish new tuple-event messages (v2) via the outbox system, refactoring event conversion and service layers to handle both report and delete operations.

New Features:
- Add ResourceDeleteEvent type and integrate deletion support in biz model, usecase, and service layers.
- Introduce TupleEvent model and convertResourceToTupleEvent to generate new tuple payloads.
- Extend outbox event generator NewOutboxEventsFromResourceEvent to return and publish a new v2 tuple message alongside resource events.

Enhancements:
- Refactor handleOutboxEvents and conversion functions to operate on a generic ResourceEvent interface for both reports and deletes.
- Branch InventoryService, K8sClustersService, and K8sPolicyService on v1beta2 DB flag, introducing Delete vs DeleteLegacy methods.
- Simplify reporter representation constructors by removing deprecated parameters and adjust initial tombstone default.

Tests:
- Add unit tests for ResourceDeleteEvent and tuple event model.
- Update existing tests to reflect ResourceReportEvents, DeleteLegacy API, and new tuple-event logic.