### PR TITLE
RHCLOUD-42396: db update for transaction ids

### DIFF
--- a/api/kessel/inventory/v1beta2/representation_metadata.pb.go
+++ b/api/kessel/inventory/v1beta2/representation_metadata.pb.go
@@ -28,8 +28,12 @@ type RepresentationMetadata struct {
 	ApiHref         string                 `protobuf:"bytes,2,opt,name=api_href,json=apiHref,proto3" json:"api_href,omitempty"`
 	ConsoleHref     *string                `protobuf:"bytes,3,opt,name=console_href,json=consoleHref,proto3,oneof" json:"console_href,omitempty"`
 	ReporterVersion *string                `protobuf:"bytes,4,opt,name=reporter_version,json=reporterVersion,proto3,oneof" json:"reporter_version,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Types that are valid to be assigned to IdempotencyKey:
+	//
+	//	*RepresentationMetadata_TransactionId
+	IdempotencyKey isRepresentationMetadata_IdempotencyKey `protobuf_oneof:"idempotency_key"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *RepresentationMetadata) Reset() {
@@ -90,16 +94,44 @@ func (x *RepresentationMetadata) GetReporterVersion() string {
 	return ""
 }
 
+func (x *RepresentationMetadata) GetIdempotencyKey() isRepresentationMetadata_IdempotencyKey {
+	if x != nil {
+		return x.IdempotencyKey
+	}
+	return nil
+}
+
+func (x *RepresentationMetadata) GetTransactionId() string {
+	if x != nil {
+		if x, ok := x.IdempotencyKey.(*RepresentationMetadata_TransactionId); ok {
+			return x.TransactionId
+		}
+	}
+	return ""
+}
+
+type isRepresentationMetadata_IdempotencyKey interface {
+	isRepresentationMetadata_IdempotencyKey()
+}
+
+type RepresentationMetadata_TransactionId struct {
+	TransactionId string `protobuf:"bytes,5,opt,name=transaction_id,json=transactionId,proto3,oneof"`
+}
+
+func (*RepresentationMetadata_TransactionId) isRepresentationMetadata_IdempotencyKey() {}
+
 var File_kessel_inventory_v1beta2_representation_metadata_proto protoreflect.FileDescriptor
 
 const file_kessel_inventory_v1beta2_representation_metadata_proto_rawDesc = "" +
 	"\n" +
-	"6kessel/inventory/v1beta2/representation_metadata.proto\x12\x18kessel.inventory.v1beta2\x1a\x1bbuf/validate/validate.proto\"\xef\x01\n" +
+	"6kessel/inventory/v1beta2/representation_metadata.proto\x12\x18kessel.inventory.v1beta2\x1a\x1bbuf/validate/validate.proto\"\xab\x02\n" +
 	"\x16RepresentationMetadata\x123\n" +
 	"\x11local_resource_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x0flocalResourceId\x12\"\n" +
 	"\bapi_href\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\aapiHref\x12&\n" +
-	"\fconsole_href\x18\x03 \x01(\tH\x00R\vconsoleHref\x88\x01\x01\x12.\n" +
-	"\x10reporter_version\x18\x04 \x01(\tH\x01R\x0freporterVersion\x88\x01\x01B\x0f\n" +
+	"\fconsole_href\x18\x03 \x01(\tH\x01R\vconsoleHref\x88\x01\x01\x12.\n" +
+	"\x10reporter_version\x18\x04 \x01(\tH\x02R\x0freporterVersion\x88\x01\x01\x12'\n" +
+	"\x0etransaction_id\x18\x05 \x01(\tH\x00R\rtransactionIdB\x11\n" +
+	"\x0fidempotency_keyB\x0f\n" +
 	"\r_console_hrefB\x13\n" +
 	"\x11_reporter_versionBr\n" +
 	"(org.project_kessel.api.inventory.v1beta2P\x01ZDgithub.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2b\x06proto3"
@@ -133,7 +165,9 @@ func file_kessel_inventory_v1beta2_representation_metadata_proto_init() {
 	if File_kessel_inventory_v1beta2_representation_metadata_proto != nil {
 		return
 	}
-	file_kessel_inventory_v1beta2_representation_metadata_proto_msgTypes[0].OneofWrappers = []any{}
+	file_kessel_inventory_v1beta2_representation_metadata_proto_msgTypes[0].OneofWrappers = []any{
+		(*RepresentationMetadata_TransactionId)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/api/kessel/inventory/v1beta2/representation_metadata.proto
+++ b/api/kessel/inventory/v1beta2/representation_metadata.proto
@@ -12,5 +12,8 @@ message RepresentationMetadata {
   string api_href = 2 [(buf.validate.field).string = {min_len: 1}];
   optional string console_href = 3 ;
   optional string reporter_version = 4;
+  oneof idempotency_key {
+    string transaction_id = 5;
+  }
 }
 

--- a/internal/biz/model/snapshots.go
+++ b/internal/biz/model/snapshots.go
@@ -63,6 +63,7 @@ type ReporterRepresentationSnapshot struct {
 	Generation         uint                   `json:"generation"`
 	ReporterVersion    *string                `json:"reporter_version"`
 	CommonVersion      uint                   `json:"common_version"`
+	TransactionId      string                 `json:"transaction_id"`
 	Tombstone          bool                   `json:"tombstone"`
 	CreatedAt          time.Time              `json:"created_at"`
 }

--- a/internal/biz/model/snapshots.go
+++ b/internal/biz/model/snapshots.go
@@ -51,6 +51,7 @@ type CommonRepresentationSnapshot struct {
 	Version                    uint                   `json:"version"`
 	ReportedByReporterType     string                 `json:"reported_by_reporter_type"`
 	ReportedByReporterInstance string                 `json:"reported_by_reporter_instance"`
+	TransactionId              string                 `json:"transaction_id"`
 	CreatedAt                  time.Time              `json:"created_at"`
 }
 

--- a/internal/data/model/common.go
+++ b/internal/data/model/common.go
@@ -15,6 +15,7 @@ const (
 	MaxAPIHrefLength            = MaxFieldSize512
 	MaxConsoleHrefLength        = MaxFieldSize512
 	MaxConsistencyTokenLength   = MaxFieldSize1024
+	MaxTransactionIdLength      = MaxFieldSize128
 
 	MinVersionValue    = 0
 	MinGenerationValue = 0

--- a/internal/data/model/common_representation.go
+++ b/internal/data/model/common_representation.go
@@ -17,6 +17,7 @@ type CommonRepresentation struct {
 	Version                    uint      `gorm:"type:bigint;primaryKey;check:version >= 0"`
 	ReportedByReporterType     string    `gorm:"size:128"`
 	ReportedByReporterInstance string    `gorm:"size:128"`
+	TransactionId              string    `gorm:"size:128"`
 	CreatedAt                  time.Time
 }
 
@@ -28,6 +29,7 @@ func NewCommonRepresentation(
 	version uint,
 	reportedByReporterType string,
 	reportedByReporterInstance string,
+	transactionId string,
 ) (*CommonRepresentation, error) {
 	cr := &CommonRepresentation{
 		Representation: Representation{
@@ -37,6 +39,7 @@ func NewCommonRepresentation(
 		Version:                    version,
 		ReportedByReporterType:     reportedByReporterType,
 		ReportedByReporterInstance: reportedByReporterInstance,
+		TransactionId:              transactionId,
 	}
 
 	if err := validateCommonRepresentation(cr); err != nil {
@@ -54,6 +57,7 @@ func validateCommonRepresentation(cr *CommonRepresentation) error {
 		bizmodel.ValidateMaxLength("ReportedByReporterType", cr.ReportedByReporterType, MaxReporterTypeLength),
 		bizmodel.ValidateStringRequired("ReportedByReporterInstance", cr.ReportedByReporterInstance),
 		bizmodel.ValidateMaxLength("ReportedByReporterInstance", cr.ReportedByReporterInstance, MaxReporterInstanceIDLength),
+		bizmodel.ValidateMaxLength("TransactionId", cr.TransactionId, MaxTransactionIdLength),
 	)
 }
 
@@ -70,11 +74,12 @@ func (cr CommonRepresentation) SerializeToSnapshot() bizmodel.CommonRepresentati
 		Version:                    cr.Version,
 		ReportedByReporterType:     cr.ReportedByReporterType,
 		ReportedByReporterInstance: cr.ReportedByReporterInstance,
+		TransactionId:              cr.TransactionId,
 		CreatedAt:                  cr.CreatedAt,
 	}
 }
 
-// DeserializeFromSnapshot creates GORM CommonRepresentation from snapshot - direct initialization without validation
+// DeserializeCommonRepresentationFromSnapshot creates GORM CommonRepresentation from snapshot - direct initialization without validation
 func DeserializeCommonRepresentationFromSnapshot(snapshot bizmodel.CommonRepresentationSnapshot) CommonRepresentation {
 	return CommonRepresentation{
 		Representation: Representation{
@@ -84,6 +89,7 @@ func DeserializeCommonRepresentationFromSnapshot(snapshot bizmodel.CommonReprese
 		Version:                    snapshot.Version,
 		ReportedByReporterType:     snapshot.ReportedByReporterType,
 		ReportedByReporterInstance: snapshot.ReportedByReporterInstance,
+		TransactionId:              snapshot.TransactionId,
 		CreatedAt:                  snapshot.CreatedAt,
 	}
 }

--- a/internal/data/model/common_representation_test.go
+++ b/internal/data/model/common_representation_test.go
@@ -430,6 +430,7 @@ func TestCommonRepresentation_Infrastructure_Serialization(t *testing.T) {
 			1,
 			"hbi",
 			"test-instance",
+			"test-transaction-id",
 		)
 		AssertNoError(t, err, "Should be able to create CommonRepresentation with nil data")
 

--- a/internal/data/model/reporter_representation.go
+++ b/internal/data/model/reporter_representation.go
@@ -19,6 +19,7 @@ type ReporterRepresentation struct {
 	Generation         uint      `gorm:"type:bigint;primaryKey;check:generation >= 0"`
 	ReporterVersion    *string   `gorm:"size:128"`
 	CommonVersion      uint      `gorm:"type:bigint;check:common_version >= 0"`
+	TransactionId      string    `gorm:"size:128"`
 	Tombstone          bool      `gorm:"not null"`
 	CreatedAt          time.Time
 
@@ -34,6 +35,7 @@ func NewReporterRepresentation(
 	version uint,
 	generation uint,
 	commonVersion uint,
+	transactionId string,
 	tombstone bool,
 	reporterVersion *string,
 ) (*ReporterRepresentation, error) {
@@ -45,6 +47,7 @@ func NewReporterRepresentation(
 		Version:            version,
 		Generation:         generation,
 		CommonVersion:      commonVersion,
+		TransactionId:      transactionId,
 		Tombstone:          tombstone,
 		ReporterVersion:    reporterVersion,
 	}
@@ -62,6 +65,7 @@ func validateReporterRepresentation(rr *ReporterRepresentation) error {
 		bizmodel.ValidateMinValueUint("Version", rr.Version, MinVersionValue),
 		bizmodel.ValidateMinValueUint("Generation", rr.Generation, MinGenerationValue),
 		bizmodel.ValidateMinValueUint("CommonVersion", rr.CommonVersion, MinCommonVersion),
+		bizmodel.ValidateMaxLength("TransactionId", rr.TransactionId, MaxTransactionIdLength),
 		bizmodel.ValidateOptionalString("ReporterVersion", rr.ReporterVersion, MaxReporterVersionLength),
 	)
 }
@@ -80,12 +84,13 @@ func (rr ReporterRepresentation) SerializeToSnapshot() bizmodel.ReporterRepresen
 		Generation:         rr.Generation,
 		ReporterVersion:    rr.ReporterVersion,
 		CommonVersion:      rr.CommonVersion,
+		TransactionId:      rr.TransactionId,
 		Tombstone:          rr.Tombstone,
 		CreatedAt:          rr.CreatedAt,
 	}
 }
 
-// DeserializeFromSnapshot creates GORM ReporterRepresentation from snapshot - direct initialization without validation
+// DeserializeReporterRepresentationFromSnapshot creates GORM ReporterRepresentation from snapshot - direct initialization without validation
 func DeserializeReporterRepresentationFromSnapshot(snapshot bizmodel.ReporterRepresentationSnapshot) ReporterRepresentation {
 	return ReporterRepresentation{
 		Representation: Representation{
@@ -96,6 +101,7 @@ func DeserializeReporterRepresentationFromSnapshot(snapshot bizmodel.ReporterRep
 		Generation:         snapshot.Generation,
 		ReporterVersion:    snapshot.ReporterVersion,
 		CommonVersion:      snapshot.CommonVersion,
+		TransactionId:      snapshot.TransactionId,
 		Tombstone:          snapshot.Tombstone,
 		CreatedAt:          snapshot.CreatedAt,
 	}

--- a/internal/data/model/reporter_representation_test.go
+++ b/internal/data/model/reporter_representation_test.go
@@ -207,6 +207,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 			1,
 			1,
 			1,
+			"test-transaction-id",
 			false,
 			nil,
 		)
@@ -224,6 +225,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 			1,
 			1,
 			1,
+			"test-transaction-id",
 			false,
 			nil,
 		)
@@ -239,6 +241,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 			4294967295, // Max uint32 Version
 			4294967295, // Max uint32 Generation
 			4294967295, // Max uint32 CommonVersion
+			"test-transaction-id",
 			false,
 			nil,
 		)
@@ -254,6 +257,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 			1,
 			1,
 			1,
+			"test-transaction-id",
 			false,
 			internal.StringPtr(""), // Empty ReporterVersion
 		)
@@ -269,6 +273,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 			1,
 			1,
 			1,
+			"test-transaction-id",
 			false,
 			nil, // Nil ReporterVersion
 		)
@@ -319,6 +324,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 			1,
 			1,
 			1,
+			"test-transaction-id",
 			false,
 			nil,
 		)
@@ -334,6 +340,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 			1,
 			1,
 			1,
+			"test-transaction-id",
 			false,
 			nil,
 		)
@@ -363,6 +370,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 					tc.version,
 					1,
 					1,
+					"test-transaction-id",
 					false,
 					nil,
 				)
@@ -398,6 +406,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 					1,
 					tc.generation,
 					1,
+					"test-transaction-id",
 					false,
 					nil,
 				)
