### PR TITLE
RHCLOUD-41957: adds image, deployment, and configuration for kessel debug container

### DIFF
--- a/tools/kessel-debug-container/Dockerfile
+++ b/tools/kessel-debug-container/Dockerfile
@@ -1,0 +1,15 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1755695350
+
+USER root
+
+ENV GRPCURL_VERSION=1.9.3 \
+    ZED_VERSION=0.31.0 \
+    SCALA_VERSION=2.13 \
+    KAFKA_VERSION=3.9.0
+
+COPY ./installer.sh /tmp
+COPY ./scripts/* /usr/local/bin/
+
+RUN /tmp/installer.sh
+
+CMD ["sleep", "infinity"]

--- a/tools/kessel-debug-container/README.md
+++ b/tools/kessel-debug-container/README.md
@@ -1,0 +1,60 @@
+# Kessel Debug Container
+
+The Kessel Debug Container is a useful tool for investigating Kessel service issues in cluster. It contains all the necessary CLI's needed for interacting with Kessel services, and configures environment variables for all Kessel endpoints and configurations needed to connect with dependent services such as SpiceDB or Kafka
+
+**What's Included?**:
+* Basic Networking tools (DNS testing tools, netcat, openssl, curl, wget, grpcurl)
+* JQ for parsing JSON data
+* Zed CLI to interact with SpiceDB
+* Kafka command-line tools (available under `/opt/kafka/bin`)
+* Helper scripts for basic tasks as part of our runbooks
+
+### Environment Configuration
+
+The debug container is configured with environment variables consisting of Kessel endpoints and credentials, loaded from secrets already deployed with Kessel services or through a ConfigMap deployed with the debug container itself.
+
+**What's Configured?**:
+* SpiceDB endpoint and token configuration (via `ZED_ENDPOINT`, `ZED_TOKEN`, and `ZED_INSECURE` variables)
+* Inventory API Endpoints: (via `INVENTORY_API_GRPC_ENDPOINT` and `INVENTORY_API_HTTP_ENDPOINT` variables)
+* Relations API Endpoints: (via `RELATIONS_API_GRPC_ENDPOINT` and `RELATIONS_API_HTTP_ENDPOINT` variables)
+* Kafka Endpoints and auth info (configured by running `source /usr/local/bin/env-setup.sh` if needed)
+* Clowder cdappconfig for Inventory API mounted to `/cdapp`
+
+
+### Running the Debug Container
+
+Everything needed for the debug container is either encompassed in the deployment file, or captured from existing data in the namespace. Simply deploy using `oc` cli and connect to the running container
+
+**To Run**:
+
+```shell
+oc process --local -f tools/kessel-debug-container/kessel-debug-deploy.yaml
+    -p ENV=<target-environment (int, stage, or prod)> | oc apply -f -
+```
+
+### Using the Debug Container
+
+**To Access**:
+
+```shell
+oc rsh $(oc get pod -l app=kessel-debug -o name)
+```
+
+If needed, Kafka connection information can be setup after accessing the pod by sourcing the `env-setup.sh` script available. This will export the Kafka bootstrap server address(es) to the `BOOTSTRAP_SERVERS` variable, as well as create a JAAS auth config file and set the path to it under the `KAFKA_AUTH_CONFIG` variable:
+
+```shell
+source /usr/local/bin/env-setup.sh
+```
+
+When leveraging any Kafka command-line tools, the `KAFKA_AUTH_CONFIG` can be provided to most commands using the `--command-config` flag to ensure authentication is used and avoid errors. Some commands have different names for this flag, see their respective `--help` commands for details.
+
+### Removing the Debug Container
+
+Its critical to always remove the debug container when finished.
+
+To destroy the container:
+
+```shell
+oc process --local -f tools/kessel-debug-container/kessel-debug-deploy.yaml
+    -p ENV=<target-environment (int, stage, or prod)> | oc delete -f -
+```

--- a/tools/kessel-debug-container/installer.sh
+++ b/tools/kessel-debug-container/installer.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+echo "Fetching required packages and RPM files..."
+curl -Lo /tmp/grpcurl.rpm https://github.com/fullstorydev/grpcurl/releases/download/v${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION}_linux_amd64.rpm && \
+curl -Lo /tmp/zed.rpm https://github.com/authzed/zed/releases/download/v${ZED_VERSION}/zed_${ZED_VERSION}_linux_amd64.rpm
+curl -Lo /tmp/kafka.tgz https://dlcdn.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
+
+
+echo "Installing packages..."
+microdnf install -y tar gzip wget bind-utils jq nmap-ncat openssl vim java-17-openjdk
+rpm -iv /tmp/grpcurl.rpm /tmp/zed.rpm
+
+mkdir -pv /opt/kafka
+tar -xvf /tmp/kafka.tgz -C /opt/kafka --strip-components=1
+
+# setup zed wrapper by renaming base zed cli
+mv /usr/bin/zed /usr/bin/zed.original
+mv /usr/local/bin/zed-wrapper.sh /usr/local/bin/zed
+
+echo "Clean up..."
+microdnf clean all -y
+rm /tmp/*.rpm

--- a/tools/kessel-debug-container/kessel-debug-deploy.yaml
+++ b/tools/kessel-debug-container/kessel-debug-deploy.yaml
@@ -1,0 +1,89 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: kessel-debug-template
+  namespace: kessel-${ENV}
+objects:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: kessel-debug-config
+  data:
+    ZED_ENDPOINT: "kessel-relations-spicedb.kessel-${ENV}.svc:50051"
+    ZED_INSECURE: "true"
+    RELATIONS_API_GRPC_ENDPOINT: "kessel-relations-api.kessel-${ENV}.svc:9000"
+    RELATIONS_API_HTTP_ENDPOINT: "kessel-relations-api.kessel-${ENV}.svc:8000"
+    INVENTORY_API_GRPC_ENDPOINT: "kessel-inventory-api.kessel-${ENV}.svc:9000"
+    INVENTORY_API_HTTP_ENDPOINT: "kessel-inventory-api.kessel-${ENV}.svc:8000"
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: kessel-debug
+    name: kessel-debug
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: kessel-debug
+    template:
+      metadata:
+        labels:
+          app: kessel-debug
+      spec:
+        containers:
+        - image: ${DEBUG_IMAGE}:${IMAGE_TAG}
+          name: kessel-debug
+          imagePullPolicy: Always
+          envFrom:
+          - configMapRef:
+              name: kessel-debug-config
+          env:
+          - name: ZED_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: spicedb-config
+                key: preshared_key
+          - name: INVENTORY_SSO_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: kessel-sso-sa
+                key: client-id
+          - name: INVENTORY_SSO_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: kessel-sso-sa
+                key: client-secret
+          - name: INVENTORY_SSO_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                name: kessel-sso-sa
+                key: url
+          volumeMounts:
+            - name: config-secret
+              mountPath: /cdapp/
+            - name: kafka-ca-certs
+              mountPath: "/kafka-ca-certs"
+        volumes:
+          - name: config-secret
+            secret:
+              secretName: kessel-inventory  # leverages inventory secret as it includes kafka info
+              defaultMode: 420
+          - name: kafka-ca-certs
+            secret:
+              secretName: ${CA_CERT_SECRET}
+              optional: true
+parameters:
+  - name: ENV
+    description: Target environment of the deployment (int, stage, or prod only)
+    required: true
+  - name: DEBUG_IMAGE
+    description: Quay image name for the debug container
+    value: quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/kessel-debug
+  - name: IMAGE_TAG
+    description: Image tag for the debug container
+    value: latest
+  - name: CA_CERT_SECRET
+    description: Name of the secret that contains the Kafka CA Cert (if applicable)
+    required: true
+    value: kessel-kafka-connect-config

--- a/tools/kessel-debug-container/scripts/env-setup.sh
+++ b/tools/kessel-debug-container/scripts/env-setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+CDAPPCONFIG="/cdapp/cdappconfig.json"
+export KAFKA_AUTH_CONFIG=/tmp/config.props
+
+echo "Setting up Kafka Connection Info..."
+# ensure we properly provide a comma-separeated list if there are more than one
+export BOOTSTRAP_SERVERS=$(cat $CDAPPCONFIG | jq -r '[.kafka.brokers[] | "\(.hostname):\(.port)"] | join(",")')
+
+
+# check if auth config info exists for setting up the auth config file as needed
+# only the first broker is checked (if multiple) as we wont have multiple brokers from different clusters ever for a service
+if [[ $(cat $CDAPPCONFIG | jq '.kafka.brokers[0] | has("sasl")') == "true" ]]; then
+    export KAFKA_USERNAME=$(cat $CDAPPCONFIG | jq -r '.kafka.brokers[0].sasl.username')
+    export KAFKA_PW=$(cat $CDAPPCONFIG | jq -r '.kafka.brokers[0].sasl.password')
+fi
+
+if [[ ! -z "$KAFKA_USERNAME" ]] && [[ ! -z "$KAFKA_PW" ]]; then
+    echo "Setting up Kafka auth config..."
+    cat <<EOF > $KAFKA_AUTH_CONFIG
+sasl.mechanism=SCRAM-SHA-512
+security.protocol=SASL_SSL
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="$KAFKA_USERNAME" password="$KAFKA_PW";
+EOF
+fi
+
+echo "Kafka Setup Complete!"

--- a/tools/kessel-debug-container/scripts/zed-wrapper.sh
+++ b/tools/kessel-debug-container/scripts/zed-wrapper.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Zed wrapper script to prevent 'write' operations while allowing all other commands
+# This provides a security policy layer for debug/read-only containers
+
+# Check if the any arguments provided are for write operations
+if [[ "$@" =~ "write" ]]; then
+echo "ERROR: 'zed write' is disabled in this container for security reasons." >&2
+echo "This container is configured for read-only operations only." >&2
+echo "Available commands: validate, relationship, schema, permission, etc." >&2
+exit 1
+fi
+
+# For all other commands, pass through to the original zed binary
+exec /usr/bin/zed.original "$@"


### PR DESCRIPTION
### PR Template:

## Describe your changes

Adds Kessel Debug container bits as part of PoC:
* adds Dockerfile and installer script for setting up the debug container
* adds deployment template for running the debug container
* adds a zed-wrapper script that is designed to prevent-through-warnings write operations using the debug container
* adds env setup script for configuring kafka setup
* Adds a README with info on using the debug container

Follow Up Work:
* We will need to setup konflux builds for the new image
* We will need to work with AppSRE on trying to get approval to grant us access to this pod (they would deploy, we would access)
    * This would get us access to SpiceDB and provide a stable debug container for all to use, including AppSRE

## Ticket reference (if applicable)
For RHCLOUD-41957

## Validation

```shell
# using a build pushed to my own quay for testing and against stage cluster
oc process --local -f tools/kessel-debug-container/kessel-debug-deploy.yaml -p ENV=stage -p DEBUG_IMAGE=quay.io/anatale/kessel-debug -p IMAGE_TAG=latest | oc apply -f -

$ oc rsh kessel-debug-5b7767fb8c-qsvcc
sh-5.1$ 

# zed wrapper properly prevents and warns with writes'
sh-5.1$ zed schema write
ERROR: 'zed write' is disabled in this container for security reasons.
This container is configured for read-only operations only.
Available commands: validate, relationship, schema, permission, etc.

# other zed commands work out the box, no extra config steps just based on configmap/secrets
sh-5.1$ zed schema read | head -n 5
definition notifications/integration {
	permission workspace = t_workspace
	relation t_workspace: rbac/workspace
	permission view = t_workspace->notifications_integration_view
	permission edit = t_workspace->notifications_integration_edit

# kafka setup script functions as intended
sh-5.1$ source /usr/local/bin/env-setup.sh 
Setting up Kafka Connection Info...
Setting up Kafka auth config...
Kafka Setup Complete!

sh-5.1$ /opt/kafka/bin/kafka-consumer-groups.sh --describe --group REDACTED --bootstrap-server $BOOTSTRAP_SERVERS --command-config $KAFKA_AUTH_CONFIG 

--ACTUAL OUTPUT REDACTED BUT EXIT CODE FOR COMMAND IS 0---

sh-5.1$ echo $?
0
```

## Summary by Sourcery

Add proof-of-concept debug container for Kessel to streamline service troubleshooting by packaging required CLI tools, configuration scripts, and deployment manifests.

New Features:
- Add Dockerfile and installer script to build a debug container image with essential CLI tools (networking, Zed, Kafka, jq, etc.)
- Provide OpenShift template for deploying the debug container with environment variables and secret mounting
- Include env-setup script to configure Kafka bootstrap servers and authentication inside the container
- Include zed-wrapper script to enforce read-only mode for SpiceDB operations
- Add README with instructions for deploying, accessing, and removing the debug container