### PR TITLE
Revert "Rename the new Resource table to resources; Add override for …

### DIFF
--- a/internal/data/migrate.go
+++ b/internal/data/migrate.go
@@ -14,6 +14,12 @@ import (
 // See https://gorm.io/docs/migration.html
 func Migrate(db *gorm.DB, logger *log.Helper) error {
 	models := []interface{}{
+		&model_legacy.ResourceHistory{},
+		&model_legacy.Resource{},
+		&model_legacy.Relationship{},
+		&model_legacy.RelationshipHistory{},
+		&model_legacy.LocalInventoryToResource{}, // Deprecated
+		&model_legacy.InventoryResource{},
 		&model_legacy.OutboxEvent{},
 		&model.ReporterRepresentation{},
 		&model.CommonRepresentation{},

--- a/internal/data/model/resource.go
+++ b/internal/data/model/resource.go
@@ -16,6 +16,10 @@ type Resource struct {
 	UpdatedAt        time.Time
 }
 
+func (Resource) TableName() string {
+	return "resource"
+}
+
 // SerializeToSnapshot converts GORM Resource to snapshot type - direct initialization without validation
 func (r Resource) SerializeToSnapshot() bizmodel.ResourceSnapshot {
 	return bizmodel.ResourceSnapshot{

--- a/internal/data/model/resource_test.go
+++ b/internal/data/model/resource_test.go
@@ -62,6 +62,12 @@ func TestResource_Infrastructure_Structure(t *testing.T) {
 		AssertFieldType(t, r, "CommonVersion", reflect.TypeOf(uint(0)))
 	})
 
+	t.Run("should have correct table name", func(t *testing.T) {
+		t.Parallel()
+
+		r := &Resource{}
+		AssertTableName(t, r, "resource")
+	})
 }
 
 func TestResource_Infrastructure_EdgeCases(t *testing.T) {

--- a/internal/data/relationships/relationshiprepository_test.go
+++ b/internal/data/relationships/relationshiprepository_test.go
@@ -1,5 +1,3 @@
-//go:build enable_resource_repository_tests
-
 package resources
 
 import (

--- a/internal/data/resource_repository.go
+++ b/internal/data/resource_repository.go
@@ -204,7 +204,7 @@ func (r *resourceRepository) FindResourceByKeys(tx *gorm.DB, key bizmodel.Report
 	`).
 		Joins(`
 		JOIN reporter_resources AS rr2 ON rr2.resource_id = rr.resource_id
-		JOIN resources AS res ON res.id = rr2.resource_id
+		JOIN resource AS res ON res.id = rr2.resource_id
 	`)
 
 	// Build WHERE conditions dynamically based on present values

--- a/internal/data/resources/resourcerepository_test.go
+++ b/internal/data/resources/resourcerepository_test.go
@@ -1,5 +1,3 @@
-//go:build enable_resource_repository_tests
-
 package resources
 
 import (


### PR DESCRIPTION
…the old … (#872)"

This reverts commit 7a9001f1e020fcdaf275693d2593c18a1d7acfb1.

### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Revert the previous table renaming by restoring the singular “resource” table naming and reintegrating legacy resource models into migrations.

Enhancements:
- Add legacy resource-related models back to the migration list
- Implement TableName override on Resource to enforce singular table name
- Update repository queries to join against the singular resource table

Tests:
- Add assertion to verify Resource uses the “resource” table name