### PR TITLE
RHCLOUD-42397: updates transaction IDs to add unique constraint; updates all tests for unique transaction ids to pass

### DIFF
--- a/internal/data/model/common_representation.go
+++ b/internal/data/model/common_representation.go
@@ -17,7 +17,7 @@ type CommonRepresentation struct {
 	Version                    uint      `gorm:"type:bigint;primaryKey;check:version >= 0"`
 	ReportedByReporterType     string    `gorm:"size:128"`
 	ReportedByReporterInstance string    `gorm:"size:128"`
-	TransactionId              string    `gorm:"size:128"`
+	TransactionId              string    `gorm:"size:128;index:ux_common_reps_txid_nn,where:transaction_id IS NOT NULL AND transaction_id != '',unique"`
 	CreatedAt                  time.Time
 }
 

--- a/internal/data/model/reporter_representation.go
+++ b/internal/data/model/reporter_representation.go
@@ -19,7 +19,7 @@ type ReporterRepresentation struct {
 	Generation         uint      `gorm:"type:bigint;primaryKey;check:generation >= 0"`
 	ReporterVersion    *string   `gorm:"size:128"`
 	CommonVersion      uint      `gorm:"type:bigint;check:common_version >= 0"`
-	TransactionId      string    `gorm:"size:128"`
+	TransactionId      string    `gorm:"size:128;index:ux_reporter_reps_txid_nn,where:transaction_id IS NOT NULL AND transaction_id != '',unique"`
 	Tombstone          bool      `gorm:"not null"`
 	CreatedAt          time.Time
 

--- a/internal/data/model/reporter_representation_test.go
+++ b/internal/data/model/reporter_representation_test.go
@@ -207,7 +207,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 			1,
 			1,
 			1,
-			"test-transaction-id",
+			"test-transaction-id-unicode-test",
 			false,
 			nil,
 		)
@@ -225,7 +225,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 			1,
 			1,
 			1,
-			"test-transaction-id",
+			"test-transaction-id-special-chars-test",
 			false,
 			nil,
 		)
@@ -241,7 +241,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 			4294967295, // Max uint32 Version
 			4294967295, // Max uint32 Generation
 			4294967295, // Max uint32 CommonVersion
-			"test-transaction-id",
+			"test-transaction-id-large-integers",
 			false,
 			nil,
 		)
@@ -257,7 +257,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 			1,
 			1,
 			1,
-			"test-transaction-id",
+			"test-transaction-id-empty-string",
 			false,
 			internal.StringPtr(""), // Empty ReporterVersion
 		)
@@ -273,7 +273,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 			1,
 			1,
 			1,
-			"test-transaction-id",
+			"test-transaction-id-nil-values",
 			false,
 			nil, // Nil ReporterVersion
 		)
@@ -324,7 +324,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 			1,
 			1,
 			1,
-			"test-transaction-id",
+			"test-transaction-id-complex-json",
 			false,
 			nil,
 		)
@@ -340,7 +340,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 			1,
 			1,
 			1,
-			"test-transaction-id",
+			"test-transaction-id-empty-json",
 			false,
 			nil,
 		)
@@ -370,7 +370,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 					tc.version,
 					1,
 					1,
-					"test-transaction-id",
+					"test-transaction-id-version-boundary",
 					false,
 					nil,
 				)
@@ -406,7 +406,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 					1,
 					tc.generation,
 					1,
-					"test-transaction-id",
+					"test-transaction-id-generation-boundary",
 					false,
 					nil,
 				)
@@ -439,7 +439,7 @@ func TestReporterRepresentation_EdgeCases(t *testing.T) {
 					1,
 					1,
 					1,
-					"test-transaction-id",
+					"test-transaction-id-tombstone-flag",
 					tc.tombstone,
 					nil,
 				)
