### PR TITLE
RHCLOUD-42184: Support empty reporter representation data

### DIFF
--- a/internal/biz/model/common.go
+++ b/internal/biz/model/common.go
@@ -394,6 +394,11 @@ func NewRepresentation(data internal.JsonObject) (Representation, error) {
 	return Representation(data), nil
 }
 
+// NewEmptyRepresentation returns a non-nil empty JSON object for reporter/common payloads.
+func NewEmptyRepresentation() Representation {
+	return Representation(map[string]interface{}{})
+}
+
 func (r Representation) Data() internal.JsonObject {
 	return internal.JsonObject(r)
 }

--- a/internal/biz/model/reporter_representation.go
+++ b/internal/biz/model/reporter_representation.go
@@ -41,7 +41,7 @@ func NewReporterDataRepresentation(
 		return ReporterDataRepresentation{}, fmt.Errorf("%w: ReporterResourceId", ErrInvalidUUID)
 	}
 
-	if len(data) == 0 {
+	if data == nil {
 		return ReporterDataRepresentation{}, fmt.Errorf("%w: ReporterDataRepresentation data", ErrInvalidData)
 	}
 

--- a/internal/biz/model/reporter_representation_test.go
+++ b/internal/biz/model/reporter_representation_test.go
@@ -114,7 +114,7 @@ func TestReporterDataRepresentation_Initialization(t *testing.T) {
 		assertInvalidReporterDataRepresentation(t, dataRep, err, ErrInvalidData)
 	})
 
