### PR TITLE
Store RR keys as lowercase

### DIFF
--- a/internal/biz/model/common.go
+++ b/internal/biz/model/common.go
@@ -212,7 +212,8 @@ func (rt ResourceType) String() string {
 }
 
 func (rt ResourceType) Serialize() string {
-	return SerializeString(rt)
+	str := SerializeString(rt)
+	return strings.ToLower(str)
 }
 
 type ReporterType string
@@ -230,7 +231,8 @@ func (rt ReporterType) String() string {
 }
 
 func (rt ReporterType) Serialize() string {
-	return SerializeString(rt)
+	str := SerializeString(rt)
+	return strings.ToLower(str)
 }
 
 type ReporterInstanceId string
@@ -248,7 +250,8 @@ func (ri ReporterInstanceId) String() string {
 }
 
 func (ri ReporterInstanceId) Serialize() string {
-	return SerializeString(ri)
+	str := SerializeString(ri)
+	return strings.ToLower(str)
 }
 
 type ConsistencyToken string

--- a/internal/data/resource_repository.go
+++ b/internal/data/resource_repository.go
@@ -207,15 +207,15 @@ func (r *resourceRepository) FindResourceByKeys(tx *gorm.DB, key bizmodel.Report
 		JOIN resource AS res ON res.id = rr2.resource_id
 	`)
 
-	// Build WHERE conditions dynamically based on present values
-	query = query.Where("LOWER(rr.local_resource_id) = LOWER(?)", key.LocalResourceId().Serialize())
-	query = query.Where("LOWER(rr.resource_type) = LOWER(?)", key.ResourceType().Serialize())
-	query = query.Where("LOWER(rr.reporter_type) = LOWER(?)", key.ReporterType().Serialize())
+	// Build WHERE conditions using normalized lowercase columns for indexable case-insensitive matching
+	query = query.Where("rr.local_resource_id = ?", key.LocalResourceId().Serialize())
+	query = query.Where("rr.resource_type = ?", key.ResourceType().Serialize())
+	query = query.Where("rr.reporter_type = ?", key.ReporterType().Serialize())
 	query = query.Where("rr.tombstone = ?", false)
 
 	// Only add reporter_instance_id condition if it's not empty
 	if reporterInstanceId := key.ReporterInstanceId().Serialize(); reporterInstanceId != "" {
-		query = query.Where("LOWER(rr.reporter_instance_id) = LOWER(?)", reporterInstanceId)
+		query = query.Where("rr.reporter_instance_id = ?", reporterInstanceId)
 	}
 
 	err := query.Find(&results).Error // Use Find since it returns multiple rows

--- a/internal/data/resource_repository.go
+++ b/internal/data/resource_repository.go
@@ -209,8 +209,8 @@ func (r *resourceRepository) FindResourceByKeys(tx *gorm.DB, key bizmodel.Report
 
 	// Build WHERE conditions using case-insensitive matching to match fake repository behavior
 	query = query.Where("rr.local_resource_id = ?", key.LocalResourceId().Serialize())
-	query = query.Where("LOWER(rr.resource_type) = LOWER(?)", key.ResourceType().Serialize())
-	query = query.Where("LOWER(rr.reporter_type) = LOWER(?)", key.ReporterType().Serialize())
+	query = query.Where("rr.resource_type = ?", key.ResourceType().Serialize())
+	query = query.Where("rr.reporter_type = ?", key.ReporterType().Serialize())
 
 	// Only add reporter_instance_id condition if it's not empty
 	if reporterInstanceId := key.ReporterInstanceId().Serialize(); reporterInstanceId != "" {

--- a/internal/data/resource_repository_test.go
+++ b/internal/data/resource_repository_test.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/google/uuid"
@@ -250,12 +251,12 @@ func TestFindResourceByKeys(t *testing.T) {
 					description        string
 				}{
 					{
-						name:               "lowercase local_resource_id",
-						localResourceId:    "test-mixed-case-resource",
+						name:               "local_resource_id",
+						localResourceId:    "Test-Mixed-Case-Resource",
 						resourceType:       "K8S_Cluster",
 						reporterType:       "OCM",
 						reporterInstanceId: "Mixed-Instance-123",
-						description:        "should find resource when local_resource_id is lowercase",
+						description:        "should find resource by local_resource_id",
 					},
 					{
 						name:               "lowercase resource_type",
@@ -283,7 +284,7 @@ func TestFindResourceByKeys(t *testing.T) {
 					},
 					{
 						name:               "all lowercase",
-						localResourceId:    "test-mixed-case-resource",
+						localResourceId:    "Test-Mixed-Case-Resource",
 						resourceType:       "k8s_cluster",
 						reporterType:       "ocm",
 						reporterInstanceId: "mixed-instance-123",


### PR DESCRIPTION
Serialization was failing very frequently due to our use of `LOWER` on our fields that were indexed in their true case.

- With SERIALIZABLE isolation level, queries must take predicate locks that cover “the set of rows that could satisfy the predicate.” When predicates aren’t indexable, Postgres often takes relation or page-level SIREAD locks.

- Because our WHERE clause applies LOWER() to columns and we don’t have expression indexes on those LOWER() forms, the planner can’t use a btree index to constrain the predicate. That forces coarse predicate locks on reporter_resources.

## Changes
- Stores `reporter_type`, `resource_type`, `reporter_instance_id` as lowercase
- Removes `LOWER` usage from queries
- Note: `local_resource_id` was excluded from this change and will be treated as case-sensitive moving forward