@@ -717,5 +717,23 @@ func TestReporterRepresentation_Serialization(t *testing.T) {
 		if len(unmarshaled.Data) != 0 {
 			t.Errorf("Data should be empty after JSON round-trip, got: %v", unmarshaled.Data)
 		}
+	})
+
+	t.Run("should enforce unique TransactionID constraint", func(t *testing.T) {
+		t.Parallel()
+
+		// Test that different ReporterRepresentations can have different TransactionIDs
+		fixture := NewTestFixture(t)
+
+		// Create first representation
+		rr1 := fixture.ValidReporterRepresentation()
+		AssertEqual(t, "test-transaction-id-valid-reporter", rr1.TransactionId, "First representation should have correct TransactionID")
+
+		// Create second representation with different TransactionID
+		rr2 := fixture.ReporterRepresentationWithTombstone(false)
+		AssertEqual(t, "test-transaction-id-with-tombstone", rr2.TransactionId, "Second representation should have different TransactionID")
+
+		// Verify they have different TransactionIDs
+		AssertNotEqual(t, rr1.TransactionId, rr2.TransactionId, "Representations should have different TransactionIDs")
 	})
 }

--- a/internal/data/model/testdata.go
+++ b/internal/data/model/testdata.go
@@ -34,7 +34,7 @@ func (f *TestFixture) ValidCommonRepresentation() *CommonRepresentation {
 		1,
 		"hbi",
 		"3088be62-1c60-4884-b133-9200542d0b3f",
-		"test-transaction-id",
+		"test-transaction-id-valid-common",
 	)
 	if err != nil {
 		f.t.Fatalf("Failed to create valid CommonRepresentation: %v", err)
@@ -66,7 +66,7 @@ func (f *TestFixture) CommonRepresentationWithID(id string) *CommonRepresentatio
 		1,
 		"hbi",
 		"3088be62-1c60-4884-b133-9200542d0b3f",
-		"test-transaction-id",
+		"test-transaction-id-with-id",
 	)
 	if err != nil {
 		// For test cases expecting invalid data, return the struct anyway for testing
@@ -97,7 +97,7 @@ func (f *TestFixture) CommonRepresentationWithVersion(version uint) *CommonRepre
 		version,
 		"hbi",
 		"3088be62-1c60-4884-b133-9200542d0b3f",
-		"test-transaction-id",
+		"test-transaction-id-with-version",
 	)
 	if err != nil {
 		f.t.Fatalf("Cannot create CommonRepresentation with version %d: %v", version, err)
@@ -117,7 +117,7 @@ func (f *TestFixture) CommonRepresentationWithResourceType(resourceType string) 
 		1,
 		"hbi",
 		"3088be62-1c60-4884-b133-9200542d0b3f",
-		"test-transaction-id",
+		"test-transaction-id-with-resource-type",
 	)
 	if err != nil {
 		f.t.Fatalf("Cannot create CommonRepresentation with resource type %q: %v", resourceType, err)
@@ -137,7 +137,7 @@ func (f *TestFixture) CommonRepresentationWithReporterType(reporterType string) 
 		1,
 		reporterType,
 		"3088be62-1c60-4884-b133-9200542d0b3f",
-		"test-transaction-id",
+		"test-transaction-id-with-reporter-type",
 	)
 	if err != nil {
 		f.t.Fatalf("Cannot create CommonRepresentation with reporter type %q: %v", reporterType, err)
@@ -157,7 +157,7 @@ func (f *TestFixture) CommonRepresentationWithReporterInstance(reporterInstance 
 		1,
 		"hbi",
 		reporterInstance,
-		"test-transaction-id",
+		"test-transaction-id-with-reporter-instance",
 	)
 	if err != nil {
 		f.t.Fatalf("Cannot create CommonRepresentation with reporter instance %q: %v", reporterInstance, err)
@@ -175,7 +175,7 @@ func (f *TestFixture) CommonRepresentationWithData(data internal.JsonObject) *Co
 		1,
 		"hbi",
 		"3088be62-1c60-4884-b133-9200542d0b3f",
-		"test-transaction-id",
+		"test-transaction-id-with-data",
 	)
 	if err != nil {
 		f.t.Fatalf("Cannot create CommonRepresentation with data %+v: %v", data, err)
@@ -193,7 +193,7 @@ func (f *TestFixture) CommonRepresentationWithEmptyData() *CommonRepresentation 
 		1,
 		"hbi",
 		"3088be62-1c60-4884-b133-9200542d0b3f",
-		"test-transaction-id",
+		"test-transaction-id-with-empty-data",
 	)
 	if err != nil {
 		f.t.Fatalf("Cannot create CommonRepresentation with empty data: %v", err)
@@ -227,7 +227,7 @@ func (f *TestFixture) MinimalCommonRepresentation() *CommonRepresentation {
 		1,
 		"ACM",
 		"57a317b1-4040-4c26-8d41-dd589ba1d2eb",
-		"test-transaction-id",
+		"test-transaction-id-minimal",
 	)
 	if err != nil {
 		f.t.Fatalf("Failed to create minimal CommonRepresentation: %v", err)
@@ -245,7 +245,7 @@ func (f *TestFixture) MaximalCommonRepresentation() *CommonRepresentation {
 		4294967295, // Max uint32
 		"ACM",
 		"14c6b63e-49b2-4cc2-99de-5d914b657548",
-		"test-transaction-id",
+		"test-transaction-id-maximal",
 	)
 	if err != nil {
 		f.t.Fatalf("Failed to create maximal CommonRepresentation: %v", err)
@@ -267,7 +267,7 @@ func (f *TestFixture) UnicodeCommonRepresentation() *CommonRepresentation {
 		1,
 		"测试-reporter",
 		"测试-instance",
-		"test-transaction-id",
+		"test-transaction-id-unicode",
 	)
 	if err != nil {
 		// Unicode should be valid, but if not, create directly for testing
@@ -285,7 +285,7 @@ func (f *TestFixture) UnicodeCommonRepresentation() *CommonRepresentation {
 			Version:                    1,
 			ReportedByReporterType:     "测试-reporter",
 			ReportedByReporterInstance: "测试-instance",
-			TransactionId:              "test-transaction-id",
+			TransactionId:              "test-transaction-id-unicode",
 		}
 	}
 	return cr
@@ -308,7 +308,7 @@ func (f *TestFixture) SpecialCharsCommonRepresentation() *CommonRepresentation {
 		1,
 		"special-†‡•-reporter",
 		"special-™®©-instance",
-		"test-transaction-id",
+		"test-transaction-id-special-chars",
 	)
 	if err != nil {
 		// Special characters should be valid, but if not, create directly for testing
@@ -329,7 +329,7 @@ func (f *TestFixture) SpecialCharsCommonRepresentation() *CommonRepresentation {
 			Version:                    1,
 			ReportedByReporterType:     "special-†‡•-reporter",
 			ReportedByReporterInstance: "special-™®©-instance",
-			TransactionId:              "test-transaction-id",
+			TransactionId:              "test-transaction-id-special-chars",
 		}
 	}
 	return cr
@@ -350,7 +350,7 @@ func (f *TestFixture) ValidReporterRepresentation() *ReporterRepresentation {
 		1, // version
 		1, // generation
 		1, // commonVersion
-		"test-transaction-id",
+		"test-transaction-id-valid-reporter",
 		false,
 		internal.StringPtr("2.7.16"),
 	)
@@ -377,7 +377,7 @@ func (f *TestFixture) ReporterRepresentationWithLocalResourceID(localResourceID 
 		1,
 		1,
 		1,
-		"test-transaction-id",
+		"test-transaction-id-with-local-resource-id",
 		false,
 		internal.StringPtr("2.7.16"),
 	)
@@ -400,7 +400,7 @@ func (f *TestFixture) ReporterRepresentationWithResourceType(resourceType string
 		1,
 		1,
 		1,
-		"test-transaction-id",
+		"test-transaction-id-with-resource-type",
 		false,
 		internal.StringPtr("2.7.16"),
 	)
@@ -442,7 +442,7 @@ func (f *TestFixture) ReporterRepresentationWithTombstone(tombstone bool) *Repor
 		1,
 		1,
 		1,
-		"test-transaction-id",
+		"test-transaction-id-with-tombstone",
 		tombstone,
 		nil,
 	)
@@ -460,7 +460,7 @@ func (f *TestFixture) ReporterRepresentationWithReporterVersion(ver *string) *Re
 		2,
 		0,
 		1,
-		"test-transaction-id",
+		"test-transaction-id-with-reporter-version",
 		false,
 		ver,
 	)
@@ -478,7 +478,7 @@ func (f *TestFixture) ReporterRepresentationWithNilReporterVersion() *ReporterRe
 		1,
 		1,
 		1,
-		"test-transaction-id",
+		"test-transaction-id-with-nil-reporter-version",
 		false,
 		nil,
 	)

--- a/internal/data/resource_repository_test.go
+++ b/internal/data/resource_repository_test.go
@@ -115,7 +115,7 @@ func testRepositoryContract(t *testing.T, repo ResourceRepository, db *gorm.DB) 
 		consoleHref, _ := bizmodel.NewConsoleHref("https://console.example.com/updated")
 		reporterData, _ := bizmodel.NewRepresentation(map[string]interface{}{"updated": true})
 		commonData, _ := bizmodel.NewRepresentation(map[string]interface{}{"workspace_id": "updated-workspace"})
-		transactionId := bizmodel.NewTransactionId("test-transaction-id")
+		transactionId := bizmodel.NewTransactionId(fmt.Sprintf("test-transaction-id-update-contract-%s", uuid.New().String()))
 
 		err = foundResource.Update(key, apiHref, consoleHref, nil, reporterData, commonData, transactionId)
 		require.NoError(t, err, "Update should succeed")
@@ -237,7 +237,7 @@ func testRepositoryContract(t *testing.T, repo ResourceRepository, db *gorm.DB) 
 		consoleHref, _ := bizmodel.NewConsoleHref("https://console.example.com/contract-updated")
 		reporterData, _ := bizmodel.NewRepresentation(map[string]interface{}{"contract": "updated"})
 		commonData, _ := bizmodel.NewRepresentation(map[string]interface{}{"workspace_id": "contract-workspace"})
-		transactionId := bizmodel.NewTransactionId("test-transaction-id")
+		transactionId := bizmodel.NewTransactionId(fmt.Sprintf("test-transaction-id-lifecycle-contract-%s", uuid.New().String()))
 
 		err = foundResource.Update(key, apiHref, consoleHref, nil, reporterData, commonData, transactionId)
 		require.NoError(t, err, "Update should succeed")
@@ -707,7 +707,7 @@ func TestUniqueConstraint_ReporterResourceCompositeKey(t *testing.T) {
 				consoleHref, _ := bizmodel.NewConsoleHref("https://console.example.com/updated")
 				reporterData, _ := bizmodel.NewRepresentation(map[string]interface{}{"update": "1"})
 				commonData, _ := bizmodel.NewRepresentation(map[string]interface{}{"update": "1"})
-				transactionId := bizmodel.NewTransactionId("test-transaction-id")
+				transactionId := bizmodel.NewTransactionId(fmt.Sprintf("test-transaction-id-version-unique-%s", uuid.New().String()))
 
 				err = resource.Update(key, apiHref, consoleHref, nil, reporterData, commonData, transactionId)
 				require.NoError(t, err, "Update should succeed")
@@ -898,7 +898,7 @@ func TestResourceRepository_IdempotentOperations(t *testing.T) {
 				consoleHref, _ := bizmodel.NewConsoleHref("https://console.example.com/duplicate")
 				reporterData, _ := bizmodel.NewRepresentation(map[string]interface{}{"duplicate": "report"})
 				commonData, _ := bizmodel.NewRepresentation(map[string]interface{}{"workspace_id": "duplicate-workspace"})
-				transactionId := bizmodel.NewTransactionId("test-transaction-id")
+				transactionId := bizmodel.NewTransactionId(fmt.Sprintf("test-transaction-id-duplicate-idempotent-%s", uuid.New().String()))
 
 				err = foundResource1.Update(key, apiHref, consoleHref, nil, reporterData, commonData, transactionId)
 				require.NoError(t, err, "Update should succeed")
@@ -963,7 +963,7 @@ func TestResourceRepository_IdempotentOperations(t *testing.T) {
 						consoleHref, _ := bizmodel.NewConsoleHref(fmt.Sprintf("https://console.example.com/cycle-%d", cycle))
 						reporterData, _ := bizmodel.NewRepresentation(map[string]interface{}{"cycle": cycle})
 						commonData, _ := bizmodel.NewRepresentation(map[string]interface{}{"workspace_id": fmt.Sprintf("cycle-%d-workspace", cycle)})
-						transactionId := bizmodel.NewTransactionId("test-transaction-id")
+						transactionId := bizmodel.NewTransactionId(fmt.Sprintf("test-transaction-id-cycle-%d-idempotent-%s", cycle, uuid.New().String()))
 
 						err = foundResource.Update(key, apiHref, consoleHref, nil, reporterData, commonData, transactionId)
 						require.NoError(t, err, "Update should succeed in cycle %d", cycle)
@@ -1074,7 +1074,7 @@ func TestSave(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				updatedTransactionId := bizmodel.NewTransactionId("updated-transaction-id")
+				updatedTransactionId := bizmodel.NewTransactionId(fmt.Sprintf("updated-transaction-id-save-test-unique-%s", uuid.New().String()))
 
 				err = resource.Update(key, apiHref, consoleHref, nil, updatedReporterData, updatedCommonData, updatedTransactionId)
 				require.NoError(t, err)
@@ -1209,12 +1209,13 @@ func TestResourceRepository_MultipleHostsLifecycle(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			updatedTransactionId := bizmodel.NewTransactionId("updated-transaction-id")
+			updatedTransactionId1 := bizmodel.NewTransactionId(fmt.Sprintf("updated-transaction-id-multiple-hosts-unique-host1-%s", uuid.New().String()))
+			updatedTransactionId2 := bizmodel.NewTransactionId(fmt.Sprintf("updated-transaction-id-multiple-hosts-unique-host2-%s", uuid.New().String()))
 
-			err = foundHost1.Update(key1, apiHref, consoleHref, nil, updatedReporterData, updatedCommonData, updatedTransactionId)
+			err = foundHost1.Update(key1, apiHref, consoleHref, nil, updatedReporterData, updatedCommonData, updatedTransactionId1)
 			require.NoError(t, err, "Should update host1")
 
-			err = foundHost2.Update(key2, apiHref, consoleHref, nil, updatedReporterData, updatedCommonData, updatedTransactionId)
+			err = foundHost2.Update(key2, apiHref, consoleHref, nil, updatedReporterData, updatedCommonData, updatedTransactionId2)
 			require.NoError(t, err, "Should update host2")
 
 			err = repo.Save(db, *foundHost1, model_legacy.OperationTypeUpdated, "tx-update-host1")
@@ -1359,9 +1360,9 @@ func TestResourceRepository_PartialDataScenarios(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				updatedTransactionId := bizmodel.NewTransactionId("updated-transaction-id")
+				updatedTransactionId1 := bizmodel.NewTransactionId(fmt.Sprintf("updated-transaction-id-partial-data-unique-reporter-%s", uuid.New().String()))
 
-				err = foundResource.Update(key, apiHref, consoleHref, nil, reporterOnlyData, emptyCommonData, updatedTransactionId)
+				err = foundResource.Update(key, apiHref, consoleHref, nil, reporterOnlyData, emptyCommonData, updatedTransactionId1)
 				require.NoError(t, err, "Should update with reporter data only")
 
 				err = repo.Save(db, *foundResource, model_legacy.OperationTypeUpdated, "tx-reporter-update")
@@ -1381,7 +1382,9 @@ func TestResourceRepository_PartialDataScenarios(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				err = foundResource.Update(key, apiHref, consoleHref, nil, emptyReporterData, commonOnlyData, updatedTransactionId)
+				updatedTransactionId2 := bizmodel.NewTransactionId(fmt.Sprintf("updated-transaction-id-partial-data-unique-common-%s", uuid.New().String()))
+
+				err = foundResource.Update(key, apiHref, consoleHref, nil, emptyReporterData, commonOnlyData, updatedTransactionId2)
 				require.NoError(t, err, "Should update with common data only")
 
 				err = repo.Save(db, *foundResource, model_legacy.OperationTypeUpdated, "tx-common-update")
@@ -1486,7 +1489,7 @@ func TestSerializableUpdateFails(t *testing.T) {
 			consoleHref, _ := bizmodel.NewConsoleHref("https://console.example.com/updated")
 			repData, _ := bizmodel.NewRepresentation(map[string]interface{}{"name": "updated"})
 			comData, _ := bizmodel.NewRepresentation(map[string]interface{}{"workspace_id": "ws-serial"})
-			assert.NoError(t, resource.Update(key, apiHref, consoleHref, nil, repData, comData, "transaction-id-1"))
+			assert.NoError(t, resource.Update(key, apiHref, consoleHref, nil, repData, comData, "transaction-id-serializable-update"))
 
 			// Begin a conflicting serializable transaction and update the same resource
 			conflictTx := db.Begin(&sql.TxOptions{Isolation: sql.LevelSerializable})
@@ -1570,7 +1573,7 @@ func createTestResourceWithLocalId(t *testing.T, localResourceId string) bizmode
 	reporterResourceIdType, err := bizmodel.NewReporterResourceId(reporterResourceId)
 	require.NoError(t, err)
 
-	transactionId := bizmodel.NewTransactionId("test-transaction-id")
+	transactionId := bizmodel.NewTransactionId(fmt.Sprintf("test-transaction-id-basic-%s-%s", localResourceId, uuid.New().String()))
 
 	resource, err := bizmodel.NewResource(resourceIdType, localResourceIdType, resourceType, reporterType, reporterInstanceId, transactionId, reporterResourceIdType, apiHref, consoleHref, reporterRepresentation, commonRepresentation, nil)
 	require.NoError(t, err)
@@ -1637,7 +1640,7 @@ func createTestResourceWithLocalIdAndType(t *testing.T, localResourceId, resourc
 	commonRepresentation, err := bizmodel.NewRepresentation(commonData)
 	require.NoError(t, err)
 
-	transactionId := bizmodel.NewTransactionId("test-transaction-id")
+	transactionId := bizmodel.NewTransactionId(fmt.Sprintf("test-transaction-id-with-type-%s-%s-%s", localResourceId, resourceType, uuid.New().String()))
 
 	resource, err := bizmodel.NewResource(resourceIdType, localResourceIdType, resourceTypeType, reporterTypeType, reporterInstanceIdType, transactionId, reporterResourceIdType, apiHref, consoleHref, reporterRepresentation, commonRepresentation, nil)
 	require.NoError(t, err)
@@ -1691,7 +1694,7 @@ func createTestResourceWithReporterDataOnly(t *testing.T, localResourceId string
 	commonRepresentation, err := bizmodel.NewRepresentation(commonData)
 	require.NoError(t, err)
 
-	transactionId := bizmodel.NewTransactionId("test-transaction-id")
+	transactionId := bizmodel.NewTransactionId(fmt.Sprintf("test-transaction-id-reporter-only-%s-%s", localResourceId, uuid.New().String()))
 
 	resource, err := bizmodel.NewResource(resourceIdType, localResourceIdType, resourceType, reporterType, reporterInstanceId, transactionId, reporterResourceIdType, apiHref, consoleHref, reporterRepresentation, commonRepresentation, nil)
 	require.NoError(t, err)
@@ -1745,7 +1748,7 @@ func createTestResourceWithCommonDataOnly(t *testing.T, localResourceId string) 
 	commonRepresentation, err := bizmodel.NewRepresentation(commonData)
 	require.NoError(t, err)
 
-	transactionId := bizmodel.NewTransactionId("test-transaction-id")
+	transactionId := bizmodel.NewTransactionId(fmt.Sprintf("test-transaction-id-common-only-%s-%s", localResourceId, uuid.New().String()))
 
 	resource, err := bizmodel.NewResource(resourceIdType, localResourceIdType, resourceType, reporterType, reporterInstanceId, transactionId, reporterResourceIdType, apiHref, consoleHref, reporterRepresentation, commonRepresentation, nil)
 	require.NoError(t, err)
@@ -1797,7 +1800,7 @@ func createTestResourceWithMixedCase(t *testing.T) bizmodel.Resource {
 	commonRepresentation, err := bizmodel.NewRepresentation(commonData)
 	require.NoError(t, err)
 
-	transactionId := bizmodel.NewTransactionId("test-transaction-id")
+	transactionId := bizmodel.NewTransactionId(fmt.Sprintf("test-transaction-id-mixed-case-unique-%s", uuid.New().String()))
 
 	resource, err := bizmodel.NewResource(resourceIdType, localResourceIdType, resourceType, reporterType, reporterInstanceId, transactionId, reporterResourceIdType, apiHref, consoleHref, reporterRepresentation, commonRepresentation, nil)
 	require.NoError(t, err)
@@ -1849,7 +1852,7 @@ func createTestResourceWithReporter(t *testing.T, localResourceId, reporterType,
 	commonRepresentation, err := bizmodel.NewRepresentation(commonData)
 	require.NoError(t, err)
 
-	transactionId := bizmodel.NewTransactionId("test-transaction-id")
+	transactionId := bizmodel.NewTransactionId(fmt.Sprintf("test-transaction-id-with-reporter-%s-%s-%s", localResourceId, reporterType, uuid.New().String()))
 
 	resource, err := bizmodel.NewResource(resourceIdType, localResourceIdType, resourceType, reporterTypeType, reporterInstanceIdType, transactionId, reporterResourceIdType, apiHref, consoleHref, reporterRepresentation, commonRepresentation, nil)
 	require.NoError(t, err)
@@ -1921,7 +1924,7 @@ func TestFindVersionedRepresentationsByVersion(t *testing.T) {
 				require.NoError(t, err)
 				updatedReporter, err := bizmodel.NewRepresentation(map[string]interface{}{"hostname": "h"})
 				require.NoError(t, err)
-				transactionId := bizmodel.NewTransactionId("test-transaction-id")
+				transactionId := bizmodel.NewTransactionId(fmt.Sprintf("test-transaction-id-versioned-unique-%s", uuid.New().String()))
 				err = res.Update(key, "", "", nil, updatedReporter, updatedCommon, transactionId)
 				require.NoError(t, err)
 				require.NoError(t, repo.Save(db, res, model_legacy.OperationTypeUpdated, "tx2"))
@@ -2013,7 +2016,7 @@ func TestGetCurrentAndPreviousWorkspaceID_Integration(t *testing.T) {
 					updatedReporter, err := bizmodel.NewRepresentation(map[string]interface{}{"hostname": "updated-host"})
 					require.NoError(t, err)
 
-					transactionId := bizmodel.NewTransactionId("test-transaction-id")
+					transactionId := bizmodel.NewTransactionId(fmt.Sprintf("test-transaction-id-workspace-unique-%s", uuid.New().String()))
 					err = resource.Update(key, "", "", nil, updatedReporter, updatedCommon, transactionId)
 					require.NoError(t, err)
 					require.NoError(t, repo.Save(db, resource, model_legacy.OperationTypeUpdated, "tx-ws-update"))


### PR DESCRIPTION
### PR Template:

## Describe your changes

* Updates the GORM tags on transaction id's to ensure that non-null or non-empty string values are unique
  * since empty strings are not considered NULL in DB, added it to partial to ensure those that may provide an empty string dont break processing -- since this is temporary anyway as we plan to generate those ID's
* Updates a lot of tests as the transaction ID has to be unique for all sub tests and there are a lot (cursor updated to ensure all test cases are covered)

## Ticket reference (if applicable)
For RHCLOUD-42397

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

