### PR TITLE
RHCLOUD-46698: adds h2c configuration to clowdapp for grpc support

### DIFF
--- a/deploy/kessel-inventory-ephem.yaml
+++ b/deploy/kessel-inventory-ephem.yaml
@@ -402,6 +402,8 @@ objects:
           webServices:
             public:
               enabled: true
+              h2cEnabled: true
+              h2cTargetPort: 9000
               apiPath: kessel
       testing:
         iqePlugin: kessel-inventory


### PR DESCRIPTION
### PR Template:

## Describe your changes
* updates ClowdApp in ephemeral to enable h2c ports and define the target port for h2c routing

This ensures the K8s service exposes a proper h2c port for GRPC networking that properly routes Clowders defined grpc port of 9800 to our services on port 9000

## Ticket reference (if applicable)
For RHCLOUD-46698



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled HTTP/2 cleartext (h2c) protocol support in the deployment configuration to enhance communication efficiency and protocol compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->