### PR TITLE
RHCLOUD-43432: adds new business metrics dashboard, updates all local dashboard jsons

### DIFF
--- a/dashboards/grafana-dashboard-kessel-inventory-business-metrics.configmap.yaml
+++ b/dashboards/grafana-dashboard-kessel-inventory-business-metrics.configmap.yaml
@@ -38,6 +38,117 @@ data:
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
+                "axisLabel": "Resource Count",
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 1,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 6,
+            "x": 0,
+            "y": 0
+          },
+          "id": 2,
+          "options": {
+            "barRadius": 0,
+            "barWidth": 0.97,
+            "fullHighlight": false,
+            "groupWidth": 0.7,
+            "legend": {
+              "calcs": [],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "orientation": "auto",
+            "showValue": "auto",
+            "stacking": "normal",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "xTickLabelRotation": 0,
+            "xTickLabelSpacing": 0
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by (resource_type, reporter_name) (max by (resource_type, reporter_name, reporter_id) (kessel_inventory_resource_count))",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Kessel Inventory: Resource Count by Type and Reporter",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                }
+              }
+            },
+            {
+              "id": "groupingToMatrix",
+              "options": {
+                "columnField": "reporter_name",
+                "emptyValue": "null",
+                "rowField": "resource_type",
+                "valueField": "Value"
+              }
+            }
+          ],
+          "type": "barchart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
                 "axisLabel": "Number of Workspaces",
                 "axisPlacement": "auto",
                 "fillOpacity": 80,
@@ -72,9 +183,9 @@ data:
             "overrides": []
           },
           "gridPos": {
-            "h": 12,
-            "w": 24,
-            "x": 0,
+            "h": 11,
+            "w": 18,
+            "x": 6,
             "y": 0
           },
           "id": 1,
@@ -107,7 +218,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1.0\"}),\"bucket\", \"1\", \"\", \"\")",
+              "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1.0\"}),\"bucket\", \"1\", \"\", \"\")",
               "format": "table",
               "instant": true,
               "refId": "A"
@@ -118,7 +229,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"2.0\"}) - sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1.0\"}), \"bucket\", \"2\", \"\", \"\")",
+              "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"2.0\"}) - max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1.0\"}), \"bucket\", \"2\", \"\", \"\")",
               "format": "table",
               "instant": true,
               "refId": "B"
@@ -128,7 +239,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"5.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"2.0\"}),\"bucket\", \"3-5\", \"\", \"\")",
+              "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"5.0\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"2.0\"}),\"bucket\", \"3-5\", \"\", \"\")",
               "format": "table",
               "instant": true,
               "refId": "C"
@@ -138,7 +249,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"10.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"5.0\"}),\"bucket\", \"6-10\", \"\", \"\")",
+              "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"10.0\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"5.0\"}),\"bucket\", \"6-10\", \"\", \"\")",
               "format": "table",
               "instant": true,
               "refId": "D"
@@ -148,7 +259,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"20.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"10.0\"}),\"bucket\", \"11-20\", \"\", \"\")",
+              "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"20.0\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"10.0\"}),\"bucket\", \"11-20\", \"\", \"\")",
               "format": "table",
               "instant": true,
               "refId": "E"
@@ -158,7 +269,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"50.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"20.0\"}),\"bucket\", \"21-50\", \"\", \"\")",
+              "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"50.0\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"20.0\"}),\"bucket\", \"21-50\", \"\", \"\")",
               "format": "table",
               "instant": true,
               "refId": "F"
@@ -168,7 +279,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"100.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"50.0\"}),\"bucket\", \"51-100\", \"\", \"\")",
+              "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"100.0\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"50.0\"}),\"bucket\", \"51-100\", \"\", \"\")",
               "format": "table",
               "instant": true,
               "refId": "G"
@@ -178,7 +289,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"200.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"100.0\"}),\"bucket\", \"101-200\", \"\", \"\")",
+              "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"200.0\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"100.0\"}),\"bucket\", \"101-200\", \"\", \"\")",
               "format": "table",
               "instant": true,
               "refId": "H"