@@ -430,6 +439,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 					1,
 					1,
 					1,
+					"test-transaction-id",
 					tc.tombstone,
 					nil,
 				)

--- a/internal/data/model/testdata.go
+++ b/internal/data/model/testdata.go
@@ -347,9 +347,10 @@ func (f *TestFixture) ValidReporterRepresentation() *ReporterRepresentation {
 			"ansible_host":            "host-1",
 		},
 		uuid.MustParse("dd1b73b9-3e33-4264-968c-e3ce55b9afec"), // reporterResourceID
-		1,                                                      // version
-		1,                                                      // generation
-		1,                                                      // commonVersion
+		1, // version
+		1, // generation
+		1, // commonVersion
+		"test-transaction-id",
 		false,
 		internal.StringPtr("2.7.16"),
 	)
@@ -376,6 +377,7 @@ func (f *TestFixture) ReporterRepresentationWithLocalResourceID(localResourceID 
 		1,
 		1,
 		1,
+		"test-transaction-id",
 		false,
 		internal.StringPtr("2.7.16"),
 	)
@@ -398,6 +400,7 @@ func (f *TestFixture) ReporterRepresentationWithResourceType(resourceType string
 		1,
 		1,
 		1,
+		"test-transaction-id",
 		false,
 		internal.StringPtr("2.7.16"),
 	)