-	t.Run("should reject data representation with empty data", func(t *testing.T) {
+	t.Run("should create data representation with empty data (optional reporter payload)", func(t *testing.T) {
 		t.Parallel()
 
 		dataRep, err := NewReporterDataRepresentation(
@@ -127,7 +127,7 @@ func TestReporterDataRepresentation_Initialization(t *testing.T) {
 			fixture.ValidTransactionIdType(),
 		)
 
-		assertInvalidReporterDataRepresentation(t, dataRep, err, ErrInvalidData)
+		assertValidReporterDataRepresentation(t, dataRep, err, "empty reporter data")
 	})
 
 	t.Run("should reject data representation with empty reporter resource ID", func(t *testing.T) {

--- a/internal/biz/model/resource.go
+++ b/internal/biz/model/resource.go
@@ -54,6 +54,13 @@ func NewResource(id ResourceId, localResourceId LocalResourceId, resourceType Re
 		return Resource{}, fmt.Errorf("resource invalid ReporterResource: %w", err)
 	}
 
+	if len(reporterRepresentationData) == 0 && len(commonRepresentationData) > 0 {
+		reporterRepresentationData = NewEmptyRepresentation()
+	}
+	if len(reporterRepresentationData) == 0 && len(commonRepresentationData) == 0 {
+		reporterRepresentationData = NewEmptyRepresentation()
+	}
+
 	resourceEvent, err := resourceEventAndRepresentations(
 		reporterResource.resourceID,
 		resourceType,
@@ -133,6 +140,13 @@ func (r *Resource) Update(
 		if err != nil {
 			return err
 		}
+	}
+
+	if len(reporterRepresentationData) == 0 && len(commonRepresentationData) > 0 {
+		reporterRepresentationData = NewEmptyRepresentation()
+	}
+	if len(reporterRepresentationData) == 0 && len(commonRepresentationData) == 0 {
+		reporterRepresentationData = NewEmptyRepresentation()
 	}
 
 	resourceEvent, err := resourceEventAndRepresentations(

--- a/internal/biz/usecase/resources/resource_service.go
+++ b/internal/biz/usecase/resources/resource_service.go
@@ -48,17 +48,6 @@ var (
 	ErrSelfSubjectMissing = errors.New("self subject missing")
 )
 
-// RepresentationRequiredError indicates a required representation was not provided (nil).
-// Kind identifies which representation is missing (e.g. "reporter", "common").
-// TODO: the logic is not correct around this currently, but this can be fixed later
-type RepresentationRequiredError struct {
-	Kind string
-}
-
-func (e *RepresentationRequiredError) Error() string {
-	return fmt.Sprintf("invalid %s representation: representation required", e.Kind)
-}
-
 const listenTimeout = 10 * time.Second
 
 // UsecaseConfig contains configuration flags that control the behavior of usecase operations.
@@ -142,10 +131,6 @@ func (uc *Usecase) ReportResource(ctx context.Context, cmd ReportResourceCommand
 
 	// Validate command against schemas
 	if err := uc.validateReportResourceCommand(ctx, cmd); err != nil {
-		var repReqErr *RepresentationRequiredError
-		if errors.As(err, &repReqErr) {
-			return err
-		}
 		return status.Errorf(codes.InvalidArgument, "failed validation for report resource: %v", err)
 	}
 

--- a/internal/biz/usecase/resources/resource_service.go
+++ b/internal/biz/usecase/resources/resource_service.go
@@ -640,8 +640,9 @@ func (uc *Usecase) enforceMetaAuthzObject(ctx context.Context, relation metaauth
 }
 
 // validateReportResourceCommand validates a ReportResourceCommand against schemas.
-// It checks that the reporter is allowed for the resource type,
-// and validates both reporter and common representations.
+// It checks that the reporter is allowed for the resource type, and validates
+// reporter and/or common representations when non-empty (metadata-only requests
+// omit both).
 func (uc *Usecase) validateReportResourceCommand(ctx context.Context, cmd ReportResourceCommand) error {
 	resourceType := cmd.ResourceType.String()
 	reporterType := cmd.ReporterType.String()
@@ -660,29 +661,22 @@ func (uc *Usecase) validateReportResourceCommand(ctx context.Context, cmd Report
 		return fmt.Errorf("reporter %s does not report resource types: %s", reporterType, resourceType)
 	}
 
-	if cmd.ReporterRepresentation == nil {
-		return &RepresentationRequiredError{Kind: "reporter"}
+	if cmd.ReporterRepresentation != nil {
+		sanitizedReporterRepresentation := removeNulls(map[string]interface{}(*cmd.ReporterRepresentation))
+		if len(sanitizedReporterRepresentation) > 0 {
+			if err := uc.schemaService.ReporterShallowValidate(ctx, resourceType, reporterType, sanitizedReporterRepresentation); err != nil {
+				return err
+			}
+		}
 	}
 
-	sanitizedReporterRepresentation := removeNulls(map[string]interface{}(*cmd.ReporterRepresentation))
-
-	// Validate reporter-specific data using the sanitized map
-	if err := uc.schemaService.ReporterShallowValidate(ctx, resourceType, reporterType, sanitizedReporterRepresentation); err != nil {
-		return err
-	}
-
-	// Allow nil common representation — CommonShallowValidate will reject it
-	// only if the schema for this resource type declares required fields.
-	var commonRepresentation map[string]interface{}
 	if cmd.CommonRepresentation != nil {
-		commonRepresentation = map[string]interface{}(*cmd.CommonRepresentation)
-	} else {
-		commonRepresentation = map[string]interface{}{}
-	}
-
-	// Validate common data
-	if err := uc.schemaService.CommonShallowValidate(ctx, resourceType, commonRepresentation); err != nil {
-		return err
+		commonRepresentation := map[string]interface{}(*cmd.CommonRepresentation)
+		if len(commonRepresentation) > 0 {
+			if err := uc.schemaService.CommonShallowValidate(ctx, resourceType, commonRepresentation); err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/internal/biz/usecase/resources/resource_service_test.go
+++ b/internal/biz/usecase/resources/resource_service_test.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -1672,15 +1671,6 @@ func TestReportResource_ValidationErrors(t *testing.T) {
 			cmd:         fixture(t).Basic("host", "unknown_reporter", "instance-1", "test-host", "ws-123"),
 			expectError: "reporter unknown_reporter does not report resource types: host",
 		},
-		{
-			name: "missing reporter representation",
-			cmd: func() ReportResourceCommand {
-				cmd := fixture(t).Basic("host", "hbi", "instance-1", "test-host", "ws-123")
-				cmd.ReporterRepresentation = nil
-				return cmd
-			}(),
-			expectError: "invalid reporter representation: representation required",
-		},
 	}
 
 	for _, tc := range tests {
@@ -1880,9 +1870,9 @@ func TestReportResource_SchemaValidation(t *testing.T) {
 // These tests verify the exact error message format returned by the usecase layer.
 // They serve as a contract and must be updated if error formats change.
 
-// TestReportResource_RepresentationRequiredError tests that nil representations
-// return RepresentationRequiredError with the correct message format.
-func TestReportResource_RepresentationRequiredError(t *testing.T) {
+// TestReportResource_OptionalRepresentations verifies common-only and metadata-only
+// ReportResource commands succeed without a reporter payload.
+func TestReportResource_OptionalRepresentations(t *testing.T) {
 	ctx := testAuthzContext()
 	schemaRepo := newFakeSchemaRepository(t)
 	usecase := New(
@@ -1904,25 +1894,25 @@ func TestReportResource_RepresentationRequiredError(t *testing.T) {
 		name                   string
 		reporterRepresentation *model.Representation
 		commonRepresentation   *model.Representation
-		expectErrorMsg         string
+		localResourceIdSuffix  string
 	}{
 		{
-			name:                   "nil reporter representation",
+			name:                   "nil reporter with common",
 			reporterRepresentation: nil,
 			commonRepresentation:   &commonRep,
-			expectErrorMsg:         "invalid reporter representation: representation required",
+			localResourceIdSuffix:  "common-only",
 		},
 		{
-			name:                   "both nil",
+			name:                   "both nil metadata only",
 			reporterRepresentation: nil,
 			commonRepresentation:   nil,
-			expectErrorMsg:         "invalid reporter representation: representation required",
+			localResourceIdSuffix:  "metadata-only",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			localResId, _ := model.NewLocalResourceId("test-host")
+			localResId, _ := model.NewLocalResourceId("test-host-" + tc.localResourceIdSuffix)
 			resType, _ := model.NewResourceType("host")
 			repType, _ := model.NewReporterType("hbi")
 			repInstanceId, _ := model.NewReporterInstanceId("instance-1")
@@ -1940,12 +1930,7 @@ func TestReportResource_RepresentationRequiredError(t *testing.T) {
 			}
 
 			err := usecase.ReportResource(ctx, cmd)
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), tc.expectErrorMsg)
-
-			// Verify it's a RepresentationRequiredError type
-			var repReqErr *RepresentationRequiredError
-			assert.True(t, errors.As(err, &repReqErr), "expected RepresentationRequiredError type")
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/internal/middleware/error_mapping.go
+++ b/internal/middleware/error_mapping.go
@@ -54,12 +54,6 @@ func MapError(err error) error {
 
 	log.Errorf("request failed with application error. mapping to status code. error: %v", err)
 
-	// Typed errors (matched by type via errors.As)
-	var repReqErr *resources.RepresentationRequiredError
-	if errors.As(err, &repReqErr) {
-		return status.Errorf(codes.InvalidArgument, "invalid %s representation: representation required", repReqErr.Kind)
-	}
-
 	switch {
 	// Application-layer errors (from usecase)
 	case errors.Is(err, resources.ErrMetaAuthzContextMissing):

--- a/internal/service/resources/kesselinventoryservice.go
+++ b/internal/service/resources/kesselinventoryservice.go
@@ -638,20 +638,26 @@ func toReportResourceCommand(r *pb.ReportResourceRequest) (resources.ReportResou
 
 	var reporterRepresentation *model.Representation
 	if r.GetRepresentations().GetReporter() != nil {
-		rep, err := model.NewRepresentation(r.GetRepresentations().GetReporter().AsMap())
-		if err != nil {
-			return resources.ReportResourceCommand{}, fmt.Errorf("invalid reporter representation: %w", err)
+		reporterMap := r.GetRepresentations().GetReporter().AsMap()
+		if len(reporterMap) > 0 {
+			rep, err := model.NewRepresentation(reporterMap)
+			if err != nil {
+				return resources.ReportResourceCommand{}, fmt.Errorf("invalid reporter representation: %w", err)
+			}
+			reporterRepresentation = &rep
 		}
-		reporterRepresentation = &rep
 	}
 
 	var commonRepresentation *model.Representation
 	if r.GetRepresentations().GetCommon() != nil {
-		rep, err := model.NewRepresentation(r.GetRepresentations().GetCommon().AsMap())
-		if err != nil {
-			return resources.ReportResourceCommand{}, fmt.Errorf("invalid common representation: %w", err)
+		commonMap := r.GetRepresentations().GetCommon().AsMap()
+		if len(commonMap) > 0 {
+			rep, err := model.NewRepresentation(commonMap)
+			if err != nil {
+				return resources.ReportResourceCommand{}, fmt.Errorf("invalid common representation: %w", err)
+			}
+			commonRepresentation = &rep
 		}
-		commonRepresentation = &rep
 	}
 
 	var transactionId *model.TransactionId

--- a/internal/service/resources/kesselinventoryservice_test.go
+++ b/internal/service/resources/kesselinventoryservice_test.go
@@ -2844,12 +2844,9 @@ func TestInventoryService_ReportResource_AllOptionalMetadataFields(t *testing.T)
 
 // --- ReportResource: Nil/Empty Optional Struct Combinations ---
 
-// The model layer requires both common and reporter representation data to be
-// non-empty. Sending nil or empty structs produces an error. These tests verify
-// the error paths.
-
-// TODO: This is actually not correct behavior.
-// These should be optional, and it depends on schema.
+// Omitted or empty google.protobuf.Struct for common/reporter is treated as no payload.
+// Metadata-only (both absent) and common-only succeed; schema validation runs only when
+// a side has non-empty JSON fields.
 func TestInventoryService_ReportResource_NilOrEmptyRepresentationStructs(t *testing.T) {
 	claims := &authnapi.Claims{
 		SubjectId: authnapi.SubjectId("reporter-service"),
@@ -2868,7 +2865,7 @@ func TestInventoryService_ReportResource_NilOrEmptyRepresentationStructs(t *test
 			localResourceId: "host-both-nil",
 			common:          nil,
 			reporter:        nil,
-			expectMsg:       "invalid reporter representation: representation required",
+			expectMsg:       "",
 		},
 		{
 			name:            "common set, reporter nil",
@@ -2879,14 +2876,14 @@ func TestInventoryService_ReportResource_NilOrEmptyRepresentationStructs(t *test
 				},
 			},
 			reporter:  nil,
-			expectMsg: "invalid reporter representation: representation required",
+			expectMsg: "",
 		},
 		{
 			name:            "both empty structs",
 			localResourceId: "host-both-empty",
 			common:          &structpb.Struct{},
 			reporter:        &structpb.Struct{},
-			expectMsg:       "invalid data structure",
+			expectMsg:       "",
 		},
 		{
 			// Reporter is required and non-empty; empty common struct is treated as
@@ -3077,19 +3074,6 @@ func TestInventoryService_ReportResource_ValidationErrorFormats(t *testing.T) {
 			},
 			expectCode:        codes.InvalidArgument,
 			expectMsgContains: "failed validation for report resource",
-		},
-		{
-			name:         "nil reporter representation",
-			resourceType: "host",
-			reporterType: "hbi",
-			common: &structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"workspace_id": structpb.NewStringValue("ws-123"),
-				},
-			},
-			reporter:          nil,
-			expectCode:        codes.InvalidArgument,
-			expectMsgContains: "invalid reporter representation: representation required",
 		},
 	}
 


### PR DESCRIPTION
### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Representations (reporter data and common metadata) are now optional when reporting resources instead of required.
  * Metadata-only resource reports without representations are now supported.
  * Empty representations are now handled gracefully without validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->