@@ -188,7 +299,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"500.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"200.0\"}),\"bucket\", \"201-500\", \"\", \"\")",
+              "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"500.0\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"200.0\"}),\"bucket\", \"201-500\", \"\", \"\")",
               "format": "table",
               "instant": true,
               "refId": "I"
@@ -198,7 +309,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1000.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"500.0\"}),\"bucket\", \"501-1000\", \"\", \"\")",
+              "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1000.0\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"500.0\"}),\"bucket\", \"501-1000\", \"\", \"\")",
               "format": "table",
               "instant": true,
               "refId": "J"
@@ -208,7 +319,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"+Inf\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1000.0\"}),\"bucket\", \"1001+\", \"\", \"\")",
+              "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"+Inf\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1000.0\"}),\"bucket\", \"1001+\", \"\", \"\")",
               "format": "table",
               "instant": true,
               "refId": "K"
@@ -299,7 +410,7 @@ data:
       "timezone": "browser",
       "title": "Kessel Inventory - Business Metrics",
       "uid": "adx9xqk",
-      "version": 1
+      "version": 2
     }
 kind: ConfigMap
 metadata:

--- a/dashboards/grafana-dashboard-kessel-inventory-business-metrics.configmap.yaml
+++ b/dashboards/grafana-dashboard-kessel-inventory-business-metrics.configmap.yaml
@@ -1,0 +1,299 @@
+apiVersion: v1
+data:
+  grafana-dashboard-kessel-inventory-business-metrics.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 1102304,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Number of Workspaces",
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 1,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "barRadius": 0,
+            "barWidth": 0.97,
+            "fullHighlight": false,
+            "groupWidth": 0.7,
+            "legend": {
+              "calcs": [],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "orientation": "auto",
+            "showValue": "auto",
+            "stacking": "normal",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "xTickLabelRotation": 0,
+            "xTickLabelSpacing": 0
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1.0\"}),\"bucket\", \"1\", \"\", \"\")",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"2.0\"}) - sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1.0\"}), \"bucket\", \"2\", \"\", \"\")",
+              "format": "table",
+              "instant": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"5.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"2.0\"}),\"bucket\", \"3-5\", \"\", \"\")",
+              "format": "table",
+              "instant": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"10.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"5.0\"}),\"bucket\", \"6-10\", \"\", \"\")",
+              "format": "table",
+              "instant": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"20.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"10.0\"}),\"bucket\", \"11-20\", \"\", \"\")",
+              "format": "table",
+              "instant": true,
+              "refId": "E"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"50.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"20.0\"}),\"bucket\", \"21-50\", \"\", \"\")",
+              "format": "table",
+              "instant": true,
+              "refId": "F"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"100.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"50.0\"}),\"bucket\", \"51-100\", \"\", \"\")",
+              "format": "table",
+              "instant": true,
+              "refId": "G"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"200.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"100.0\"}),\"bucket\", \"101-200\", \"\", \"\")",
+              "format": "table",
+              "instant": true,
+              "refId": "H"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"500.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"200.0\"}),\"bucket\", \"201-500\", \"\", \"\")",
+              "format": "table",
+              "instant": true,
+              "refId": "I"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1000.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"500.0\"}),\"bucket\", \"501-1000\", \"\", \"\")",
+              "format": "table",
+              "instant": true,
+              "refId": "J"
+            }
+          ],
+          "title": "Kessel Inventory: Workspaces Grouped by Resource Count",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "Count",
+                "mode": "reduceRow",
+                "reduce": {
+                  "reducer": "sum"
+                },
+                "replaceFields": false
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Value #A": true,
+                  "Value #B": true,
+                  "Value #C": true,
+                  "Value #D": true,
+                  "Value #E": true,
+                  "Value #F": true,
+                  "Value #G": true,
+                  "Value #H": true,
+                  "Value #I": true,
+                  "Value #J": true
+                }
+              }
+            },
+            {
+              "id": "groupingToMatrix",
+              "options": {
+                "columnField": "resource_type",
+                "emptyValue": "null",
+                "rowField": "bucket",
+                "valueField": "Count"
+              }
+            }
+          ],
+          "type": "barchart"
+        }
+      ],
+      "preload": false,
+      "schemaVersion": 41,
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "text": "crcs02ue1-prometheus",
+              "value": "PDD8BE47D10408F45"
+            },
+            "description": "Choose between the production, stage, or Govcloud environments",
+            "label": "Datasource",
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "/(crcp01ue1-prometheus)|(crcfrp01ugw1-prometheus)|(crcs02ue1-prometheus)|(crcfrs01ugw1-prometheus)|(hccs01ue1-prometheus)|(hccp01ue1-prometheus)/",
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Kessel Inventory - Business Metrics",
+      "uid": "adx9xqk",
+      "version": 1
+    }
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-kessel-business-metrics
+  labels:
+    grafana_dashboard: "true"
+  annotations:
+    grafana-folder: /grafana-dashboard-definitions/Kessel