@@ -439,6 +442,7 @@ func (f *TestFixture) ReporterRepresentationWithTombstone(tombstone bool) *Repor
 		1,
 		1,
 		1,
+		"test-transaction-id",
 		tombstone,
 		nil,
 	)
@@ -456,6 +460,7 @@ func (f *TestFixture) ReporterRepresentationWithReporterVersion(ver *string) *Re
 		2,
 		0,
 		1,
+		"test-transaction-id",
 		false,
 		ver,
 	)
@@ -473,6 +478,7 @@ func (f *TestFixture) ReporterRepresentationWithNilReporterVersion() *ReporterRe
 		1,
 		1,
 		1,
+		"test-transaction-id",
 		false,
 		nil,
 	)

--- a/internal/data/model/testdata.go
+++ b/internal/data/model/testdata.go
@@ -34,6 +34,7 @@ func (f *TestFixture) ValidCommonRepresentation() *CommonRepresentation {
 		1,
 		"hbi",
 		"3088be62-1c60-4884-b133-9200542d0b3f",
+		"test-transaction-id",
 	)
 	if err != nil {
 		f.t.Fatalf("Failed to create valid CommonRepresentation: %v", err)
@@ -65,6 +66,7 @@ func (f *TestFixture) CommonRepresentationWithID(id string) *CommonRepresentatio
 		1,
 		"hbi",
 		"3088be62-1c60-4884-b133-9200542d0b3f",
+		"test-transaction-id",
 	)
 	if err != nil {
 		// For test cases expecting invalid data, return the struct anyway for testing
@@ -95,6 +97,7 @@ func (f *TestFixture) CommonRepresentationWithVersion(version uint) *CommonRepre
 		version,
 		"hbi",
 		"3088be62-1c60-4884-b133-9200542d0b3f",
+		"test-transaction-id",
 	)
 	if err != nil {
 		f.t.Fatalf("Cannot create CommonRepresentation with version %d: %v", version, err)
@@ -114,6 +117,7 @@ func (f *TestFixture) CommonRepresentationWithResourceType(resourceType string) 
 		1,
 		"hbi",
 		"3088be62-1c60-4884-b133-9200542d0b3f",
+		"test-transaction-id",
 	)
 	if err != nil {
 		f.t.Fatalf("Cannot create CommonRepresentation with resource type %q: %v", resourceType, err)
@@ -133,6 +137,7 @@ func (f *TestFixture) CommonRepresentationWithReporterType(reporterType string) 
 		1,
 		reporterType,
 		"3088be62-1c60-4884-b133-9200542d0b3f",
+		"test-transaction-id",
 	)
 	if err != nil {
 		f.t.Fatalf("Cannot create CommonRepresentation with reporter type %q: %v", reporterType, err)
@@ -152,6 +157,7 @@ func (f *TestFixture) CommonRepresentationWithReporterInstance(reporterInstance 
 		1,
 		"hbi",
 		reporterInstance,
+		"test-transaction-id",
 	)
 	if err != nil {
 		f.t.Fatalf("Cannot create CommonRepresentation with reporter instance %q: %v", reporterInstance, err)
@@ -169,6 +175,7 @@ func (f *TestFixture) CommonRepresentationWithData(data internal.JsonObject) *Co
 		1,
 		"hbi",
 		"3088be62-1c60-4884-b133-9200542d0b3f",
+		"test-transaction-id",
 	)
 	if err != nil {
 		f.t.Fatalf("Cannot create CommonRepresentation with data %+v: %v", data, err)
@@ -186,6 +193,7 @@ func (f *TestFixture) CommonRepresentationWithEmptyData() *CommonRepresentation 
 		1,
 		"hbi",
 		"3088be62-1c60-4884-b133-9200542d0b3f",
+		"test-transaction-id",
 	)
 	if err != nil {
 		f.t.Fatalf("Cannot create CommonRepresentation with empty data: %v", err)
@@ -219,6 +227,7 @@ func (f *TestFixture) MinimalCommonRepresentation() *CommonRepresentation {
 		1,
 		"ACM",
 		"57a317b1-4040-4c26-8d41-dd589ba1d2eb",
+		"test-transaction-id",
 	)
 	if err != nil {
 		f.t.Fatalf("Failed to create minimal CommonRepresentation: %v", err)
@@ -236,6 +245,7 @@ func (f *TestFixture) MaximalCommonRepresentation() *CommonRepresentation {
 		4294967295, // Max uint32
 		"ACM",
 		"14c6b63e-49b2-4cc2-99de-5d914b657548",
+		"test-transaction-id",
 	)
 	if err != nil {
 		f.t.Fatalf("Failed to create maximal CommonRepresentation: %v", err)
@@ -257,6 +267,7 @@ func (f *TestFixture) UnicodeCommonRepresentation() *CommonRepresentation {
 		1,
 		"测试-reporter",
 		"测试-instance",
+		"test-transaction-id",
 	)
 	if err != nil {
 		// Unicode should be valid, but if not, create directly for testing
@@ -274,6 +285,7 @@ func (f *TestFixture) UnicodeCommonRepresentation() *CommonRepresentation {
 			Version:                    1,
 			ReportedByReporterType:     "测试-reporter",
 			ReportedByReporterInstance: "测试-instance",
+			TransactionId:              "test-transaction-id",
 		}
 	}
 	return cr
@@ -296,6 +308,7 @@ func (f *TestFixture) SpecialCharsCommonRepresentation() *CommonRepresentation {
 		1,
 		"special-†‡•-reporter",
 		"special-™®©-instance",
+		"test-transaction-id",
 	)
 	if err != nil {
 		// Special characters should be valid, but if not, create directly for testing
@@ -316,6 +329,7 @@ func (f *TestFixture) SpecialCharsCommonRepresentation() *CommonRepresentation {
 			Version:                    1,
 			ReportedByReporterType:     "special-†‡•-reporter",
 			ReportedByReporterInstance: "special-™®©-instance",
+			TransactionId:              "test-transaction-id",
 		}
 	}
 	return cr
@@ -333,9 +347,9 @@ func (f *TestFixture) ValidReporterRepresentation() *ReporterRepresentation {
 			"ansible_host":            "host-1",
 		},
 		uuid.MustParse("dd1b73b9-3e33-4264-968c-e3ce55b9afec"), // reporterResourceID
-		1, // version
-		1, // generation
-		1, // commonVersion
+		1,                                                      // version
+		1,                                                      // generation
+		1,                                                      // commonVersion
 		false,
 		internal.StringPtr("2.7.16"),
 	)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1106,6 +1106,8 @@ components:
                     type: string
                 reporterVersion:
                     type: string
+                transactionId:
+                    type: string
         kessel.inventory.v1beta2.ResourceReference:
             type: object
             properties:


### PR DESCRIPTION
### PR Template:

## Describe your changes
Initial updates to support leveraging transaction id's as a means to deduplicate requests
* Updates the representation metadata proto to include an idempotency key, starting with just transaction id
* Updates the common_representation DB to include a new transaction_id column
* Updates the reporter_representation DB to include a new transaction_id column
* Updates any related tests to ensure passing -- does not add new test yet

This will allow for updating biz logic to leverage these new columns

```shell
# Example tables in sqllite
sqlite> PRAGMA table_info(common_representations);
+-----+-------------------------------+----------+---------+------------+----+
| cid |             name              |   type   | notnull | dflt_value | pk |
+-----+-------------------------------+----------+---------+------------+----+
| 0   | data                          | JSON     | 0       |            | 0  |
| 1   | resource_id                   | TEXT     | 0       |            | 1  |
| 2   | version                       | bigint   | 0       |            | 2  |
| 3   | reported_by_reporter_type     | TEXT     | 0       |            | 0  |
| 4   | reported_by_reporter_instance | TEXT     | 0       |            | 0  |
| 5   | transaction_id                | TEXT     | 0       |            | 0  |
| 6   | created_at                    | datetime | 0       |            | 0  |
+-----+-------------------------------+----------+---------+------------+----+

sqlite> PRAGMA table_info(reporter_representations);
+-----+----------------------+----------+---------+------------+----+
| cid |         name         |   type   | notnull | dflt_value | pk |
+-----+----------------------+----------+---------+------------+----+
| 0   | data                 | JSON     | 0       |            | 0  |
| 1   | reporter_resource_id | uuid     | 0       |            | 1  |
| 2   | version              | bigint   | 0       |            | 2  |
| 3   | generation           | bigint   | 0       |            | 3  |
| 4   | reporter_version     | TEXT     | 0       |            | 0  |
| 5   | common_version       | bigint   | 0       |            | 0  |
| 6   | transaction_id       | TEXT     | 0       |            | 0  |
| 7   | tombstone            | numeric  | 1       |            | 0  |
| 8   | created_at           | datetime | 0       |            | 0  |
+-----+----------------------+----------+---------+------------+----+
```

## Ticket reference (if applicable)
For RHCLOUD-42396