### PR TITLE
RHCLOUD-46698: adds h2c configuration to clowdapp for grpc support

### DIFF
--- a/deploy/kessel-inventory-ephem.yaml
+++ b/deploy/kessel-inventory-ephem.yaml
@@ -402,6 +402,8 @@ objects:
           webServices:
             public:
               enabled: true
+              h2cEnabled: true
+              h2cTargetPort: 9000
               apiPath: kessel
       testing:
         iqePlugin: kessel-inventory

--- a/deploy/kessel-inventory.yaml
+++ b/deploy/kessel-inventory.yaml
@@ -101,6 +101,8 @@ objects:
           webServices:
             public:
               enabled: true
+              h2cEnabled: true
+              h2cTargetPort: 9000
               apiPath: inventory
       testing:
         iqePlugin: kessel-inventory


### PR DESCRIPTION
### PR Template:

## Describe your changes
Updates ClowdApp to define grpc (h2c) ports for external cluster access via Istio
* enabled h2c port definitions in K8s service via Clowder
* defines the target port for h2c to route to Inventory API's proper grpc port of 9000

**IMPORTANT!!!** 
Support for defining a target port for h2c was added in https://github.com/RedHatInsights/clowder/pull/1763. This has not rolled out to all environments yet. 

Until: 
* Clowder in stage and/or prod is updated to run image tag `cb5ef8a`
* The ClowdEnv used for stage and/or prod is updated to define an `h2cPort` 
these settings will be ignored by the Clowder operator but will be reconciled once the operator and ClowdEnv are updated

## Ticket reference (if applicable)
For RHCLOUD-46698


## Validation in Ephemeral
```shell
### ClowdEnv has a defined h2cPort value of 9800
$ oc get env env-ephemeral-yd3otu -o yaml | yq '.spec.providers.web'
gatewayCert: {}
h2cPort: 9800
images: {}
ingressClass: openshift-default
mode: local
port: 8000
privatePort: 10000
tls:
  port: 8800
  privatePort: 18000

### K8s service created by ClowdApp reconcile contains the h2c port with source of 9800 and pod target of 9000 due to h2cTargetPort setting in our ClowdApp
$ oc get svc kessel-inventory-api -o yaml | yq '.spec.ports'
- appProtocol: http
  name: public
  port: 8000
  protocol: TCP
  targetPort: 8000
- appProtocol: http
  name: auth
  port: 8080
  protocol: TCP
  targetPort: 8080
- appProtocol: kubernetes.io/h2c  <---
  name: h2c
  port: 9800  <---
  protocol: TCP
  targetPort: 9000  <---
- appProtocol: http
  name: metrics
  port: 9000
  protocol: TCP
  targetPort: 9000
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled HTTP/2 cleartext (h2c) support for public web services, improving performance and protocol compatibility for API endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->