### PR TITLE
converts debug container to use Pod def

### DIFF
--- a/.tekton/kessel-debug-pull-request.yaml
+++ b/.tekton/kessel-debug-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "/tools/kessel-debug-container/***".pathChanged() || ".tekton/kessel-debug-pull-request.yaml".pathChanged()
+      == "main" && ( "tools/kessel-debug-container/***".pathChanged() || ".tekton/kessel-debug-pull-request.yaml".pathChanged()
       || "tools/kessel-debug-container/Dockerfile".pathChanged() )
   creationTimestamp: null
   labels:

--- a/.tekton/kessel-debug-push.yaml
+++ b/.tekton/kessel-debug-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "/tools/kessel-debug-container/***".pathChanged() || ".tekton/kessel-debug-push.yaml".pathChanged()
+      == "main" && ( "tools/kessel-debug-container/***".pathChanged() || ".tekton/kessel-debug-push.yaml".pathChanged()
       || "tools/kessel-debug-container/Dockerfile".pathChanged() )
   creationTimestamp: null
   labels:

--- a/tools/kessel-debug-container/README.md
+++ b/tools/kessel-debug-container/README.md
@@ -37,7 +37,7 @@ oc process --local -f tools/kessel-debug-container/kessel-debug-deploy.yaml
 **To Access**:
 
 ```shell
-oc rsh $(oc get pod -l app=kessel-debug -o name)
+oc rsh kessel-debug
 ```
 
 If needed, Kafka connection information can be setup after accessing the pod by sourcing the `env-setup.sh` script available. This will export the Kafka bootstrap server address(es) to the `BOOTSTRAP_SERVERS` variable, as well as create a JAAS auth config file and set the path to it under the `KAFKA_AUTH_CONFIG` variable:

--- a/tools/kessel-debug-container/kessel-debug-deploy.yaml
+++ b/tools/kessel-debug-container/kessel-debug-deploy.yaml
@@ -15,71 +15,62 @@ objects:
     RELATIONS_API_HTTP_ENDPOINT: "kessel-relations-api.kessel-${ENV}.svc:8000"
     INVENTORY_API_GRPC_ENDPOINT: "kessel-inventory-api.kessel-${ENV}.svc:9000"
     INVENTORY_API_HTTP_ENDPOINT: "kessel-inventory-api.kessel-${ENV}.svc:8000"
-- apiVersion: apps/v1
-  kind: Deployment
+- apiVersion: v1
+  kind: Pod
   metadata:
     labels:
       app: kessel-debug
     name: kessel-debug
   spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: kessel-debug
-    template:
-      metadata:
-        labels:
-          app: kessel-debug
-      spec:
-        containers:
-        - image: ${DEBUG_IMAGE}:${IMAGE_TAG}
-          name: kessel-debug
-          imagePullPolicy: Always
-          envFrom:
-          - configMapRef:
-              name: kessel-debug-config
-          env:
-          - name: ZED_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: spicedb-config
-                key: preshared_key
-          - name: INVENTORY_SSO_CLIENT_ID
-            valueFrom:
-              secretKeyRef:
-                name: kessel-sso-sa
-                key: client-id
-          - name: INVENTORY_SSO_CLIENT_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: kessel-sso-sa
-                key: client-secret
-          - name: INVENTORY_SSO_ENDPOINT
-            valueFrom:
-              secretKeyRef:
-                name: kessel-sso-sa
-                key: url
-          volumeMounts:
-            - name: config-secret
-              mountPath: /cdapp/
-            - name: kafka-ca-certs
-              mountPath: "/kafka-ca-certs"
-        volumes:
-          - name: config-secret
-            secret:
-              secretName: kessel-inventory  # leverages inventory secret as it includes kafka info
-              defaultMode: 420
-          - name: kafka-ca-certs
-            secret:
-              secretName: ${CA_CERT_SECRET}
-              optional: true
+    containers:
+    - image: ${DEBUG_IMAGE}:${IMAGE_TAG}
+      name: kessel-debug
+      imagePullPolicy: Always
+      envFrom:
+      - configMapRef:
+          name: kessel-debug-config
+      env:
+      - name: ZED_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: spicedb-config
+            key: preshared_key
+      - name: INVENTORY_SSO_CLIENT_ID
+        valueFrom:
+          secretKeyRef:
+            name: kessel-sso-sa
+            key: client-id
+      - name: INVENTORY_SSO_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: kessel-sso-sa
+            key: client-secret
+      - name: INVENTORY_SSO_ENDPOINT
+        valueFrom:
+          secretKeyRef:
+            name: kessel-sso-sa
+            key: url
+      volumeMounts:
+        - name: config-secret
+          mountPath: /cdapp/
+        - name: kafka-ca-certs
+          mountPath: "/kafka-ca-certs"
+    volumes:
+      - name: config-secret
+        secret:
+          secretName: kessel-inventory  # leverages inventory secret as it includes kafka info
+          defaultMode: 420
+      - name: kafka-ca-certs
+        secret:
+          secretName: ${CA_CERT_SECRET}
+          optional: true
 parameters:
   - name: ENV
     description: Target environment of the deployment (int, stage, or prod only)
     required: true
   - name: DEBUG_IMAGE
     description: Quay image name for the debug container
-    value: quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/kessel-debug
+    value: quay.io/redhat-services-prod/project-kessel-tenant/kessel-debug
   - name: IMAGE_TAG
     description: Image tag for the debug container
     value: latest


### PR DESCRIPTION
### PR Template:

## Describe your changes

Kessel Debug Updates for ease of use:
* Converts the deployment to use `Pod` over `Deployment`
  * This will ensure predictable naming for RBAC needs (can grant permissions to a pod names kessel-debug)
* Updates the default image to use new Konflux built image

## Summary by Sourcery

Convert kessel-debug deployment to a standalone Pod resource, update the default debug image reference, and simplify access instructions in the README.

Enhancements:
- Switch kessel-debug from a Deployment to a Pod for predictable naming and RBAC compatibility
- Update the default DEBUG_IMAGE parameter to point to the new kessel-debug image in Quay

Documentation:
- Simplify oc rsh command in README to use the fixed pod name