### PR TITLE
update old v1beta1 curl and grpc examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,13 +217,13 @@ To add a rhel-host to the inventory:
 To hit the REST endpoint use the following `curl` command
 
 ```shell
-curl -H "Content-Type: application/json" --data "@data/testData/v1beta1/host.json" http://localhost:8000/api/inventory/v1beta1/resources/rhel-hosts
+curl -X POST -H "Content-Type: application/json" --data "@data/testData/v1beta2/host.json" http://localhost:8000/api/inventory/v1beta2/resources
 ```
 
 To hit the gRPC endpoint use the following `grpcurl` command
 
 ```
-grpcurl -plaintext -d @ localhost:9000 kessel.inventory.v1beta1.resources.KesselRhelHostService.CreateRhelHost < data/testData/v1beta1/host.json
+grpcurl -plaintext -d @ localhost:9000 kessel.inventory.v1beta2.KesselInventoryService.ReportResource < data/testData/v1beta2/host.json
 ```
 
 To update it:
@@ -231,13 +231,13 @@ To update it:
 To hit the REST endpoint
 
 ```shell
-curl -XPUT -H "Content-Type: application/json" --data "@data/testData/v1beta1/host.json" http://localhost:8000/api/inventory/v1beta1/resources/rhel-hosts
+curl -X POST -H "Content-Type: application/json" --data "@data/testData/v1beta2/host.json" http://localhost:8000/api/inventory/v1beta2/resources
 ```
 
 To hit the gRPC endpoint
 
 ```
-grpcurl -plaintext -d @ localhost:9000 kessel.inventory.v1beta1.resources.KesselRhelHostService.UpdateRhelHost < data/testData/v1beta1/host.json
+grpcurl -plaintext -d @ localhost:9000 kessel.inventory.v1beta2.KesselInventoryService.ReportResource < data/testData/v1beta2/host.json
 ```
 
 
@@ -246,22 +246,22 @@ and finally, to delete it, note that we use a different file, as the only requir
 To hit the REST endpoint
 
 ```shell
-curl -XDELETE -H "Content-Type: application/json" --data "@data/testData/v1beta1/host-reporter.json" http://localhost:8000/api/inventory/v1beta1/resources/rhel-hosts
+curl -XDELETE -H "Content-Type: application/json" --data "@data/testData/v1beta2/delete-host.json" http://localhost:8000/api/inventory/v1beta2/resources
 ```
 
 To hit the gRPC endpoint
 
 ```
-grpcurl -plaintext -d @ localhost:9000 kessel.inventory.v1beta1.resources.KesselRhelHostService.DeleteRhelHost < data/testData/v1beta1/host-reporter.json
+grpcurl -plaintext -d @ localhost:9000 kessel.inventory.v1beta2.KesselInventoryService.DeleteResource < data/testData/v1beta2/delete-host.json
 ```
 To add a notifications integration (useful for testing in stage)
 
 ```shell
 # create the integration (auth is required for stage -- see internal docs)
-curl -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d @data/testData/v1beta1/notifications-integrations.json localhost:8000/api/inventory/v1beta1/resources/notifications-integrations
+curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d @data/testData/v1beta2/notifications-integrations.json localhost:8000/api/inventory/v1beta2/resources
 
 # delete the integration
-curl -X DELETE -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d @data/testData/v1beta1/notifications-integration-reporter.json localhost:8000/api/inventory/v1beta1/resources/notifications-integrations
+curl -X DELETE -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d @data/testData/v1beta2/delete-notifications-integration.json localhost:8000/api/inventory/v1beta2/resources
 
 ```
 ### Adding a new relationship (k8s-policy is propagated to k8s-cluster)


### PR DESCRIPTION
### PR Template:

## Describe your changes

- noticed we still had some of our old v1beta1 curl and grpc commands in the readme, updated to the new v1beta2 endpoints

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Update README examples to use v1beta2 API endpoints and data payloads

Documentation:
- Switch curl commands in README from v1beta1 to v1beta2 endpoints and update associated JSON file paths
- Switch grpcurl commands in README from v1beta1 service/method names to v1beta2 counterparts and update associated JSON file paths