--- a/dashboards/grafana-dashboard-kessel-inventory-business-metrics.configmap.yaml
+++ b/dashboards/grafana-dashboard-kessel-inventory-business-metrics.configmap.yaml
@@ -202,6 +202,16 @@ data:
               "format": "table",
               "instant": true,
               "refId": "J"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"+Inf\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1000.0\"}),\"bucket\", \"1001+\", \"\", \"\")",
+              "format": "table",
+              "instant": true,
+              "refId": "K"
             }
           ],
           "title": "Kessel Inventory: Workspaces Grouped by Resource Count",
@@ -242,7 +252,8 @@ data:
                   "Value #G": true,
                   "Value #H": true,
                   "Value #I": true,
-                  "Value #J": true
+                  "Value #J": true,
+                  "Value #K": true
                 }
               }
             },

--- a/development/configs/monitoring/dashboards/grafana-dashboard-kessel-inventory-api-ops.configmap.json
+++ b/development/configs/monitoring/dashboards/grafana-dashboard-kessel-inventory-api-ops.configmap.json
@@ -5163,7 +5163,8 @@
                     "value": 80
                   }
                 ]
-              }
+              },
+              "unit": "s"
             },
             "overrides": []
           },
@@ -6147,9 +6148,14 @@
             "selected": false,
             "text": "kessel-prod",
             "value": "kessel-prod"
+          },
+          {
+            "selected": false,
+            "text": "kessel-testing-perf",
+            "value": "kessel-testing-perf"
           }
         ],
-        "query": "kessel-stage,kessel-prod",
+        "query": "kessel-stage,kessel-prod,kessel-testing-perf",
         "type": "custom"
       },
       {

--- a/development/configs/monitoring/dashboards/grafana-dashboard-kessel-inventory-api.configmap.json
+++ b/development/configs/monitoring/dashboards/grafana-dashboard-kessel-inventory-api.configmap.json
@@ -2707,5 +2707,5 @@
   "timezone": "browser",
   "title": "Kessel - Inventory API",
   "uid": "ddxs3i6o0xpmof",
-  "version": 11
+  "version": 12
 }

--- a/development/configs/monitoring/dashboards/grafana-dashboard-kessel-inventory-business-metrics.configmap.json
+++ b/development/configs/monitoring/dashboards/grafana-dashboard-kessel-inventory-business-metrics.configmap.json
@@ -199,6 +199,16 @@
           "format": "table",
           "instant": true,
           "refId": "J"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"+Inf\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1000.0\"}),\"bucket\", \"1001+\", \"\", \"\")",
+          "format": "table",
+          "instant": true,
+          "refId": "K"
         }
       ],
       "title": "Kessel Inventory: Workspaces Grouped by Resource Count",
@@ -239,7 +249,8 @@
               "Value #G": true,
               "Value #H": true,
               "Value #I": true,
