### PR TITLE
Remove creation of old tables from auto migrate

### DIFF
--- a/internal/data/migrate.go
+++ b/internal/data/migrate.go
@@ -14,12 +14,6 @@ import (
 // See https://gorm.io/docs/migration.html
 func Migrate(db *gorm.DB, logger *log.Helper) error {
 	models := []interface{}{
-		&model_legacy.ResourceHistory{},
-		&model_legacy.Resource{},
-		&model_legacy.Relationship{},
-		&model_legacy.RelationshipHistory{},
-		&model_legacy.LocalInventoryToResource{}, // Deprecated
-		&model_legacy.InventoryResource{},
 		&model_legacy.OutboxEvent{},
 		&model.ReporterRepresentation{},
 		&model.CommonRepresentation{},

--- a/internal/data/relationships/relationshiprepository_test.go
+++ b/internal/data/relationships/relationshiprepository_test.go
@@ -1,3 +1,5 @@
+//go:build enable_resource_repository_tests
+
 package resources
 
 import (

--- a/internal/data/resources/resourcerepository_test.go
+++ b/internal/data/resources/resourcerepository_test.go
@@ -1,3 +1,5 @@
+//go:build enable_resource_repository_tests
+
 package resources
 
 import (


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Remove creation of legacy tables during automigration to avoid creating them after we do the db cleanup

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