-              "Value #J": true
+              "Value #J": true,
+              "Value #K": true
             }
           }
         },

--- a/development/configs/monitoring/dashboards/grafana-dashboard-kessel-inventory-business-metrics.configmap.json
+++ b/development/configs/monitoring/dashboards/grafana-dashboard-kessel-inventory-business-metrics.configmap.json
@@ -1,0 +1,289 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1102304,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Number of Workspaces",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "normal",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "11.6.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1.0\"}),\"bucket\", \"1\", \"\", \"\")",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"2.0\"}) - sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1.0\"}), \"bucket\", \"2\", \"\", \"\")",
+          "format": "table",
+          "instant": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"5.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"2.0\"}),\"bucket\", \"3-5\", \"\", \"\")",
+          "format": "table",
+          "instant": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"10.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"5.0\"}),\"bucket\", \"6-10\", \"\", \"\")",
+          "format": "table",
+          "instant": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"20.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"10.0\"}),\"bucket\", \"11-20\", \"\", \"\")",
+          "format": "table",
+          "instant": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"50.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"20.0\"}),\"bucket\", \"21-50\", \"\", \"\")",
+          "format": "table",
+          "instant": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"100.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"50.0\"}),\"bucket\", \"51-100\", \"\", \"\")",
+          "format": "table",
+          "instant": true,
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"200.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"100.0\"}),\"bucket\", \"101-200\", \"\", \"\")",
+          "format": "table",
+          "instant": true,
+          "refId": "H"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"500.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"200.0\"}),\"bucket\", \"201-500\", \"\", \"\")",
+          "format": "table",
+          "instant": true,
+          "refId": "I"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1000.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"500.0\"}),\"bucket\", \"501-1000\", \"\", \"\")",
+          "format": "table",
+          "instant": true,
+          "refId": "J"
+        }
+      ],
+      "title": "Kessel Inventory: Workspaces Grouped by Resource Count",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Count",
+            "mode": "reduceRow",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Value #A": true,
+              "Value #B": true,
+              "Value #C": true,
+              "Value #D": true,
+              "Value #E": true,
+              "Value #F": true,
+              "Value #G": true,
+              "Value #H": true,
+              "Value #I": true,
+              "Value #J": true
+            }
+          }
+        },
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "resource_type",
+            "emptyValue": "null",
+            "rowField": "bucket",
+            "valueField": "Count"
+          }
+        }
+      ],
+      "type": "barchart"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "crcs02ue1-prometheus",
+          "value": "PDD8BE47D10408F45"
+        },
+        "description": "Choose between the production, stage, or Govcloud environments",
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "/(prometheus.*)/",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Kessel Inventory - Business Metrics",
+  "uid": "adx9xqk",
+  "version": 1
+}

--- a/development/configs/monitoring/dashboards/grafana-dashboard-kessel-inventory-business-metrics.configmap.json
+++ b/development/configs/monitoring/dashboards/grafana-dashboard-kessel-inventory-business-metrics.configmap.json
@@ -35,6 +35,117 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
+            "axisLabel": "Resource Count",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "normal",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "11.6.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (resource_type, reporter_name) (max by (resource_type, reporter_name, reporter_id) (kessel_inventory_resource_count))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Kessel Inventory: Resource Count by Type and Reporter",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            }
+          }
+        },
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "reporter_name",
+            "emptyValue": "null",
+            "rowField": "resource_type",
+            "valueField": "Value"
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "Number of Workspaces",
             "axisPlacement": "auto",
             "fillOpacity": 80,
@@ -69,9 +180,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 12,
-        "w": 24,
-        "x": 0,
+        "h": 11,
+        "w": 18,
+        "x": 6,
         "y": 0
       },
       "id": 1,
@@ -104,7 +215,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1.0\"}),\"bucket\", \"1\", \"\", \"\")",
+          "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1.0\"}),\"bucket\", \"1\", \"\", \"\")",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -115,7 +226,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"2.0\"}) - sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1.0\"}), \"bucket\", \"2\", \"\", \"\")",
+          "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"2.0\"}) - max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1.0\"}), \"bucket\", \"2\", \"\", \"\")",
           "format": "table",
           "instant": true,
           "refId": "B"
@@ -125,7 +236,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"5.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"2.0\"}),\"bucket\", \"3-5\", \"\", \"\")",
+          "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"5.0\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"2.0\"}),\"bucket\", \"3-5\", \"\", \"\")",
           "format": "table",
           "instant": true,
           "refId": "C"
@@ -135,7 +246,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"10.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"5.0\"}),\"bucket\", \"6-10\", \"\", \"\")",
+          "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"10.0\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"5.0\"}),\"bucket\", \"6-10\", \"\", \"\")",
           "format": "table",
           "instant": true,
           "refId": "D"
@@ -145,7 +256,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"20.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"10.0\"}),\"bucket\", \"11-20\", \"\", \"\")",
+          "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"20.0\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"10.0\"}),\"bucket\", \"11-20\", \"\", \"\")",
           "format": "table",
           "instant": true,
           "refId": "E"
@@ -155,7 +266,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"50.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"20.0\"}),\"bucket\", \"21-50\", \"\", \"\")",
+          "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"50.0\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"20.0\"}),\"bucket\", \"21-50\", \"\", \"\")",
           "format": "table",
           "instant": true,
           "refId": "F"
@@ -165,7 +276,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"100.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"50.0\"}),\"bucket\", \"51-100\", \"\", \"\")",
+          "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"100.0\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"50.0\"}),\"bucket\", \"51-100\", \"\", \"\")",
           "format": "table",
           "instant": true,
           "refId": "G"
@@ -175,7 +286,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"200.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"100.0\"}),\"bucket\", \"101-200\", \"\", \"\")",
+          "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"200.0\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"100.0\"}),\"bucket\", \"101-200\", \"\", \"\")",
           "format": "table",
           "instant": true,
           "refId": "H"
@@ -185,7 +296,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"500.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"200.0\"}),\"bucket\", \"201-500\", \"\", \"\")",
+          "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"500.0\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"200.0\"}),\"bucket\", \"201-500\", \"\", \"\")",
           "format": "table",
           "instant": true,
           "refId": "I"
@@ -195,7 +306,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1000.0\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"500.0\"}),\"bucket\", \"501-1000\", \"\", \"\")",
+          "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1000.0\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"500.0\"}),\"bucket\", \"501-1000\", \"\", \"\")",
           "format": "table",
           "instant": true,
           "refId": "J"
@@ -205,7 +316,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"+Inf\"})- sum by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1000.0\"}),\"bucket\", \"1001+\", \"\", \"\")",
+          "expr": "label_replace(max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"+Inf\"})- max by (resource_type) (kessel_inventory_resources_per_workspace_bucket{le=\"1000.0\"}),\"bucket\", \"1001+\", \"\", \"\")",
           "format": "table",
           "instant": true,
           "refId": "K"
@@ -296,5 +407,5 @@
   "timezone": "browser",
   "title": "Kessel Inventory - Business Metrics",
   "uid": "adx9xqk",
-  "version": 1
+  "version": 5
 }


### PR DESCRIPTION
### PR Template:

## Describe your changes
* Adds dashboard for visualizing business related metrics
* updates local dashboards for local metrics testing

New business metrics dashboard based on sample dashboard provided by Ryan Abbott

Sample dashboard in stage: https://grafana.stage.devshift.net/goto/XXJAhQtDR?orgId=1

## Ticket reference (if applicable)
For RHCLOUD-43432


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Grafana dashboard "Kessel Inventory - Business Metrics" with two bar-chart panels: resource counts by type/reporter and workspaces grouped by resource-count buckets; default time range is last 30 minutes.

* **Enhancements**
  * Added a new testing namespace option for monitoring dashboards.
  * Set duration display units to seconds for relevant panels.
  * Incremented a dashboard metadata version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->