### PR TITLE
RHCLOUD-45010: Add test coverage before RelationsRepository refactor

### DIFF
--- a/internal/biz/usecase/resources/resource_service_test.go
+++ b/internal/biz/usecase/resources/resource_service_test.go
@@ -583,7 +583,7 @@ func TestReportResourceThenDelete(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, deleteFoundResource)
 
-			err = h.usecase.Delete(h.ctx, key)
+			err = h.usecase.Delete(h.ctx, deleteKey)
 			require.NoError(t, err)
 
 			assert.Equal(t, 2, metricscollector.GetOutboxEventWriteCount())

--- a/internal/biz/usecase/resources/resource_service_test.go
+++ b/internal/biz/usecase/resources/resource_service_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -2562,4 +2563,394 @@ func TestLookupSubjectsCommandToV1beta1_UsesAtLeastAsFreshWhenSpecified(t *testi
 	atLeastAsFresh, ok := req.Consistency.Requirement.(*kessel.Consistency_AtLeastAsFresh)
 	assert.True(t, ok, "at_least_as_fresh consistency should be preserved")
 	assert.Equal(t, "test-subjects-token", atLeastAsFresh.AtLeastAsFresh.Token)
+}
+
+// TestCheck_RelationsDenied verifies that Check returns ALLOWED_FALSE when no tuples are granted.
+func TestCheck_RelationsDenied(t *testing.T) {
+	ctx := testAuthzContext()
+	meta := &recordingMetaAuthorizer{allowed: true}
+
+	simpleAuthz := data.NewSimpleRelationsRepository()
+	// No grants - should deny
+
+	uc := New(
+		data.NewFakeResourceRepository(),
+		newFakeSchemaRepository(t),
+		simpleAuthz,
+		"rbac",
+		log.DefaultLogger,
+		nil,
+		nil,
+		&UsecaseConfig{},
+		metricscollector.NewFakeMetricsCollector(),
+		meta,
+		newTestSelfSubjectStrategy(),
+	)
+
+	subject, err := buildTestSubjectReference("user-1")
+	require.NoError(t, err)
+	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
+	relation, err := model.NewRelation("view")
+	require.NoError(t, err)
+
+	allowed, _, err := uc.Check(ctx, relation, subject, key, model.NewConsistencyUnspecified())
+	require.NoError(t, err)
+	assert.False(t, allowed, "Check should return ALLOWED_FALSE when no tuples granted")
+	assert.Equal(t, 1, meta.calls)
+}
+
+// TestCheck_RelationsAllowed verifies that Check returns ALLOWED_TRUE and a consistency token when a tuple is granted.
+func TestCheck_RelationsAllowed(t *testing.T) {
+	ctx := testAuthzContext()
+	meta := &recordingMetaAuthorizer{allowed: true}
+
+	simpleAuthz := data.NewSimpleRelationsRepository()
+	simpleAuthz.Grant("user-1", "view", "hbi", "host", "host-1")
+
+	uc := New(
+		data.NewFakeResourceRepository(),
+		newFakeSchemaRepository(t),
+		simpleAuthz,
+		"rbac",
+		log.DefaultLogger,
+		nil,
+		nil,
+		&UsecaseConfig{},
+		metricscollector.NewFakeMetricsCollector(),
+		meta,
+		newTestSelfSubjectStrategy(),
+	)
+
+	subject, err := buildTestSubjectReference("user-1")
+	require.NoError(t, err)
+	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
+	relation, err := model.NewRelation("view")
+	require.NoError(t, err)
+
+	allowed, token, err := uc.Check(ctx, relation, subject, key, model.NewConsistencyUnspecified())
+	require.NoError(t, err)
+	assert.True(t, allowed, "Check should return ALLOWED_TRUE when tuple is granted")
+	assert.NotNil(t, token, "consistency token should be non-nil")
+	assert.NotEmpty(t, token, "consistency token should be non-empty")
+	assert.Equal(t, 1, meta.calls)
+}
+
+// TestCheckForUpdate_RelationsDenied verifies that CheckForUpdate returns ALLOWED_FALSE when no tuples are granted.
+func TestCheckForUpdate_RelationsDenied(t *testing.T) {
+	ctx := testAuthzContext()
+	meta := &recordingMetaAuthorizer{allowed: true}
+
+	simpleAuthz := data.NewSimpleRelationsRepository()
+	// No grants - should deny
+
+	uc := New(
+		data.NewFakeResourceRepository(),
+		newFakeSchemaRepository(t),
+		simpleAuthz,
+		"rbac",
+		log.DefaultLogger,
+		nil,
+		nil,
+		&UsecaseConfig{},
+		metricscollector.NewFakeMetricsCollector(),
+		meta,
+		newTestSelfSubjectStrategy(),
+	)
+
+	subject, err := buildTestSubjectReference("user-1")
+	require.NoError(t, err)
+	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
+	relation, err := model.NewRelation("update")
+	require.NoError(t, err)
+
+	allowed, _, err := uc.CheckForUpdate(ctx, relation, subject, key)
+	require.NoError(t, err)
+	assert.False(t, allowed, "CheckForUpdate should return ALLOWED_FALSE when no tuples granted")
+	assert.Equal(t, 1, meta.calls)
+}
+
+// TestCheckForUpdate_RelationsAllowed verifies that CheckForUpdate returns ALLOWED_TRUE when a tuple is granted.
+func TestCheckForUpdate_RelationsAllowed(t *testing.T) {
+	ctx := testAuthzContext()
+	meta := &recordingMetaAuthorizer{allowed: true}
+
+	simpleAuthz := data.NewSimpleRelationsRepository()
+	simpleAuthz.Grant("user-1", "update", "hbi", "host", "host-1")
+
+	uc := New(
+		data.NewFakeResourceRepository(),
+		newFakeSchemaRepository(t),
+		simpleAuthz,
+		"rbac",
+		log.DefaultLogger,
+		nil,
+		nil,
+		&UsecaseConfig{},
+		metricscollector.NewFakeMetricsCollector(),
+		meta,
+		newTestSelfSubjectStrategy(),
+	)
+
+	subject, err := buildTestSubjectReference("user-1")
+	require.NoError(t, err)
+	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
+	relation, err := model.NewRelation("update")
+	require.NoError(t, err)
+
+	allowed, token, err := uc.CheckForUpdate(ctx, relation, subject, key)
+	require.NoError(t, err)
+	assert.True(t, allowed, "CheckForUpdate should return ALLOWED_TRUE when tuple is granted")
+	assert.NotNil(t, token, "consistency token should be non-nil")
+	assert.NotEmpty(t, token, "consistency token should be non-empty")
+	assert.Equal(t, 1, meta.calls)
+}
+
+// TestCheckBulk_RelationsMixedResults verifies that CheckBulk returns per-item allowed/denied results.
+func TestCheckBulk_RelationsMixedResults(t *testing.T) {
+	ctx := testAuthzContext()
+	meta := &recordingMetaAuthorizer{allowed: true}
+
+	simpleAuthz := data.NewSimpleRelationsRepository()
+	simpleAuthz.Grant("user-1", "view", "hbi", "host", "host-1")
+	// No grant for host-2
+
+	uc := New(
+		data.NewFakeResourceRepository(),
+		newFakeSchemaRepository(t),
+		simpleAuthz,
+		"rbac",
+		log.DefaultLogger,
+		nil,
+		nil,
+		&UsecaseConfig{},
+		metricscollector.NewFakeMetricsCollector(),
+		meta,
+		newTestSelfSubjectStrategy(),
+	)
+
+	subject, err := buildTestSubjectReference("user-1")
+	require.NoError(t, err)
+	key1 := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
+	key2 := createReporterResourceKey(t, "host-2", "host", "hbi", "instance-1")
+	relation, err := model.NewRelation("view")
+	require.NoError(t, err)
+
+	result, err := uc.CheckBulk(ctx, CheckBulkCommand{
+		Items: []CheckBulkItem{
+			{Resource: key1, Relation: relation, Subject: subject},
+			{Resource: key2, Relation: relation, Subject: subject},
+		},
+		Consistency: model.NewConsistencyUnspecified(),
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Pairs, 2)
+	assert.True(t, result.Pairs[0].Result.Allowed, "host-1 should be allowed")
+	assert.Nil(t, result.Pairs[0].Result.Error)
+	assert.False(t, result.Pairs[1].Result.Allowed, "host-2 should be denied")
+	assert.Nil(t, result.Pairs[1].Result.Error)
+	assert.Equal(t, 2, meta.calls)
+}
+
+// TestLookupResources_EndToEnd verifies that LookupResources returns granted resources via stream.
+func TestLookupResources_EndToEnd(t *testing.T) {
+	ctx := testAuthzContext()
+	meta := &recordingMetaAuthorizer{allowed: true}
+
+	simpleAuthz := data.NewSimpleRelationsRepository()
+	simpleAuthz.Grant("user-1", "view", "hbi", "host", "host-1")
+	simpleAuthz.Grant("user-1", "view", "hbi", "host", "host-2")
+
+	uc := New(
+		data.NewFakeResourceRepository(),
+		newFakeSchemaRepository(t),
+		simpleAuthz,
+		"rbac",
+		log.DefaultLogger,
+		nil,
+		nil,
+		&UsecaseConfig{},
+		metricscollector.NewFakeMetricsCollector(),
+		meta,
+		newTestSelfSubjectStrategy(),
+	)
+
+	subject, err := buildTestSubjectReference("user-1")
+	require.NoError(t, err)
+	resourceType, err := model.NewResourceType("host")
+	require.NoError(t, err)
+	reporterType, err := model.NewReporterType("hbi")
+	require.NoError(t, err)
+	relation, err := model.NewRelation("view")
+	require.NoError(t, err)
+
+	stream, err := uc.LookupResources(ctx, LookupResourcesCommand{
+		ResourceType: resourceType,
+		ReporterType: reporterType,
+		Relation:     relation,
+		Subject:      subject,
+		Consistency:  model.NewConsistencyUnspecified(),
+	})
+	require.NoError(t, err)
+
+	var resourceIds []string
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		resourceIds = append(resourceIds, resp.Resource.Id)
+	}
+
+	assert.Len(t, resourceIds, 2, "should return 2 granted resources")
+	assert.Contains(t, resourceIds, "host-1")
+	assert.Contains(t, resourceIds, "host-2")
+	assert.Equal(t, 1, meta.calls, "meta-authz should be called once for the resource type")
+}
+
+// TestLookupResources_Empty verifies that LookupResources returns EOF immediately when no tuples are granted.
+func TestLookupResources_Empty(t *testing.T) {
+	ctx := testAuthzContext()
+	meta := &recordingMetaAuthorizer{allowed: true}
+
+	simpleAuthz := data.NewSimpleRelationsRepository()
+	// No grants
+
+	uc := New(
+		data.NewFakeResourceRepository(),
+		newFakeSchemaRepository(t),
+		simpleAuthz,
+		"rbac",
+		log.DefaultLogger,
+		nil,
+		nil,
+		&UsecaseConfig{},
+		metricscollector.NewFakeMetricsCollector(),
+		meta,
+		newTestSelfSubjectStrategy(),
+	)
+
+	subject, err := buildTestSubjectReference("user-1")
+	require.NoError(t, err)
+	resourceType, err := model.NewResourceType("host")
+	require.NoError(t, err)
+	reporterType, err := model.NewReporterType("hbi")
+	require.NoError(t, err)
+	relation, err := model.NewRelation("view")
+	require.NoError(t, err)
+
+	stream, err := uc.LookupResources(ctx, LookupResourcesCommand{
+		ResourceType: resourceType,
+		ReporterType: reporterType,
+		Relation:     relation,
+		Subject:      subject,
+		Consistency:  model.NewConsistencyUnspecified(),
+	})
+	require.NoError(t, err)
+
+	// First Recv should return EOF
+	_, err = stream.Recv()
+	assert.Equal(t, io.EOF, err, "empty stream should return EOF immediately")
+	assert.Equal(t, 1, meta.calls)
+}
+
+// TestLookupSubjects_EndToEnd verifies that LookupSubjects returns granted subjects via stream.
+func TestLookupSubjects_EndToEnd(t *testing.T) {
+	ctx := testAuthzContext()
+	meta := &recordingMetaAuthorizer{allowed: true}
+
+	simpleAuthz := data.NewSimpleRelationsRepository()
+	simpleAuthz.Grant("user-1", "view", "hbi", "host", "host-1")
+	simpleAuthz.Grant("user-2", "view", "hbi", "host", "host-1")
+
+	uc := New(
+		data.NewFakeResourceRepository(),
+		newFakeSchemaRepository(t),
+		simpleAuthz,
+		"rbac",
+		log.DefaultLogger,
+		nil,
+		nil,
+		&UsecaseConfig{},
+		metricscollector.NewFakeMetricsCollector(),
+		meta,
+		newTestSelfSubjectStrategy(),
+	)
+
+	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
+	relation, err := model.NewRelation("view")
+	require.NoError(t, err)
+	subjectType, err := model.NewResourceType("principal")
+	require.NoError(t, err)
+	subjectReporter, err := model.NewReporterType("rbac")
+	require.NoError(t, err)
+
+	stream, err := uc.LookupSubjects(ctx, LookupSubjectsCommand{
+		Resource:        key,
+		Relation:        relation,
+		SubjectType:     subjectType,
+		SubjectReporter: subjectReporter,
+		Consistency:     model.NewConsistencyUnspecified(),
+	})
+	require.NoError(t, err)
+
+	var subjectIds []string
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		subjectIds = append(subjectIds, resp.Subject.Subject.Id)
+	}
+
+	assert.Len(t, subjectIds, 2, "should return 2 granted subjects")
+	assert.Contains(t, subjectIds, "user-1")
+	assert.Contains(t, subjectIds, "user-2")
+	assert.Equal(t, 1, meta.calls, "meta-authz should be called once for the resource")
+}
+
+// TestLookupSubjects_Empty verifies that LookupSubjects returns EOF immediately when no tuples are granted.
+func TestLookupSubjects_Empty(t *testing.T) {
+	ctx := testAuthzContext()
+	meta := &recordingMetaAuthorizer{allowed: true}
+
+	simpleAuthz := data.NewSimpleRelationsRepository()
+	// No grants
+
+	uc := New(
+		data.NewFakeResourceRepository(),
+		newFakeSchemaRepository(t),
+		simpleAuthz,
+		"rbac",
+		log.DefaultLogger,
+		nil,
+		nil,
+		&UsecaseConfig{},
+		metricscollector.NewFakeMetricsCollector(),
+		meta,
+		newTestSelfSubjectStrategy(),
+	)
+
+	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
+	relation, err := model.NewRelation("view")
+	require.NoError(t, err)
+	subjectType, err := model.NewResourceType("principal")
+	require.NoError(t, err)
+	subjectReporter, err := model.NewReporterType("rbac")
+	require.NoError(t, err)
+
+	stream, err := uc.LookupSubjects(ctx, LookupSubjectsCommand{
+		Resource:        key,
+		Relation:        relation,
+		SubjectType:     subjectType,
+		SubjectReporter: subjectReporter,
+		Consistency:     model.NewConsistencyUnspecified(),
+	})
+	require.NoError(t, err)
+
+	// First Recv should return EOF
+	_, err = stream.Recv()
+	assert.Equal(t, io.EOF, err, "empty stream should return EOF immediately")
+	assert.Equal(t, 1, meta.calls)
 }

--- a/internal/biz/usecase/resources/resource_service_test.go
+++ b/internal/biz/usecase/resources/resource_service_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"testing"
 
@@ -2565,144 +2566,102 @@ func TestLookupSubjectsCommandToV1beta1_UsesAtLeastAsFreshWhenSpecified(t *testi
 	assert.Equal(t, "test-subjects-token", atLeastAsFresh.AtLeastAsFresh.Token)
 }
 
-// TestCheck_RelationsDenied verifies that Check returns ALLOWED_FALSE when no tuples are granted.
-func TestCheck_RelationsDenied(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
+func TestCheck_AuthzDecisions(t *testing.T) {
+	tests := []struct {
+		name           string
+		grantSubjectID string
+		wantAllowed    bool
+	}{
+		{"denied - no grants", "", false},
+		{"allowed - grant exists", "user-1", true},
+	}
 
-	simpleAuthz := data.NewSimpleRelationsRepository()
-	// No grants - should deny
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := testAuthzContext()
+			meta := &recordingMetaAuthorizer{allowed: true}
 
-	uc := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		simpleAuthz,
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+			simpleAuthz := data.NewSimpleRelationsRepository()
+			if tt.grantSubjectID != "" {
+				simpleAuthz.Grant(tt.grantSubjectID, "view", "hbi", "host", "host-1")
+			}
 
-	subject, err := buildTestSubjectReference("user-1")
-	require.NoError(t, err)
-	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
-	relation, err := model.NewRelation("view")
-	require.NoError(t, err)
+			uc := New(
+				data.NewFakeResourceRepository(),
+				newFakeSchemaRepository(t),
+				simpleAuthz,
+				"rbac",
+				log.DefaultLogger,
+				nil,
+				nil,
+				&UsecaseConfig{},
+				metricscollector.NewFakeMetricsCollector(),
+				meta,
+				newTestSelfSubjectStrategy(),
+			)
 
-	allowed, _, err := uc.Check(ctx, relation, subject, key, model.NewConsistencyUnspecified())
-	require.NoError(t, err)
-	assert.False(t, allowed, "Check should return ALLOWED_FALSE when no tuples granted")
-	assert.Equal(t, 1, meta.calls)
+			subject, err := buildTestSubjectReference("user-1")
+			require.NoError(t, err)
+			key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
+			relation, err := model.NewRelation("view")
+			require.NoError(t, err)
+
+			allowed, token, err := uc.Check(ctx, relation, subject, key, model.NewConsistencyUnspecified())
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAllowed, allowed)
+			assert.NotEmpty(t, token)
+			assert.Equal(t, 1, meta.calls)
+		})
+	}
 }
 
-// TestCheck_RelationsAllowed verifies that Check returns ALLOWED_TRUE and a consistency token when a tuple is granted.
-func TestCheck_RelationsAllowed(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
+func TestCheckForUpdate_AuthzDecisions(t *testing.T) {
+	tests := []struct {
+		name           string
+		grantSubjectID string
+		wantAllowed    bool
+	}{
+		{"denied - no grants", "", false},
+		{"allowed - grant exists", "user-1", true},
+	}
 
-	simpleAuthz := data.NewSimpleRelationsRepository()
-	simpleAuthz.Grant("user-1", "view", "hbi", "host", "host-1")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := testAuthzContext()
+			meta := &recordingMetaAuthorizer{allowed: true}
 
-	uc := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		simpleAuthz,
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+			simpleAuthz := data.NewSimpleRelationsRepository()
+			if tt.grantSubjectID != "" {
+				simpleAuthz.Grant(tt.grantSubjectID, "update", "hbi", "host", "host-1")
+			}
 
-	subject, err := buildTestSubjectReference("user-1")
-	require.NoError(t, err)
-	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
-	relation, err := model.NewRelation("view")
-	require.NoError(t, err)
+			uc := New(
+				data.NewFakeResourceRepository(),
+				newFakeSchemaRepository(t),
+				simpleAuthz,
+				"rbac",
+				log.DefaultLogger,
+				nil,
+				nil,
+				&UsecaseConfig{},
+				metricscollector.NewFakeMetricsCollector(),
+				meta,
+				newTestSelfSubjectStrategy(),
+			)
 
-	allowed, token, err := uc.Check(ctx, relation, subject, key, model.NewConsistencyUnspecified())
-	require.NoError(t, err)
-	assert.True(t, allowed, "Check should return ALLOWED_TRUE when tuple is granted")
-	assert.NotNil(t, token, "consistency token should be non-nil")
-	assert.NotEmpty(t, token, "consistency token should be non-empty")
-	assert.Equal(t, 1, meta.calls)
-}
+			subject, err := buildTestSubjectReference("user-1")
+			require.NoError(t, err)
+			key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
+			relation, err := model.NewRelation("update")
+			require.NoError(t, err)
 
-// TestCheckForUpdate_RelationsDenied verifies that CheckForUpdate returns ALLOWED_FALSE when no tuples are granted.
-func TestCheckForUpdate_RelationsDenied(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
-
-	simpleAuthz := data.NewSimpleRelationsRepository()
-	// No grants - should deny
-
-	uc := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		simpleAuthz,
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
-
-	subject, err := buildTestSubjectReference("user-1")
-	require.NoError(t, err)
-	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
-	relation, err := model.NewRelation("update")
-	require.NoError(t, err)
-
-	allowed, _, err := uc.CheckForUpdate(ctx, relation, subject, key)
-	require.NoError(t, err)
-	assert.False(t, allowed, "CheckForUpdate should return ALLOWED_FALSE when no tuples granted")
-	assert.Equal(t, 1, meta.calls)
-}
-
-// TestCheckForUpdate_RelationsAllowed verifies that CheckForUpdate returns ALLOWED_TRUE when a tuple is granted.
-func TestCheckForUpdate_RelationsAllowed(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
-
-	simpleAuthz := data.NewSimpleRelationsRepository()
-	simpleAuthz.Grant("user-1", "update", "hbi", "host", "host-1")
-
-	uc := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		simpleAuthz,
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
-
-	subject, err := buildTestSubjectReference("user-1")
-	require.NoError(t, err)
-	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
-	relation, err := model.NewRelation("update")
-	require.NoError(t, err)
-
-	allowed, token, err := uc.CheckForUpdate(ctx, relation, subject, key)
-	require.NoError(t, err)
-	assert.True(t, allowed, "CheckForUpdate should return ALLOWED_TRUE when tuple is granted")
-	assert.NotNil(t, token, "consistency token should be non-nil")
-	assert.NotEmpty(t, token, "consistency token should be non-empty")
-	assert.Equal(t, 1, meta.calls)
+			allowed, token, err := uc.CheckForUpdate(ctx, relation, subject, key)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAllowed, allowed)
+			assert.NotEmpty(t, token)
+			assert.Equal(t, 1, meta.calls)
+		})
+	}
 }
 
 // TestCheckBulk_RelationsMixedResults verifies that CheckBulk returns per-item allowed/denied results.
@@ -2751,206 +2710,162 @@ func TestCheckBulk_RelationsMixedResults(t *testing.T) {
 	assert.Equal(t, 2, meta.calls)
 }
 
-// TestLookupResources_EndToEnd verifies that LookupResources returns granted resources via stream.
-func TestLookupResources_EndToEnd(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
-
-	simpleAuthz := data.NewSimpleRelationsRepository()
-	simpleAuthz.Grant("user-1", "view", "hbi", "host", "host-1")
-	simpleAuthz.Grant("user-1", "view", "hbi", "host", "host-2")
-
-	uc := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		simpleAuthz,
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
-
-	subject, err := buildTestSubjectReference("user-1")
-	require.NoError(t, err)
-	resourceType, err := model.NewResourceType("host")
-	require.NoError(t, err)
-	reporterType, err := model.NewReporterType("hbi")
-	require.NoError(t, err)
-	relation, err := model.NewRelation("view")
-	require.NoError(t, err)
-
-	stream, err := uc.LookupResources(ctx, LookupResourcesCommand{
-		ResourceType: resourceType,
-		ReporterType: reporterType,
-		Relation:     relation,
-		Subject:      subject,
-		Consistency:  model.NewConsistencyUnspecified(),
-	})
-	require.NoError(t, err)
-
-	var resourceIds []string
-	for {
-		resp, err := stream.Recv()
-		if err == io.EOF {
-			break
-		}
-		require.NoError(t, err)
-		resourceIds = append(resourceIds, resp.Resource.Id)
+func TestLookupResources_StreamResults(t *testing.T) {
+	type grant struct {
+		subjectID, resourceID string
+	}
+	tests := []struct {
+		name    string
+		grants  []grant
+		wantIDs []string
+	}{
+		{
+			"returns granted resources",
+			[]grant{{"user-1", "host-1"}, {"user-1", "host-2"}},
+			[]string{"host-1", "host-2"},
+		},
+		{
+			"empty - no grants",
+			nil,
+			nil,
+		},
 	}
 
-	assert.Len(t, resourceIds, 2, "should return 2 granted resources")
-	assert.Contains(t, resourceIds, "host-1")
-	assert.Contains(t, resourceIds, "host-2")
-	assert.Equal(t, 1, meta.calls, "meta-authz should be called once for the resource type")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := testAuthzContext()
+			meta := &recordingMetaAuthorizer{allowed: true}
+
+			simpleAuthz := data.NewSimpleRelationsRepository()
+			for _, g := range tt.grants {
+				simpleAuthz.Grant(g.subjectID, "view", "hbi", "host", g.resourceID)
+			}
+
+			uc := New(
+				data.NewFakeResourceRepository(),
+				newFakeSchemaRepository(t),
+				simpleAuthz,
+				"rbac",
+				log.DefaultLogger,
+				nil,
+				nil,
+				&UsecaseConfig{},
+				metricscollector.NewFakeMetricsCollector(),
+				meta,
+				newTestSelfSubjectStrategy(),
+			)
+
+			subject, err := buildTestSubjectReference("user-1")
+			require.NoError(t, err)
+			resourceType, err := model.NewResourceType("host")
+			require.NoError(t, err)
+			reporterType, err := model.NewReporterType("hbi")
+			require.NoError(t, err)
+			relation, err := model.NewRelation("view")
+			require.NoError(t, err)
+
+			stream, err := uc.LookupResources(ctx, LookupResourcesCommand{
+				ResourceType: resourceType,
+				ReporterType: reporterType,
+				Relation:     relation,
+				Subject:      subject,
+				Consistency:  model.NewConsistencyUnspecified(),
+			})
+			require.NoError(t, err)
+
+			var resourceIds []string
+			for {
+				resp, err := stream.Recv()
+				if err == io.EOF {
+					break
+				}
+				require.NoError(t, err)
+				resourceIds = append(resourceIds, resp.Resource.Id)
+			}
+
+			slices.Sort(resourceIds)
+			wantSorted := slices.Clone(tt.wantIDs)
+			slices.Sort(wantSorted)
+			assert.Equal(t, wantSorted, resourceIds)
+			assert.Equal(t, 1, meta.calls)
+		})
+	}
 }
 
-// TestLookupResources_Empty verifies that LookupResources returns EOF immediately when no tuples are granted.
-func TestLookupResources_Empty(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
-
-	simpleAuthz := data.NewSimpleRelationsRepository()
-	// No grants
-
-	uc := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		simpleAuthz,
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
-
-	subject, err := buildTestSubjectReference("user-1")
-	require.NoError(t, err)
-	resourceType, err := model.NewResourceType("host")
-	require.NoError(t, err)
-	reporterType, err := model.NewReporterType("hbi")
-	require.NoError(t, err)
-	relation, err := model.NewRelation("view")
-	require.NoError(t, err)
-
-	stream, err := uc.LookupResources(ctx, LookupResourcesCommand{
-		ResourceType: resourceType,
-		ReporterType: reporterType,
-		Relation:     relation,
-		Subject:      subject,
-		Consistency:  model.NewConsistencyUnspecified(),
-	})
-	require.NoError(t, err)
-
-	// First Recv should return EOF
-	_, err = stream.Recv()
-	assert.Equal(t, io.EOF, err, "empty stream should return EOF immediately")
-	assert.Equal(t, 1, meta.calls)
-}
-
-// TestLookupSubjects_EndToEnd verifies that LookupSubjects returns granted subjects via stream.
-func TestLookupSubjects_EndToEnd(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
-
-	simpleAuthz := data.NewSimpleRelationsRepository()
-	simpleAuthz.Grant("user-1", "view", "hbi", "host", "host-1")
-	simpleAuthz.Grant("user-2", "view", "hbi", "host", "host-1")
-
-	uc := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		simpleAuthz,
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
-
-	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
-	relation, err := model.NewRelation("view")
-	require.NoError(t, err)
-	subjectType, err := model.NewResourceType("principal")
-	require.NoError(t, err)
-	subjectReporter, err := model.NewReporterType("rbac")
-	require.NoError(t, err)
-
-	stream, err := uc.LookupSubjects(ctx, LookupSubjectsCommand{
-		Resource:        key,
-		Relation:        relation,
-		SubjectType:     subjectType,
-		SubjectReporter: subjectReporter,
-		Consistency:     model.NewConsistencyUnspecified(),
-	})
-	require.NoError(t, err)
-
-	var subjectIds []string
-	for {
-		resp, err := stream.Recv()
-		if err == io.EOF {
-			break
-		}
-		require.NoError(t, err)
-		subjectIds = append(subjectIds, resp.Subject.Subject.Id)
+func TestLookupSubjects_StreamResults(t *testing.T) {
+	tests := []struct {
+		name            string
+		grantSubjectIDs []string
+		wantIDs         []string
+	}{
+		{
+			"returns granted subjects",
+			[]string{"user-1", "user-2"},
+			[]string{"user-1", "user-2"},
+		},
+		{
+			"empty - no grants",
+			nil,
+			nil,
+		},
 	}
 
-	assert.Len(t, subjectIds, 2, "should return 2 granted subjects")
-	assert.Contains(t, subjectIds, "user-1")
-	assert.Contains(t, subjectIds, "user-2")
-	assert.Equal(t, 1, meta.calls, "meta-authz should be called once for the resource")
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := testAuthzContext()
+			meta := &recordingMetaAuthorizer{allowed: true}
 
-// TestLookupSubjects_Empty verifies that LookupSubjects returns EOF immediately when no tuples are granted.
-func TestLookupSubjects_Empty(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
+			simpleAuthz := data.NewSimpleRelationsRepository()
+			for _, subjectID := range tt.grantSubjectIDs {
+				simpleAuthz.Grant(subjectID, "view", "hbi", "host", "host-1")
+			}
 
-	simpleAuthz := data.NewSimpleRelationsRepository()
-	// No grants
+			uc := New(
+				data.NewFakeResourceRepository(),
+				newFakeSchemaRepository(t),
+				simpleAuthz,
+				"rbac",
+				log.DefaultLogger,
+				nil,
+				nil,
+				&UsecaseConfig{},
+				metricscollector.NewFakeMetricsCollector(),
+				meta,
+				newTestSelfSubjectStrategy(),
+			)
 
-	uc := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		simpleAuthz,
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+			key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
+			relation, err := model.NewRelation("view")
+			require.NoError(t, err)
+			subjectType, err := model.NewResourceType("principal")
+			require.NoError(t, err)
+			subjectReporter, err := model.NewReporterType("rbac")
+			require.NoError(t, err)
 
-	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
-	relation, err := model.NewRelation("view")
-	require.NoError(t, err)
-	subjectType, err := model.NewResourceType("principal")
-	require.NoError(t, err)
-	subjectReporter, err := model.NewReporterType("rbac")
-	require.NoError(t, err)
+			stream, err := uc.LookupSubjects(ctx, LookupSubjectsCommand{
+				Resource:        key,
+				Relation:        relation,
+				SubjectType:     subjectType,
+				SubjectReporter: subjectReporter,
+				Consistency:     model.NewConsistencyUnspecified(),
+			})
+			require.NoError(t, err)
 
-	stream, err := uc.LookupSubjects(ctx, LookupSubjectsCommand{
-		Resource:        key,
-		Relation:        relation,
-		SubjectType:     subjectType,
-		SubjectReporter: subjectReporter,
-		Consistency:     model.NewConsistencyUnspecified(),
-	})
-	require.NoError(t, err)
+			var subjectIds []string
+			for {
+				resp, err := stream.Recv()
+				if err == io.EOF {
+					break
+				}
+				require.NoError(t, err)
+				subjectIds = append(subjectIds, resp.Subject.Subject.Id)
+			}
 
-	// First Recv should return EOF
-	_, err = stream.Recv()
-	assert.Equal(t, io.EOF, err, "empty stream should return EOF immediately")
-	assert.Equal(t, 1, meta.calls)
+			slices.Sort(subjectIds)
+			wantSorted := slices.Clone(tt.wantIDs)
+			slices.Sort(wantSorted)
+			assert.Equal(t, wantSorted, subjectIds)
+			assert.Equal(t, 1, meta.calls)
+		})
+	}
 }

--- a/internal/biz/usecase/resources/resource_service_test.go
+++ b/internal/biz/usecase/resources/resource_service_test.go
@@ -25,6 +25,97 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// --- Test harness: reduces boilerplate across all test cases ---
+
+type testHarness struct {
+	usecase      *Usecase
+	resourceRepo model.ResourceRepository
+	meta         *recordingMetaAuthorizer
+	ctx          context.Context
+}
+
+type harnessOption func(*harnessConfig)
+
+type harnessConfig struct {
+	relationsRepo model.RelationsRepository
+	meta          *recordingMetaAuthorizer
+	usecaseConfig *UsecaseConfig
+	logger        log.Logger
+	namespace     string
+}
+
+func newTestHarness(t *testing.T, opts ...harnessOption) *testHarness {
+	t.Helper()
+	cfg := &harnessConfig{
+		relationsRepo: &data.AllowAllRelationsRepository{},
+		usecaseConfig: &UsecaseConfig{},
+		logger:        log.DefaultLogger,
+		namespace:     "rbac",
+	}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	resourceRepo := data.NewFakeResourceRepository()
+	mc := metricscollector.NewFakeMetricsCollector()
+	var metaAuth metaauthorizer.MetaAuthorizer
+	if cfg.meta != nil {
+		metaAuth = cfg.meta
+	}
+
+	uc := New(
+		resourceRepo,
+		newFakeSchemaRepository(t),
+		cfg.relationsRepo,
+		cfg.namespace,
+		cfg.logger,
+		nil, nil,
+		cfg.usecaseConfig,
+		mc,
+		metaAuth,
+		newTestSelfSubjectStrategy(),
+	)
+
+	return &testHarness{
+		usecase:      uc,
+		resourceRepo: resourceRepo,
+		meta:         cfg.meta,
+		ctx:          testAuthzContext(),
+	}
+}
+
+func withMeta(allowed bool) harnessOption {
+	return func(c *harnessConfig) {
+		c.meta = &recordingMetaAuthorizer{allowed: allowed}
+	}
+}
+
+func withRelations(repo model.RelationsRepository) harnessOption {
+	return func(c *harnessConfig) { c.relationsRepo = repo }
+}
+
+func withUsecaseConfig(cfg *UsecaseConfig) harnessOption {
+	return func(c *harnessConfig) { c.usecaseConfig = cfg }
+}
+
+func withNamespace(ns string) harnessOption {
+	return func(c *harnessConfig) { c.namespace = ns }
+}
+
+func withLogger(l log.Logger) harnessOption {
+	return func(c *harnessConfig) { c.logger = l }
+}
+
+// resetMeta clears recorded meta-authorizer state (useful after setup calls).
+func (h *testHarness) resetMeta() {
+	if h.meta != nil {
+		h.meta.calls = 0
+		h.meta.relations = nil
+	}
+}
+
+// --- Test helpers ---
+
 func testAuthzContext() context.Context {
 	claims := &authnapi.Claims{
 		SubjectId: authnapi.SubjectId("test-user"),
@@ -46,7 +137,6 @@ func (testSelfSubjectStrategy) SubjectFromAuthorizationContext(authzContext auth
 	return buildTestSubjectReference(subjectID)
 }
 
-// buildTestSubjectReference creates a model.SubjectReference for testing.
 func buildTestSubjectReference(subjectID string) (model.SubjectReference, error) {
 	localResourceId, err := model.NewLocalResourceId(subjectID)
 	if err != nil {
@@ -85,154 +175,70 @@ func (r *recordingMetaAuthorizer) Check(_ context.Context, _ metaauthorizer.Meta
 }
 
 func TestCheckSelf_UsesCheckSelfRelation(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
-	usecase := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		&data.AllowAllRelationsRepository{},
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withMeta(true))
 
 	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
 	relation, err := model.NewRelation("view")
 	require.NoError(t, err)
 
-	allowed, _, err := usecase.CheckSelf(ctx, relation, key, model.NewConsistencyMinimizeLatency())
+	allowed, _, err := h.usecase.CheckSelf(h.ctx, relation, key, model.NewConsistencyMinimizeLatency())
 	require.NoError(t, err)
 	assert.True(t, allowed)
-	assert.Equal(t, 1, meta.calls)
-	assert.Equal(t, []metaauthorizer.Relation{metaauthorizer.RelationCheckSelf}, meta.relations)
+	assert.Equal(t, 1, h.meta.calls)
+	assert.Equal(t, []metaauthorizer.Relation{metaauthorizer.RelationCheckSelf}, h.meta.relations)
 }
 
 func TestCheckSelf_DeniedByMetaAuthz(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: false}
-	usecase := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		&data.AllowAllRelationsRepository{},
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withMeta(false))
 
 	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
 	relation, err := model.NewRelation("view")
 	require.NoError(t, err)
 
-	_, _, err = usecase.CheckSelf(ctx, relation, key, model.NewConsistencyMinimizeLatency())
+	_, _, err = h.usecase.CheckSelf(h.ctx, relation, key, model.NewConsistencyMinimizeLatency())
 	assert.ErrorIs(t, err, ErrMetaAuthorizationDenied)
 }
 
 func TestCheckSelf_MissingAuthzContext(t *testing.T) {
-	meta := &recordingMetaAuthorizer{allowed: true}
-	usecase := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		&data.AllowAllRelationsRepository{},
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withMeta(true))
 
 	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
 	relation, err := model.NewRelation("view")
 	require.NoError(t, err)
 
-	_, _, err = usecase.CheckSelf(context.Background(), relation, key, model.NewConsistencyMinimizeLatency())
+	_, _, err = h.usecase.CheckSelf(context.Background(), relation, key, model.NewConsistencyMinimizeLatency())
 	assert.ErrorIs(t, err, ErrMetaAuthzContextMissing)
-	assert.Equal(t, 0, meta.calls)
+	assert.Equal(t, 0, h.meta.calls)
 }
 
 func TestReportResource_UsesReportRelation(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
-	usecase := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		&data.AllowAllRelationsRepository{},
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withMeta(true))
 
 	cmd := fixture(t).Basic("host", "hbi", "instance-1", "host-1", "workspace-1")
-	err := usecase.ReportResource(ctx, cmd)
+	err := h.usecase.ReportResource(h.ctx, cmd)
 	require.NoError(t, err)
-	assert.Equal(t, 1, meta.calls)
-	assert.Equal(t, []metaauthorizer.Relation{metaauthorizer.RelationReportResource}, meta.relations)
+	assert.Equal(t, 1, h.meta.calls)
+	assert.Equal(t, []metaauthorizer.Relation{metaauthorizer.RelationReportResource}, h.meta.relations)
 }
 
 func TestDelete_UsesDeleteRelation(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
-	usecase := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		&data.AllowAllRelationsRepository{},
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withMeta(true))
 
 	cmd := fixture(t).Basic("host", "hbi", "instance-1", "host-1", "workspace-1")
-	err := usecase.ReportResource(ctx, cmd)
+	err := h.usecase.ReportResource(h.ctx, cmd)
 	require.NoError(t, err)
 
-	meta.calls = 0
-	meta.relations = nil
+	h.resetMeta()
 
 	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
-	err = usecase.Delete(ctx, key)
+	err = h.usecase.Delete(h.ctx, key)
 	require.NoError(t, err)
-	assert.Equal(t, 1, meta.calls)
-	assert.Equal(t, []metaauthorizer.Relation{metaauthorizer.RelationDeleteResource}, meta.relations)
+	assert.Equal(t, 1, h.meta.calls)
+	assert.Equal(t, []metaauthorizer.Relation{metaauthorizer.RelationDeleteResource}, h.meta.relations)
 }
 
 func TestCheck_UsesCheckRelation(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
-	usecase := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		&data.AllowAllRelationsRepository{},
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withMeta(true))
 
 	subject, err := buildTestSubjectReference("user-1")
 	require.NoError(t, err)
@@ -240,29 +246,15 @@ func TestCheck_UsesCheckRelation(t *testing.T) {
 	relation, err := model.NewRelation("view")
 	require.NoError(t, err)
 
-	allowed, _, err := usecase.Check(ctx, relation, subject, key, model.NewConsistencyUnspecified())
+	allowed, _, err := h.usecase.Check(h.ctx, relation, subject, key, model.NewConsistencyUnspecified())
 	require.NoError(t, err)
 	assert.True(t, allowed)
-	assert.Equal(t, 1, meta.calls)
-	assert.Equal(t, []metaauthorizer.Relation{metaauthorizer.RelationCheck}, meta.relations)
+	assert.Equal(t, 1, h.meta.calls)
+	assert.Equal(t, []metaauthorizer.Relation{metaauthorizer.RelationCheck}, h.meta.relations)
 }
 
 func TestCheckForUpdate_UsesCheckForUpdateRelation(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
-	usecase := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		&data.AllowAllRelationsRepository{},
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withMeta(true))
 
 	subject, err := buildTestSubjectReference("user-1")
 	require.NoError(t, err)
@@ -270,29 +262,15 @@ func TestCheckForUpdate_UsesCheckForUpdateRelation(t *testing.T) {
 	relation, err := model.NewRelation("view")
 	require.NoError(t, err)
 
-	allowed, _, err := usecase.CheckForUpdate(ctx, relation, subject, key)
+	allowed, _, err := h.usecase.CheckForUpdate(h.ctx, relation, subject, key)
 	require.NoError(t, err)
 	assert.True(t, allowed)
-	assert.Equal(t, 1, meta.calls)
-	assert.Equal(t, []metaauthorizer.Relation{metaauthorizer.RelationCheckForUpdate}, meta.relations)
+	assert.Equal(t, 1, h.meta.calls)
+	assert.Equal(t, []metaauthorizer.Relation{metaauthorizer.RelationCheckForUpdate}, h.meta.relations)
 }
 
 func TestCheckForUpdateBulk_UsesCheckForUpdateBulkRelation(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
-	usecase := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		&data.AllowAllRelationsRepository{},
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withMeta(true))
 
 	subject, err := buildTestSubjectReference("user-1")
 	require.NoError(t, err)
@@ -305,31 +283,16 @@ func TestCheckForUpdateBulk_UsesCheckForUpdateBulkRelation(t *testing.T) {
 			{Resource: key, Relation: relation, Subject: subject},
 		},
 	}
-	result, err := usecase.CheckForUpdateBulk(ctx, cmd)
+	result, err := h.usecase.CheckForUpdateBulk(h.ctx, cmd)
 	require.NoError(t, err)
 	require.Len(t, result.Pairs, 1)
 	assert.True(t, result.Pairs[0].Result.Allowed)
-	// One meta-authz per item (check_for_update_bulk); Relations.CheckForUpdateBulk called once.
-	assert.Equal(t, 1, meta.calls)
-	assert.Equal(t, []metaauthorizer.Relation{metaauthorizer.RelationCheckForUpdateBulk}, meta.relations)
+	assert.Equal(t, 1, h.meta.calls)
+	assert.Equal(t, []metaauthorizer.Relation{metaauthorizer.RelationCheckForUpdateBulk}, h.meta.relations)
 }
 
 func TestCheckForUpdateBulk_MetaAuthzDenied(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: false}
-	uc := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		&data.AllowAllRelationsRepository{},
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withMeta(false))
 
 	subject, err := buildTestSubjectReference("user-1")
 	require.NoError(t, err)
@@ -337,36 +300,20 @@ func TestCheckForUpdateBulk_MetaAuthzDenied(t *testing.T) {
 	relation, err := model.NewRelation("update")
 	require.NoError(t, err)
 
-	_, err = uc.CheckForUpdateBulk(ctx, CheckForUpdateBulkCommand{
+	_, err = h.usecase.CheckForUpdateBulk(h.ctx, CheckForUpdateBulkCommand{
 		Items: []CheckBulkItem{
 			{Resource: key, Relation: relation, Subject: subject},
 		},
 	})
 	assert.ErrorIs(t, err, ErrMetaAuthorizationDenied)
-	assert.Equal(t, 1, meta.calls)
+	assert.Equal(t, 1, h.meta.calls)
 }
 
 func TestCheckForUpdateBulk_MixedResults(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
-
 	simpleAuthz := data.NewSimpleRelationsRepository()
 	simpleAuthz.Grant("user-1", "update", "hbi", "host", "host-1")
-	// No grant for host-2
 
-	uc := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		simpleAuthz,
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withMeta(true), withRelations(simpleAuthz))
 
 	subject, err := buildTestSubjectReference("user-1")
 	require.NoError(t, err)
@@ -375,7 +322,7 @@ func TestCheckForUpdateBulk_MixedResults(t *testing.T) {
 	relation, err := model.NewRelation("update")
 	require.NoError(t, err)
 
-	result, err := uc.CheckForUpdateBulk(ctx, CheckForUpdateBulkCommand{
+	result, err := h.usecase.CheckForUpdateBulk(h.ctx, CheckForUpdateBulkCommand{
 		Items: []CheckBulkItem{
 			{Resource: key1, Relation: relation, Subject: subject},
 			{Resource: key2, Relation: relation, Subject: subject},
@@ -387,25 +334,11 @@ func TestCheckForUpdateBulk_MixedResults(t *testing.T) {
 	assert.Nil(t, result.Pairs[0].Result.Error)
 	assert.False(t, result.Pairs[1].Result.Allowed)
 	assert.Nil(t, result.Pairs[1].Result.Error)
-	assert.Equal(t, 2, meta.calls)
+	assert.Equal(t, 2, h.meta.calls)
 }
 
 func TestCheckSelfBulk_UsesCheckSelfRelationForEachItem(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
-	usecase := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		&data.AllowAllRelationsRepository{},
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withMeta(true))
 
 	key1 := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
 	key2 := createReporterResourceKey(t, "host-2", "host", "hbi", "instance-1")
@@ -422,27 +355,14 @@ func TestCheckSelfBulk_UsesCheckSelfRelationForEachItem(t *testing.T) {
 		Consistency: model.NewConsistencyMinimizeLatency(),
 	}
 
-	resp, err := usecase.CheckSelfBulk(ctx, cmd)
+	resp, err := h.usecase.CheckSelfBulk(h.ctx, cmd)
 	require.NoError(t, err)
 	require.Len(t, resp.Pairs, 2)
-	assert.Equal(t, []metaauthorizer.Relation{metaauthorizer.RelationCheckSelf, metaauthorizer.RelationCheckSelf}, meta.relations)
+	assert.Equal(t, []metaauthorizer.Relation{metaauthorizer.RelationCheckSelf, metaauthorizer.RelationCheckSelf}, h.meta.relations)
 }
 
 func TestCheckSelfBulk_MissingAuthzContext(t *testing.T) {
-	meta := &recordingMetaAuthorizer{allowed: true}
-	usecase := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		&data.AllowAllRelationsRepository{},
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withMeta(true))
 
 	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
 	viewRelation, err := model.NewRelation("view")
@@ -455,27 +375,13 @@ func TestCheckSelfBulk_MissingAuthzContext(t *testing.T) {
 		Consistency: model.NewConsistencyMinimizeLatency(),
 	}
 
-	_, err = usecase.CheckSelfBulk(context.Background(), cmd)
+	_, err = h.usecase.CheckSelfBulk(context.Background(), cmd)
 	assert.ErrorIs(t, err, ErrMetaAuthzContextMissing)
-	assert.Equal(t, 0, meta.calls)
+	assert.Equal(t, 0, h.meta.calls)
 }
 
 func TestCheckBulk_RejectsInventoryManagedConsistency(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
-	usecase := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		&data.AllowAllRelationsRepository{},
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withMeta(true))
 
 	subject, err := buildTestSubjectReference("user-1")
 	require.NoError(t, err)
@@ -483,7 +389,7 @@ func TestCheckBulk_RejectsInventoryManagedConsistency(t *testing.T) {
 	require.NoError(t, err)
 	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
 
-	_, err = usecase.CheckBulk(ctx, CheckBulkCommand{
+	_, err = h.usecase.CheckBulk(h.ctx, CheckBulkCommand{
 		Items: []CheckBulkItem{
 			{
 				Resource: key,
@@ -496,31 +402,17 @@ func TestCheckBulk_RejectsInventoryManagedConsistency(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 	assert.Contains(t, err.Error(), "inventory-managed consistency tokens aren't available")
-	assert.Equal(t, 0, meta.calls)
+	assert.Equal(t, 0, h.meta.calls)
 }
 
 func TestCheckSelfBulk_RejectsInventoryManagedConsistency(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
-	usecase := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		&data.AllowAllRelationsRepository{},
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withMeta(true))
 
 	viewRelation, err := model.NewRelation("view")
 	require.NoError(t, err)
 	key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
 
-	_, err = usecase.CheckSelfBulk(ctx, CheckSelfBulkCommand{
+	_, err = h.usecase.CheckSelfBulk(h.ctx, CheckSelfBulkCommand{
 		Items: []CheckSelfBulkItem{
 			{
 				Resource: key,
@@ -532,7 +424,7 @@ func TestCheckSelfBulk_RejectsInventoryManagedConsistency(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 	assert.Contains(t, err.Error(), "inventory-managed consistency tokens aren't available")
-	assert.Equal(t, 0, meta.calls)
+	assert.Equal(t, 0, h.meta.calls)
 }
 
 func newFakeSchemaRepository(t *testing.T) model.SchemaRepository {
@@ -616,21 +508,10 @@ func TestReportResource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := testAuthzContext()
-			logger := log.DefaultLogger
-
-			resourceRepo := data.NewFakeResourceRepository()
-			schemaRepo := newFakeSchemaRepository(t)
-			relationsRepo := &data.AllowAllRelationsRepository{}
-			usecaseConfig := &UsecaseConfig{
-				ReadAfterWriteEnabled: false,
-				ConsumerEnabled:       false,
-			}
-			mc := metricscollector.NewFakeMetricsCollector()
-			usecase := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
+			h := newTestHarness(t, withNamespace("test-topic"))
 
 			cmd := fixture(t).Basic(tt.resourceType, tt.reporterType, tt.reporterInstance, tt.localResourceId, tt.workspaceId)
-			err := usecase.ReportResource(ctx, cmd)
+			err := h.usecase.ReportResource(h.ctx, cmd)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -639,23 +520,11 @@ func TestReportResource(t *testing.T) {
 
 			require.NoError(t, err)
 
-			localResourceId, err := model.NewLocalResourceId(tt.localResourceId)
-			require.NoError(t, err)
-			resourceType, err := model.NewResourceType(tt.resourceType)
-			require.NoError(t, err)
-			reporterType, err := model.NewReporterType(tt.reporterType)
-			require.NoError(t, err)
-			reporterInstanceId, err := model.NewReporterInstanceId(tt.reporterInstance)
-			require.NoError(t, err)
-
-			key, err := model.NewReporterResourceKey(localResourceId, resourceType, reporterType, reporterInstanceId)
-			require.NoError(t, err)
-
-			foundResource, err := resourceRepo.FindResourceByKeys(nil, key)
+			key := createReporterResourceKey(t, tt.localResourceId, tt.resourceType, tt.reporterType, tt.reporterInstance)
+			foundResource, err := h.resourceRepo.FindResourceByKeys(nil, key)
 			require.NoError(t, err)
 			require.NotNil(t, foundResource)
 
-			// Report should trigger a single outbox event write
 			assert.Equal(t, 1, metricscollector.GetOutboxEventWriteCount())
 		})
 	}
@@ -696,285 +565,165 @@ func TestReportResourceThenDelete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := testAuthzContext()
-			logger := log.DefaultLogger
-
-			resourceRepo := data.NewFakeResourceRepository()
-			schemaRepo := newFakeSchemaRepository(t)
-			relationsRepo := &data.AllowAllRelationsRepository{}
-			usecaseConfig := &UsecaseConfig{
-				ReadAfterWriteEnabled: false,
-				ConsumerEnabled:       false,
-			}
-			mc := metricscollector.NewFakeMetricsCollector()
-			usecase := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
+			h := newTestHarness(t, withNamespace("test-topic"))
 
 			cmd := fixture(t).Basic(tt.resourceType, tt.reporterType, tt.reporterInstanceId, tt.localResourceId, tt.workspaceId)
-			err := usecase.ReportResource(ctx, cmd)
+			err := h.usecase.ReportResource(h.ctx, cmd)
 			require.NoError(t, err)
 
-			localResourceId, err := model.NewLocalResourceId(tt.localResourceId)
-			require.NoError(t, err)
-			resourceType, err := model.NewResourceType(tt.resourceType)
-			require.NoError(t, err)
-			reporterType, err := model.NewReporterType(tt.reporterType)
-			require.NoError(t, err)
-			reporterInstanceId, err := model.NewReporterInstanceId(tt.reporterInstanceId)
-			require.NoError(t, err)
-
-			key, err := model.NewReporterResourceKey(localResourceId, resourceType, reporterType, reporterInstanceId)
-			require.NoError(t, err)
-
-			foundResource, err := resourceRepo.FindResourceByKeys(nil, key)
+			key := createReporterResourceKey(t, tt.localResourceId, tt.resourceType, tt.reporterType, tt.reporterInstanceId)
+			foundResource, err := h.resourceRepo.FindResourceByKeys(nil, key)
 			require.NoError(t, err)
 			require.NotNil(t, foundResource)
 
-			// Report should trigger a single outbox event write
 			assert.Equal(t, 1, metricscollector.GetOutboxEventWriteCount())
 
-			var deleteReporterInstanceId model.ReporterInstanceId
-			if tt.deleteReporterInstanceId != "" {
-				deleteReporterInstanceId, err = model.NewReporterInstanceId(tt.deleteReporterInstanceId)
-				require.NoError(t, err)
-			} else {
-				deleteReporterInstanceId = model.ReporterInstanceId("")
-			}
-
-			deleteKey, err := model.NewReporterResourceKey(localResourceId, resourceType, reporterType, deleteReporterInstanceId)
-			require.NoError(t, err)
-
-			deleteFoundResource, err := resourceRepo.FindResourceByKeys(nil, deleteKey)
+			deleteKey := createReporterResourceKeyAllowEmptyInstance(t, tt.localResourceId, tt.resourceType, tt.reporterType, tt.deleteReporterInstanceId)
+			deleteFoundResource, err := h.resourceRepo.FindResourceByKeys(nil, deleteKey)
 			require.NoError(t, err)
 			require.NotNil(t, deleteFoundResource)
 
-			err = usecase.Delete(ctx, key)
+			err = h.usecase.Delete(h.ctx, key)
 			require.NoError(t, err)
 
-			// Delete should trigger another outbox event write
 			assert.Equal(t, 2, metricscollector.GetOutboxEventWriteCount())
 		})
 	}
 }
 
 func TestDelete_ResourceNotFound(t *testing.T) {
-	logger := log.DefaultLogger
+	h := newTestHarness(t, withNamespace("test-topic"))
 
-	resourceRepo := data.NewFakeResourceRepository()
-	schemaRepo := newFakeSchemaRepository(t)
-	relationsRepo := &data.AllowAllRelationsRepository{}
-	usecaseConfig := &UsecaseConfig{
-		ReadAfterWriteEnabled: false,
-		ConsumerEnabled:       false,
-	}
-
-	mc := metricscollector.NewFakeMetricsCollector()
-	usecase := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
-
-	localResourceId, err := model.NewLocalResourceId("non-existent-resource")
-	require.NoError(t, err)
-	resourceType, err := model.NewResourceType("k8s_cluster")
-	require.NoError(t, err)
-	reporterType, err := model.NewReporterType("ocm")
-	require.NoError(t, err)
-	reporterInstanceId, err := model.NewReporterInstanceId("test-instance")
-	require.NoError(t, err)
-
-	key, err := model.NewReporterResourceKey(localResourceId, resourceType, reporterType, reporterInstanceId)
-	require.NoError(t, err)
-
-	err = usecase.Delete(testAuthzContext(), key)
+	key := createReporterResourceKey(t, "non-existent-resource", "k8s_cluster", "ocm", "test-instance")
+	err := h.usecase.Delete(h.ctx, key)
 	require.Error(t, err)
 }
 
 func TestReportFindDeleteFind_TombstoneLifecycle(t *testing.T) {
-	ctx := testAuthzContext()
-	logger := log.DefaultLogger
-
-	resourceRepo := data.NewFakeResourceRepository()
-	schemaRepo := newFakeSchemaRepository(t)
-	relationsRepo := &data.AllowAllRelationsRepository{}
-	usecaseConfig := &UsecaseConfig{
-		ReadAfterWriteEnabled: false,
-		ConsumerEnabled:       false,
-	}
-
-	mc := metricscollector.NewFakeMetricsCollector()
-	usecase := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
+	h := newTestHarness(t, withNamespace("test-topic"))
 
 	cmd := fixture(t).Basic("k8s_cluster", "ocm", "lifecycle-instance", "lifecycle-resource", "lifecycle-workspace")
-	err := usecase.ReportResource(ctx, cmd)
+	err := h.usecase.ReportResource(h.ctx, cmd)
 	require.NoError(t, err)
 
-	localResourceId, err := model.NewLocalResourceId("lifecycle-resource")
-	require.NoError(t, err)
-	resourceType, err := model.NewResourceType("k8s_cluster")
-	require.NoError(t, err)
-	reporterType, err := model.NewReporterType("ocm")
-	require.NoError(t, err)
-	reporterInstanceId, err := model.NewReporterInstanceId("lifecycle-instance")
-	require.NoError(t, err)
+	key := createReporterResourceKey(t, "lifecycle-resource", "k8s_cluster", "ocm", "lifecycle-instance")
 
-	key, err := model.NewReporterResourceKey(localResourceId, resourceType, reporterType, reporterInstanceId)
-	require.NoError(t, err)
-
-	foundResource, err := resourceRepo.FindResourceByKeys(nil, key)
+	foundResource, err := h.resourceRepo.FindResourceByKeys(nil, key)
 	require.NoError(t, err)
 	require.NotNil(t, foundResource)
 
-	err = usecase.Delete(ctx, key)
+	err = h.usecase.Delete(h.ctx, key)
 	require.NoError(t, err)
 
-	foundResource, err = resourceRepo.FindResourceByKeys(nil, key)
-	// With tombstone filter removed, we should find the tombstoned resource
+	foundResource, err = h.resourceRepo.FindResourceByKeys(nil, key)
 	require.NoError(t, err)
 	require.NotNil(t, foundResource)
 	assert.True(t, foundResource.ReporterResources()[0].Serialize().Tombstone, "Resource should be tombstoned")
 }
 
 func TestMultipleHostsLifecycle(t *testing.T) {
-	ctx := testAuthzContext()
-	logger := log.DefaultLogger
+	h := newTestHarness(t, withNamespace("test-topic"))
 
-	resourceRepo := data.NewFakeResourceRepository()
-	schemaRepo := newFakeSchemaRepository(t)
-	relationsRepo := &data.AllowAllRelationsRepository{}
-	usecaseConfig := &UsecaseConfig{
-		ReadAfterWriteEnabled: false,
-		ConsumerEnabled:       false,
-	}
-
-	mc := metricscollector.NewFakeMetricsCollector()
-	usecase := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
-
-	// Create 2 hosts
 	cmd := fixture(t).Basic("host", "hbi", "hbi-instance-1", "host-1", "workspace-1")
-	err := usecase.ReportResource(ctx, cmd)
+	err := h.usecase.ReportResource(h.ctx, cmd)
 	require.NoError(t, err, "Should create host1")
 
 	cmd = fixture(t).Basic("host", "hbi", "hbi-instance-1", "host-2", "workspace-1")
-	err = usecase.ReportResource(ctx, cmd)
+	err = h.usecase.ReportResource(h.ctx, cmd)
 	require.NoError(t, err, "Should create host2")
 
-	// Verify both hosts can be found
-	key1, err := model.NewReporterResourceKey("host-1", "host", "hbi", "hbi-instance-1")
-	require.NoError(t, err)
-	key2, err := model.NewReporterResourceKey("host-2", "host", "hbi", "hbi-instance-1")
-	require.NoError(t, err)
+	key1 := createReporterResourceKey(t, "host-1", "host", "hbi", "hbi-instance-1")
+	key2 := createReporterResourceKey(t, "host-2", "host", "hbi", "hbi-instance-1")
 
-	foundHost1, err := resourceRepo.FindResourceByKeys(nil, key1)
+	foundHost1, err := h.resourceRepo.FindResourceByKeys(nil, key1)
 	require.NoError(t, err, "Should find host1 after creation")
 	require.NotNil(t, foundHost1)
 
-	foundHost2, err := resourceRepo.FindResourceByKeys(nil, key2)
+	foundHost2, err := h.resourceRepo.FindResourceByKeys(nil, key2)
 	require.NoError(t, err, "Should find host2 after creation")
 	require.NotNil(t, foundHost2)
 
-	// Update both hosts by reporting them again with updated data
 	cmd = fixture(t).Updated("host", "hbi", "hbi-instance-1", "host-1", "workspace-1")
-	err = usecase.ReportResource(ctx, cmd)
+	err = h.usecase.ReportResource(h.ctx, cmd)
 	require.NoError(t, err, "Should update host1")
 
 	cmd = fixture(t).Updated("host", "hbi", "hbi-instance-1", "host-2", "workspace-1")
-	err = usecase.ReportResource(ctx, cmd)
+	err = h.usecase.ReportResource(h.ctx, cmd)
 	require.NoError(t, err, "Should update host2")
 
-	// Verify both updated hosts can still be found
-	updatedHost1, err := resourceRepo.FindResourceByKeys(nil, key1)
+	updatedHost1, err := h.resourceRepo.FindResourceByKeys(nil, key1)
 	require.NoError(t, err, "Should find host1 after update")
 	require.NotNil(t, updatedHost1)
 
-	updatedHost2, err := resourceRepo.FindResourceByKeys(nil, key2)
+	updatedHost2, err := h.resourceRepo.FindResourceByKeys(nil, key2)
 	require.NoError(t, err, "Should find host2 after update")
 	require.NotNil(t, updatedHost2)
 
-	// Delete both hosts
-	err = usecase.Delete(ctx, key1)
+	err = h.usecase.Delete(h.ctx, key1)
 	require.NoError(t, err, "Should delete host1")
 
-	err = usecase.Delete(ctx, key2)
+	err = h.usecase.Delete(h.ctx, key2)
 	require.NoError(t, err, "Should delete host2")
 
-	// Verify both hosts can be found (tombstoned) with tombstone filter removed
-	foundHost1, err = resourceRepo.FindResourceByKeys(nil, key1)
+	foundHost1, err = h.resourceRepo.FindResourceByKeys(nil, key1)
 	require.NoError(t, err, "Should find tombstoned host1")
 	require.NotNil(t, foundHost1)
 	assert.True(t, foundHost1.ReporterResources()[0].Serialize().Tombstone, "Host1 should be tombstoned")
 
-	foundHost2, err = resourceRepo.FindResourceByKeys(nil, key2)
+	foundHost2, err = h.resourceRepo.FindResourceByKeys(nil, key2)
 	require.NoError(t, err, "Should find tombstoned host2")
 	require.NotNil(t, foundHost2)
 	assert.True(t, foundHost2.ReporterResources()[0].Serialize().Tombstone, "Host2 should be tombstoned")
 }
 
 func TestPartialDataScenarios(t *testing.T) {
-	ctx := testAuthzContext()
-	logger := log.DefaultLogger
-
-	resourceRepo := data.NewFakeResourceRepository()
-	schemaRepo := newFakeSchemaRepository(t)
-	relationsRepo := &data.AllowAllRelationsRepository{}
-	usecaseConfig := &UsecaseConfig{
-		ReadAfterWriteEnabled: false,
-		ConsumerEnabled:       false,
-	}
-
-	mc := metricscollector.NewFakeMetricsCollector()
-	usecase := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
+	h := newTestHarness(t, withNamespace("test-topic"))
 
 	t.Run("Report resource with rich reporter data and minimal common data", func(t *testing.T) {
 		cmd := fixture(t).ReporterRich("k8s_cluster", "ocm", "ocm-instance-1", "reporter-rich-resource", "minimal-workspace")
-		err := usecase.ReportResource(ctx, cmd)
+		err := h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Should create resource with rich reporter data")
 
-		key, err := model.NewReporterResourceKey("reporter-rich-resource", "k8s_cluster", "ocm", "ocm-instance-1")
-		require.NoError(t, err)
-
-		foundResource, err := resourceRepo.FindResourceByKeys(nil, key)
+		key := createReporterResourceKey(t, "reporter-rich-resource", "k8s_cluster", "ocm", "ocm-instance-1")
+		foundResource, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource with rich reporter data")
 		require.NotNil(t, foundResource)
 	})
 
 	t.Run("Report resource with minimal reporter data and rich common data", func(t *testing.T) {
 		cmd := fixture(t).CommonRich("k8s_cluster", "ocm", "ocm-instance-1", "common-rich-resource", "rich-workspace")
-		err := usecase.ReportResource(ctx, cmd)
+		err := h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Should create resource with rich common data")
 
-		key, err := model.NewReporterResourceKey("common-rich-resource", "k8s_cluster", "ocm", "ocm-instance-1")
-		require.NoError(t, err)
-
-		foundResource, err := resourceRepo.FindResourceByKeys(nil, key)
+		key := createReporterResourceKey(t, "common-rich-resource", "k8s_cluster", "ocm", "ocm-instance-1")
+		foundResource, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource with rich common data")
 		require.NotNil(t, foundResource)
 	})
 
 	t.Run("Report resource with both data, then reporter-focused update, then common-focused update", func(t *testing.T) {
-		// 1. Initial report with both reporter and common data
 		cmd := fixture(t).Basic("k8s_cluster", "ocm", "ocm-instance-1", "progressive-resource", "initial-workspace")
-		err := usecase.ReportResource(ctx, cmd)
+		err := h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Should create resource with both data types")
 
-		key, err := model.NewReporterResourceKey("progressive-resource", "k8s_cluster", "ocm", "ocm-instance-1")
-		require.NoError(t, err)
-
-		foundResource, err := resourceRepo.FindResourceByKeys(nil, key)
+		key := createReporterResourceKey(t, "progressive-resource", "k8s_cluster", "ocm", "ocm-instance-1")
+		foundResource, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after initial creation")
 		require.NotNil(t, foundResource)
 
-		// 2. Reporter-focused update
 		cmd = fixture(t).ReporterRich("k8s_cluster", "ocm", "ocm-instance-1", "progressive-resource", "initial-workspace")
-		err = usecase.ReportResource(ctx, cmd)
+		err = h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Should update resource with reporter-focused data")
 
-		foundResource, err = resourceRepo.FindResourceByKeys(nil, key)
+		foundResource, err = h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after reporter-focused update")
 		require.NotNil(t, foundResource)
 
-		// 3. Common-focused update
 		cmd = fixture(t).CommonRich("k8s_cluster", "ocm", "ocm-instance-1", "progressive-resource", "updated-workspace")
-		err = usecase.ReportResource(ctx, cmd)
+		err = h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Should update resource with common-focused data")
 
-		finalResource, err := resourceRepo.FindResourceByKeys(nil, key)
+		finalResource, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after all updates")
 		require.NotNil(t, finalResource)
 	})
@@ -982,19 +731,7 @@ func TestPartialDataScenarios(t *testing.T) {
 
 func TestResourceLifecycle_ReportUpdateDeleteReport(t *testing.T) {
 	t.Run("report new -> update -> delete -> report new", func(t *testing.T) {
-		ctx := testAuthzContext()
-		logger := log.DefaultLogger
-
-		resourceRepo := data.NewFakeResourceRepository()
-		schemaRepo := newFakeSchemaRepository(t)
-		relationsRepo := &data.AllowAllRelationsRepository{}
-		usecaseConfig := &UsecaseConfig{
-			ReadAfterWriteEnabled: false,
-			ConsumerEnabled:       false,
-		}
-
-		mc := metricscollector.NewFakeMetricsCollector()
-		usecase := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
+		h := newTestHarness(t, withNamespace("test-topic"))
 
 		resourceType := "host"
 		reporterType := "hbi"
@@ -1005,93 +742,59 @@ func TestResourceLifecycle_ReportUpdateDeleteReport(t *testing.T) {
 		// 1. REPORT NEW: Initial resource creation
 		log.Info("Report New ---------------------")
 		cmd := fixture(t).Basic(resourceType, reporterType, reporterInstance, localResourceId, workspaceId)
-		err := usecase.ReportResource(ctx, cmd)
+		err := h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Initial report should succeed")
 
 		key := createReporterResourceKey(t, localResourceId, resourceType, reporterType, reporterInstance)
 
-		// Verify initial state: generation = 0, representationVersion = 0
-		afterCreate, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterCreate, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after creation")
 		require.NotNil(t, afterCreate)
 		initialSnapshot := afterCreate.ReporterResources()[0].Serialize()
-		initialGeneration := initialSnapshot.Generation
-		initialRepVersion := initialSnapshot.RepresentationVersion
-		initialTombstone := initialSnapshot.Tombstone
-		assert.Equal(t, uint(0), initialGeneration, "Initial generation should be 0")
-		assert.Equal(t, uint(0), initialRepVersion, "Initial representationVersion should be 0")
-		assert.False(t, initialTombstone, "Initial tombstone should be false")
+		assert.Equal(t, uint(0), initialSnapshot.Generation, "Initial generation should be 0")
+		assert.Equal(t, uint(0), initialSnapshot.RepresentationVersion, "Initial representationVersion should be 0")
+		assert.False(t, initialSnapshot.Tombstone, "Initial tombstone should be false")
 
-		log.Info("Update 1 ---------------------")
-		// 2. UPDATE: Update the resource
 		cmd = fixture(t).Updated(resourceType, reporterType, reporterInstance, localResourceId, workspaceId)
-		err = usecase.ReportResource(ctx, cmd)
+		err = h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Update should succeed")
 
-		// Verify state after update: representationVersion incremented, generation unchanged
-		afterUpdate, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterUpdate, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after update")
 		require.NotNil(t, afterUpdate)
 		updateSnapshot := afterUpdate.ReporterResources()[0].Serialize()
-		updateGeneration := updateSnapshot.Generation
-		updateRepVersion := updateSnapshot.RepresentationVersion
-		updateTombstone := updateSnapshot.Tombstone
-		assert.Equal(t, uint(0), updateGeneration, "Generation should remain 0 after update (tombstone=false)")
-		assert.Equal(t, uint(1), updateRepVersion, "RepresentationVersion should increment to 1 after update")
-		assert.False(t, updateTombstone, "Tombstone should remain false after update")
+		assert.Equal(t, uint(0), updateSnapshot.Generation, "Generation should remain 0 after update (tombstone=false)")
+		assert.Equal(t, uint(1), updateSnapshot.RepresentationVersion, "RepresentationVersion should increment to 1 after update")
+		assert.False(t, updateSnapshot.Tombstone, "Tombstone should remain false after update")
 
-		// 3. DELETE: Delete the resource
-		log.Info("Delete ---------------------")
-		err = usecase.Delete(ctx, key)
+		err = h.usecase.Delete(h.ctx, key)
 		require.NoError(t, err, "Delete should succeed")
 
-		// Verify state after delete: representationVersion incremented, generation unchanged, tombstoned
-		afterDelete, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterDelete, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find tombstoned resource after delete")
 		require.NotNil(t, afterDelete)
 		deleteSnapshot := afterDelete.ReporterResources()[0].Serialize()
-		deleteGeneration := deleteSnapshot.Generation
-		deleteRepVersion := deleteSnapshot.RepresentationVersion
-		deleteTombstone := deleteSnapshot.Tombstone
-		assert.Equal(t, uint(0), deleteGeneration, "Generation should remain 0 after delete")
-		assert.Equal(t, uint(2), deleteRepVersion, "RepresentationVersion should increment to 2 after delete")
-		assert.True(t, deleteTombstone, "Resource should be tombstoned after delete")
+		assert.Equal(t, uint(0), deleteSnapshot.Generation, "Generation should remain 0 after delete")
+		assert.Equal(t, uint(2), deleteSnapshot.RepresentationVersion, "RepresentationVersion should increment to 2 after delete")
+		assert.True(t, deleteSnapshot.Tombstone, "Resource should be tombstoned after delete")
 
-		// 4. REPORT NEW: Report the same resource again after deletion (this should be an update)
-		log.Info("Revive again ---------------------")
 		cmd = fixture(t).Updated(resourceType, reporterType, reporterInstance, localResourceId, workspaceId)
-		err = usecase.ReportResource(ctx, cmd)
+		err = h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Report after delete should succeed")
 
-		// Verify final state after update on tombstoned resource
-		afterRevive, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterRevive, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after revival")
 		require.NotNil(t, afterRevive)
 		reviveSnapshot := afterRevive.ReporterResources()[0].Serialize()
-		reviveGeneration := reviveSnapshot.Generation
-		reviveRepVersion := reviveSnapshot.RepresentationVersion
-		reviveTombstone := reviveSnapshot.Tombstone
-		assert.Equal(t, uint(1), reviveGeneration, "Generation should increment to 1 after update on tombstoned resource")
-		assert.Equal(t, uint(0), reviveRepVersion, "RepresentationVersion should start fresh at 0 for revival (new generation)")
-		assert.False(t, reviveTombstone, "Resource should no longer be tombstoned after revival update")
+		assert.Equal(t, uint(1), reviveSnapshot.Generation, "Generation should increment to 1 after update on tombstoned resource")
+		assert.Equal(t, uint(0), reviveSnapshot.RepresentationVersion, "RepresentationVersion should start fresh at 0 for revival (new generation)")
+		assert.False(t, reviveSnapshot.Tombstone, "Resource should no longer be tombstoned after revival update")
 	})
 }
 
 func TestResourceLifecycle_ReportUpdateDeleteReportDelete(t *testing.T) {
 	t.Run("report new -> update -> delete -> report new -> delete", func(t *testing.T) {
-		ctx := testAuthzContext()
-		logger := log.DefaultLogger
-
-		resourceRepo := data.NewFakeResourceRepository()
-		schemaRepo := newFakeSchemaRepository(t)
-		relationsRepo := &data.AllowAllRelationsRepository{}
-		usecaseConfig := &UsecaseConfig{
-			ReadAfterWriteEnabled: false,
-			ConsumerEnabled:       false,
-		}
-
-		mc := metricscollector.NewFakeMetricsCollector()
-		usecase := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
+		h := newTestHarness(t, withNamespace("test-topic"))
 
 		resourceType := "k8s_cluster"
 		reporterType := "ocm"
@@ -1099,37 +802,29 @@ func TestResourceLifecycle_ReportUpdateDeleteReportDelete(t *testing.T) {
 		localResourceId := "lifecycle-test-cluster"
 		workspaceId := "test-workspace-2"
 
-		// 1. REPORT NEW: Initial resource creation
 		cmd := fixture(t).Basic(resourceType, reporterType, reporterInstance, localResourceId, workspaceId)
-		err := usecase.ReportResource(ctx, cmd)
+		err := h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Initial report should succeed")
 
-		// 2. UPDATE: Update the resource
 		cmd = fixture(t).Updated(resourceType, reporterType, reporterInstance, localResourceId, workspaceId)
-		err = usecase.ReportResource(ctx, cmd)
+		err = h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Update should succeed")
 
-		// 3. DELETE: Delete the resource
 		key := createReporterResourceKey(t, localResourceId, resourceType, reporterType, reporterInstance)
-		err = usecase.Delete(ctx, key)
+		err = h.usecase.Delete(h.ctx, key)
 		require.NoError(t, err, "First delete should succeed")
 
-		// 4. REPORT NEW: Report the same resource again after deletion
 		cmd = fixture(t).Updated(resourceType, reporterType, reporterInstance, localResourceId, workspaceId)
-		err = usecase.ReportResource(ctx, cmd)
+		err = h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Report after delete should succeed")
 
-		// 5. DELETE: Delete the recreated resource
-		err = usecase.Delete(ctx, key)
+		err = h.usecase.Delete(h.ctx, key)
 		require.NoError(t, err, "Second delete should succeed")
 
-		// Verify final state - resource should be tombstoned
-		finalResource, err := resourceRepo.FindResourceByKeys(nil, key)
+		finalResource, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		if err == gorm.ErrRecordNotFound {
-			// This is expected with current tombstone filtering
 			assert.Nil(t, finalResource, "Resource should not be found if tombstone filter is active")
 		} else {
-			// If tombstone filter is removed, we should find the resource
 			require.NoError(t, err, "Should find tombstoned resource if filter is removed")
 			require.NotNil(t, finalResource)
 		}
@@ -1137,6 +832,7 @@ func TestResourceLifecycle_ReportUpdateDeleteReportDelete(t *testing.T) {
 }
 
 func createReporterResourceKey(t *testing.T, localResourceId, resourceType, reporterType, reporterInstance string) model.ReporterResourceKey {
+	t.Helper()
 	localResourceIdType, err := model.NewLocalResourceId(localResourceId)
 	require.NoError(t, err)
 	resourceTypeType, err := model.NewResourceType(resourceType)
@@ -1151,21 +847,33 @@ func createReporterResourceKey(t *testing.T, localResourceId, resourceType, repo
 	return key
 }
 
+// createReporterResourceKeyAllowEmptyInstance is like createReporterResourceKey but
+// allows an empty reporterInstance (bypassing validation) for delete-without-instance tests.
+func createReporterResourceKeyAllowEmptyInstance(t *testing.T, localResourceId, resourceType, reporterType, reporterInstance string) model.ReporterResourceKey {
+	t.Helper()
+	localResourceIdType, err := model.NewLocalResourceId(localResourceId)
+	require.NoError(t, err)
+	resourceTypeType, err := model.NewResourceType(resourceType)
+	require.NoError(t, err)
+	reporterTypeType, err := model.NewReporterType(reporterType)
+	require.NoError(t, err)
+
+	var reporterInstanceIdType model.ReporterInstanceId
+	if reporterInstance != "" {
+		reporterInstanceIdType, err = model.NewReporterInstanceId(reporterInstance)
+		require.NoError(t, err)
+	} else {
+		reporterInstanceIdType = model.ReporterInstanceId("")
+	}
+
+	key, err := model.NewReporterResourceKey(localResourceIdType, resourceTypeType, reporterTypeType, reporterInstanceIdType)
+	require.NoError(t, err)
+	return key
+}
+
 func TestResourceLifecycle_ReportDeleteResubmitDelete(t *testing.T) {
 	t.Run("report -> delete -> resubmit same delete", func(t *testing.T) {
-		ctx := testAuthzContext()
-		logger := log.DefaultLogger
-
-		resourceRepo := data.NewFakeResourceRepository()
-		schemaRepo := newFakeSchemaRepository(t)
-		relationsRepo := &data.AllowAllRelationsRepository{}
-		usecaseConfig := &UsecaseConfig{
-			ReadAfterWriteEnabled: false,
-			ConsumerEnabled:       false,
-		}
-
-		mc := metricscollector.NewFakeMetricsCollector()
-		usecase := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
+		h := newTestHarness(t, withNamespace("test-topic"))
 
 		resourceType := "k8s_cluster"
 		reporterType := "ocm"
@@ -1173,16 +881,13 @@ func TestResourceLifecycle_ReportDeleteResubmitDelete(t *testing.T) {
 		localResourceId := "idempotent-test-resource"
 		workspaceId := "idempotent-workspace"
 
-		// 1. REPORT: Initial resource creation
-		log.Info("1. Initial Report ---------------------")
 		cmd := fixture(t).Basic(resourceType, reporterType, reporterInstance, localResourceId, workspaceId)
-		err := usecase.ReportResource(ctx, cmd)
+		err := h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Initial report should succeed")
 
 		key := createReporterResourceKey(t, localResourceId, resourceType, reporterType, reporterInstance)
 
-		// Verify initial state
-		afterReport1, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterReport1, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after initial report")
 		require.NotNil(t, afterReport1)
 		initialState := afterReport1.ReporterResources()[0].Serialize()
@@ -1190,13 +895,10 @@ func TestResourceLifecycle_ReportDeleteResubmitDelete(t *testing.T) {
 		assert.Equal(t, uint(0), initialState.Generation, "Initial generation should be 0")
 		assert.False(t, initialState.Tombstone, "Initial tombstone should be false")
 
-		// 2. DELETE: Delete the resource
-		log.Info("2. Delete ---------------------")
-		err = usecase.Delete(ctx, key)
+		err = h.usecase.Delete(h.ctx, key)
 		require.NoError(t, err, "Delete should succeed")
 
-		// Verify delete state
-		afterDelete1, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterDelete1, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find tombstoned resource after delete")
 		require.NotNil(t, afterDelete1)
 		deleteState1 := afterDelete1.ReporterResources()[0].Serialize()
@@ -1204,38 +906,23 @@ func TestResourceLifecycle_ReportDeleteResubmitDelete(t *testing.T) {
 		assert.Equal(t, uint(0), deleteState1.Generation, "Generation should remain 0 after delete")
 		assert.True(t, deleteState1.Tombstone, "Resource should be tombstoned")
 
-		// 3. RESUBMIT SAME DELETE: Should be idempotent
-		log.Info("3. Resubmit Delete ---------------------")
-		err = usecase.Delete(ctx, key)
+		err = h.usecase.Delete(h.ctx, key)
 		require.NoError(t, err, "Resubmitted delete should succeed (idempotent)")
 
-		// Verify state after duplicate delete (operations are idempotent - no changes for tombstoned resources)
-		afterDelete2, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterDelete2, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should still find tombstoned resource")
 		require.NotNil(t, afterDelete2)
 		deleteState2 := afterDelete2.ReporterResources()[0].Serialize()
 		assert.Equal(t, deleteState1.RepresentationVersion, deleteState2.RepresentationVersion, "RepresentationVersion should remain unchanged for duplicate delete on tombstoned resource")
 		assert.Equal(t, deleteState1.Generation, deleteState2.Generation, "Generation should be unchanged by duplicate delete")
 		assert.True(t, deleteState2.Tombstone, "Resource should still be tombstoned")
-
 	})
 }
 
 func TestResourceLifecycle_ReportResubmitDeleteResubmit(t *testing.T) {
 	t.Run("report -> resubmit same report -> delete -> resubmit same delete", func(t *testing.T) {
-		ctx := testAuthzContext()
-		logger := log.DefaultLogger
+		h := newTestHarness(t, withNamespace("test-topic"))
 
-		resourceRepo := data.NewFakeResourceRepository()
-		schemaRepo := newFakeSchemaRepository(t)
-		relationsRepo := &data.AllowAllRelationsRepository{}
-		usecaseConfig := &UsecaseConfig{
-			ReadAfterWriteEnabled: false,
-			ConsumerEnabled:       false,
-		}
-
-		mc := metricscollector.NewFakeMetricsCollector()
-		usecase := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
 		resourceType := "host"
 		reporterType := "hbi"
 		reporterInstance := "idempotent-instance-2"
@@ -1245,13 +932,12 @@ func TestResourceLifecycle_ReportResubmitDeleteResubmit(t *testing.T) {
 		// 1. REPORT: Initial resource creation
 		log.Info("1. Initial Report ---------------------")
 		cmd := fixture(t).Basic(resourceType, reporterType, reporterInstance, localResourceId, workspaceId)
-		err := usecase.ReportResource(ctx, cmd)
+		err := h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Initial report should succeed")
 
 		key := createReporterResourceKey(t, localResourceId, resourceType, reporterType, reporterInstance)
 
-		// Verify initial state
-		afterReport1, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterReport1, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after initial report")
 		require.NotNil(t, afterReport1)
 		initialState := afterReport1.ReporterResources()[0].Serialize()
@@ -1259,14 +945,11 @@ func TestResourceLifecycle_ReportResubmitDeleteResubmit(t *testing.T) {
 		assert.Equal(t, uint(0), initialState.Generation, "Initial generation should be 0")
 		assert.False(t, initialState.Tombstone, "Initial tombstone should be false")
 
-		// 2. RESUBMIT SAME REPORT: Should be idempotent
-		log.Info("2. Resubmit Same Report ---------------------")
 		cmd = fixture(t).Basic(resourceType, reporterType, reporterInstance, localResourceId, workspaceId)
-		err = usecase.ReportResource(ctx, cmd)
+		err = h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Resubmitted report should succeed (idempotent)")
 
-		// Verify state after duplicate report (should increment representation version)
-		afterReport2, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterReport2, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after duplicate report")
 		require.NotNil(t, afterReport2)
 		duplicateState := afterReport2.ReporterResources()[0].Serialize()
@@ -1274,13 +957,10 @@ func TestResourceLifecycle_ReportResubmitDeleteResubmit(t *testing.T) {
 		assert.Equal(t, uint(0), duplicateState.Generation, "Generation should remain 0")
 		assert.False(t, duplicateState.Tombstone, "Resource should remain active")
 
-		// 3. DELETE: Delete the resource
-		log.Info("3. Delete ---------------------")
-		err = usecase.Delete(ctx, key)
+		err = h.usecase.Delete(h.ctx, key)
 		require.NoError(t, err, "Delete should succeed")
 
-		// Verify delete state
-		afterDelete1, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterDelete1, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find tombstoned resource after delete")
 		require.NotNil(t, afterDelete1)
 		deleteState1 := afterDelete1.ReporterResources()[0].Serialize()
@@ -1288,13 +968,10 @@ func TestResourceLifecycle_ReportResubmitDeleteResubmit(t *testing.T) {
 		assert.Equal(t, uint(0), deleteState1.Generation, "Generation should remain 0 after delete")
 		assert.True(t, deleteState1.Tombstone, "Resource should be tombstoned")
 
-		// 4. RESUBMIT SAME DELETE: Should be idempotent
-		log.Info("4. Resubmit Delete ---------------------")
-		err = usecase.Delete(ctx, key)
+		err = h.usecase.Delete(h.ctx, key)
 		require.NoError(t, err, "Resubmitted delete should succeed (idempotent)")
 
-		// Verify final state after duplicate delete (operations are idempotent - no changes for tombstoned resources)
-		afterDelete2, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterDelete2, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should still find tombstoned resource")
 		require.NotNil(t, afterDelete2)
 		finalDeleteState := afterDelete2.ReporterResources()[0].Serialize()
@@ -1306,19 +983,7 @@ func TestResourceLifecycle_ReportResubmitDeleteResubmit(t *testing.T) {
 
 func TestResourceLifecycle_ComplexIdempotency(t *testing.T) {
 	t.Run("3 cycles of create+update+delete for same resource", func(t *testing.T) {
-		ctx := testAuthzContext()
-		logger := log.DefaultLogger
-
-		resourceRepo := data.NewFakeResourceRepository()
-		schemaRepo := newFakeSchemaRepository(t)
-		relationsRepo := &data.AllowAllRelationsRepository{}
-		usecaseConfig := &UsecaseConfig{
-			ReadAfterWriteEnabled: false,
-			ConsumerEnabled:       false,
-		}
-
-		mc := metricscollector.NewFakeMetricsCollector()
-		usecase := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
+		h := newTestHarness(t, withNamespace("test-topic"))
 
 		resourceType := "k8s_cluster"
 		reporterType := "ocm"
@@ -1328,35 +993,28 @@ func TestResourceLifecycle_ComplexIdempotency(t *testing.T) {
 
 		key := createReporterResourceKey(t, localResourceId, resourceType, reporterType, reporterInstance)
 
-		// Run 3 cycles of create+update+delete
 		for cycle := 0; cycle < 3; cycle++ {
 			t.Logf("=== Cycle %d: Create+Update+Delete ===", cycle)
 
-			// 1. REPORT (CREATE or UPDATE): Should find existing or create new
-			log.Infof("Cycle %d: Report Resource", cycle)
 			cmd := fixture(t).WithCycleData(resourceType, reporterType, reporterInstance, localResourceId, workspaceId, cycle)
-			err := usecase.ReportResource(ctx, cmd)
+			err := h.usecase.ReportResource(h.ctx, cmd)
 			require.NoError(t, err, "Report should succeed in cycle %d", cycle)
 
-			// Verify state after report
-			afterReport, err := resourceRepo.FindResourceByKeys(nil, key)
+			afterReport, err := h.resourceRepo.FindResourceByKeys(nil, key)
 			require.NoError(t, err, "Should find resource after report in cycle %d", cycle)
 			require.NotNil(t, afterReport)
 			reportState := afterReport.ReporterResources()[0].Serialize()
 
-			expectedGeneration := uint(cycle) // Generation should be 0, 1, 2 for cycles 0, 1, 2
+			expectedGeneration := uint(cycle)
 			assert.Equal(t, expectedGeneration, reportState.Generation, "Generation should be %d in cycle %d", expectedGeneration, cycle)
 			assert.Equal(t, uint(0), reportState.RepresentationVersion, "RepresentationVersion should reset to 0 for new generation in cycle %d", cycle)
 			assert.False(t, reportState.Tombstone, "Resource should be active after report in cycle %d", cycle)
 
-			// 2. UPDATE: Update the resource
-			log.Infof("Cycle %d: Update Resource", cycle)
 			cmd = fixture(t).Updated(resourceType, reporterType, reporterInstance, localResourceId, workspaceId)
-			err = usecase.ReportResource(ctx, cmd)
+			err = h.usecase.ReportResource(h.ctx, cmd)
 			require.NoError(t, err, "Update should succeed in cycle %d", cycle)
 
-			// Verify state after update
-			afterUpdate, err := resourceRepo.FindResourceByKeys(nil, key)
+			afterUpdate, err := h.resourceRepo.FindResourceByKeys(nil, key)
 			require.NoError(t, err, "Should find resource after update in cycle %d", cycle)
 			require.NotNil(t, afterUpdate)
 			updateState := afterUpdate.ReporterResources()[0].Serialize()
@@ -1364,13 +1022,10 @@ func TestResourceLifecycle_ComplexIdempotency(t *testing.T) {
 			assert.Equal(t, uint(1), updateState.RepresentationVersion, "RepresentationVersion should increment to 1 after update in cycle %d", cycle)
 			assert.False(t, updateState.Tombstone, "Resource should remain active after update in cycle %d", cycle)
 
-			// 3. DELETE: Delete the resource
-			log.Infof("Cycle %d: Delete Resource", cycle)
-			err = usecase.Delete(ctx, key)
+			err = h.usecase.Delete(h.ctx, key)
 			require.NoError(t, err, "Delete should succeed in cycle %d", cycle)
 
-			// Verify state after delete
-			afterDelete, err := resourceRepo.FindResourceByKeys(nil, key)
+			afterDelete, err := h.resourceRepo.FindResourceByKeys(nil, key)
 			require.NoError(t, err, "Should find tombstoned resource after delete in cycle %d", cycle)
 			require.NotNil(t, afterDelete)
 			deleteState := afterDelete.ReporterResources()[0].Serialize()
@@ -1382,8 +1037,7 @@ func TestResourceLifecycle_ComplexIdempotency(t *testing.T) {
 				cycle, deleteState.Generation, deleteState.RepresentationVersion, deleteState.Tombstone)
 		}
 
-		// Final verification: Resource should be in generation 2 after 3 cycles
-		finalResource, err := resourceRepo.FindResourceByKeys(nil, key)
+		finalResource, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find final resource")
 		require.NotNil(t, finalResource)
 		finalState := finalResource.ReporterResources()[0].Serialize()
@@ -1467,160 +1121,97 @@ func createTestRep(t *testing.T, version uint, data map[string]interface{}) *mod
 }
 
 func TestTransactionIdIdempotency(t *testing.T) {
-	ctx := testAuthzContext()
-	logger := log.DefaultLogger
+	h := newTestHarness(t, withNamespace("test-topic"))
 
-	resourceRepo := data.NewFakeResourceRepository()
-	schemaRepo := newFakeSchemaRepository(t)
-	relationsRepo := &data.AllowAllRelationsRepository{}
-	usecaseConfig := &UsecaseConfig{
-		ReadAfterWriteEnabled: false,
-		ConsumerEnabled:       false,
-	}
-
-	mc := metricscollector.NewFakeMetricsCollector()
-	usecase := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
-
-	// When TransactionId is nil, resolveOptionalFields returns nil; domain generates a new transaction ID.
-	// ReportResource should still succeed.
 	t.Run("Nil TransactionId in command resolves to generated ID and create succeeds", func(t *testing.T) {
 		cmd := fixture(t).Basic("host", "hbi", "nil-tx-instance", "local-nil-tx", "ws-nil-tx")
 		require.Nil(t, cmd.TransactionId, "fixture Basic leaves TransactionId nil")
-		err := usecase.ReportResource(ctx, cmd)
+		err := h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "ReportResource with nil TransactionId should succeed (ID generated)")
 		key := createReporterResourceKey(t, "local-nil-tx", "host", "hbi", "nil-tx-instance")
-		found, err := resourceRepo.FindResourceByKeys(nil, key)
+		found, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err)
 		require.NotNil(t, found, "Resource should exist after create with nil TransactionId")
 	})
 
 	t.Run("Same transaction ID should be idempotent - no changes to representation tables", func(t *testing.T) {
-		resourceType := "host"
-		reporterType := "hbi"
-		reporterInstance := "test-instance"
-		localResourceId := "test-resource"
-		workspaceId := "test-workspace"
-		transactionId := "test-transaction-123"
-
-		// 1. First report with transaction ID
-		cmd := fixture(t).WithTransactionId(resourceType, reporterType, reporterInstance, localResourceId, workspaceId, transactionId)
-		err := usecase.ReportResource(ctx, cmd)
+		cmd := fixture(t).WithTransactionId("host", "hbi", "test-instance", "test-resource", "test-workspace", "test-transaction-123")
+		err := h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "First report should succeed")
 
-		// Get the resource key for verification
-		key := createReporterResourceKey(t, localResourceId, resourceType, reporterType, reporterInstance)
-
-		// Verify initial state
-		afterFirst, err := resourceRepo.FindResourceByKeys(nil, key)
+		key := createReporterResourceKey(t, "test-resource", "host", "hbi", "test-instance")
+		afterFirst, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after first report")
 		require.NotNil(t, afterFirst)
 		firstState := afterFirst.ReporterResources()[0].Serialize()
-		initialRepVersion := firstState.RepresentationVersion
-		initialGeneration := firstState.Generation
 
-		// 2. Second report with SAME transaction ID - should be idempotent
-		cmd = fixture(t).WithTransactionId(resourceType, reporterType, reporterInstance, localResourceId, workspaceId, transactionId)
-		err = usecase.ReportResource(ctx, cmd)
+		cmd = fixture(t).WithTransactionId("host", "hbi", "test-instance", "test-resource", "test-workspace", "test-transaction-123")
+		err = h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Second report with same transaction ID should succeed (idempotent)")
 
-		// Verify no changes were made to representation tables
-		afterSecond, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterSecond, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after second report")
 		require.NotNil(t, afterSecond)
 		secondState := afterSecond.ReporterResources()[0].Serialize()
 
-		assert.Equal(t, initialRepVersion, secondState.RepresentationVersion, "RepresentationVersion should not change for idempotent request")
-		assert.Equal(t, initialGeneration, secondState.Generation, "Generation should not change for idempotent request")
+		assert.Equal(t, firstState.RepresentationVersion, secondState.RepresentationVersion, "RepresentationVersion should not change for idempotent request")
+		assert.Equal(t, firstState.Generation, secondState.Generation, "Generation should not change for idempotent request")
 	})
 
 	t.Run("Different transaction ID should update representations", func(t *testing.T) {
-		resourceType := "host"
-		reporterType := "hbi"
-		reporterInstance := "test-instance-2"
-		localResourceId := "test-resource-2"
-		workspaceId := "test-workspace-2"
-		transactionId1 := "test-transaction-456"
-		transactionId2 := "test-transaction-789"
-
-		// 1. First report with transaction ID
-		cmd := fixture(t).WithTransactionId(resourceType, reporterType, reporterInstance, localResourceId, workspaceId, transactionId1)
-		err := usecase.ReportResource(ctx, cmd)
+		cmd := fixture(t).WithTransactionId("host", "hbi", "test-instance-2", "test-resource-2", "test-workspace-2", "test-transaction-456")
+		err := h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "First report should succeed")
 
-		// Get the resource key for verification
-		key := createReporterResourceKey(t, localResourceId, resourceType, reporterType, reporterInstance)
-
-		// Verify initial state
-		afterFirst, err := resourceRepo.FindResourceByKeys(nil, key)
+		key := createReporterResourceKey(t, "test-resource-2", "host", "hbi", "test-instance-2")
+		afterFirst, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after first report")
 		require.NotNil(t, afterFirst)
 		firstState := afterFirst.ReporterResources()[0].Serialize()
-		initialRepVersion := firstState.RepresentationVersion
-		initialGeneration := firstState.Generation
 
-		// 2. Second report with DIFFERENT transaction ID - should update representations
-		cmd = fixture(t).UpdatedWithTransactionId(resourceType, reporterType, reporterInstance, localResourceId, workspaceId, transactionId2)
-		err = usecase.ReportResource(ctx, cmd)
+		cmd = fixture(t).UpdatedWithTransactionId("host", "hbi", "test-instance-2", "test-resource-2", "test-workspace-2", "test-transaction-789")
+		err = h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Second report with different transaction ID should succeed")
 
-		// Verify representations were updated
-		afterSecond, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterSecond, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after second report")
 		require.NotNil(t, afterSecond)
 		secondState := afterSecond.ReporterResources()[0].Serialize()
 
-		assert.Equal(t, initialRepVersion+1, secondState.RepresentationVersion, "RepresentationVersion should increment for different transaction ID")
-		assert.Equal(t, initialGeneration, secondState.Generation, "Generation should remain the same for update")
+		assert.Equal(t, firstState.RepresentationVersion+1, secondState.RepresentationVersion, "RepresentationVersion should increment for different transaction ID")
+		assert.Equal(t, firstState.Generation, secondState.Generation, "Generation should remain the same for update")
 	})
 
 	t.Run("Report with transaction ID -> Update with new transaction ID -> Delete should update representations", func(t *testing.T) {
-		resourceType := "host"
-		reporterType := "hbi"
-		reporterInstance := "test-instance-3"
-		localResourceId := "test-resource-3"
-		workspaceId := "test-workspace-3"
-		transactionId1 := "test-transaction-111"
-		transactionId2 := "test-transaction-222"
-
-		// 1. First report with transaction ID
-		cmd := fixture(t).WithTransactionId(resourceType, reporterType, reporterInstance, localResourceId, workspaceId, transactionId1)
-		err := usecase.ReportResource(ctx, cmd)
+		cmd := fixture(t).WithTransactionId("host", "hbi", "test-instance-3", "test-resource-3", "test-workspace-3", "test-transaction-111")
+		err := h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "First report should succeed")
 
-		// Get the resource key for verification
-		key := createReporterResourceKey(t, localResourceId, resourceType, reporterType, reporterInstance)
-
-		// Verify initial state
-		afterFirst, err := resourceRepo.FindResourceByKeys(nil, key)
+		key := createReporterResourceKey(t, "test-resource-3", "host", "hbi", "test-instance-3")
+		afterFirst, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after first report")
 		require.NotNil(t, afterFirst)
 		firstState := afterFirst.ReporterResources()[0].Serialize()
-		initialRepVersion := firstState.RepresentationVersion
-		initialGeneration := firstState.Generation
-		assert.Equal(t, uint(0), initialRepVersion, "Initial representationVersion should be 0")
-		assert.Equal(t, uint(0), initialGeneration, "Initial generation should be 0")
+		assert.Equal(t, uint(0), firstState.RepresentationVersion, "Initial representationVersion should be 0")
+		assert.Equal(t, uint(0), firstState.Generation, "Initial generation should be 0")
 		assert.False(t, firstState.Tombstone, "Initial tombstone should be false")
 
-		// 2. Update with DIFFERENT transaction ID - should update representations
-		cmd = fixture(t).UpdatedWithTransactionId(resourceType, reporterType, reporterInstance, localResourceId, workspaceId, transactionId2)
-		err = usecase.ReportResource(ctx, cmd)
+		cmd = fixture(t).UpdatedWithTransactionId("host", "hbi", "test-instance-3", "test-resource-3", "test-workspace-3", "test-transaction-222")
+		err = h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Update with different transaction ID should succeed")
 
-		// Verify state after update
-		afterUpdate, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterUpdate, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after update")
 		require.NotNil(t, afterUpdate)
 		updateState := afterUpdate.ReporterResources()[0].Serialize()
-		assert.Equal(t, initialRepVersion+1, updateState.RepresentationVersion, "RepresentationVersion should increment after update")
-		assert.Equal(t, initialGeneration, updateState.Generation, "Generation should remain the same after update")
+		assert.Equal(t, firstState.RepresentationVersion+1, updateState.RepresentationVersion, "RepresentationVersion should increment after update")
+		assert.Equal(t, firstState.Generation, updateState.Generation, "Generation should remain the same after update")
 		assert.False(t, updateState.Tombstone, "Resource should remain active after update")
 
-		// 3. Delete resource (no transaction ID) - should update representations
-		err = usecase.Delete(ctx, key)
+		err = h.usecase.Delete(h.ctx, key)
 		require.NoError(t, err, "Delete should succeed")
 
-		// Verify state after delete
-		afterDelete, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterDelete, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find tombstoned resource after delete")
 		require.NotNil(t, afterDelete)
 		deleteState := afterDelete.ReporterResources()[0].Serialize()
@@ -1630,52 +1221,35 @@ func TestTransactionIdIdempotency(t *testing.T) {
 	})
 
 	t.Run("Report with transaction ID -> Report with same transaction ID -> Delete should update representations", func(t *testing.T) {
-		resourceType := "host"
-		reporterType := "hbi"
-		reporterInstance := "test-instance-4"
-		localResourceId := "test-resource-4"
-		workspaceId := "test-workspace-4"
-		transactionId := "test-transaction-333"
-
-		// 1. First report with transaction ID
-		cmd := fixture(t).WithTransactionId(resourceType, reporterType, reporterInstance, localResourceId, workspaceId, transactionId)
-		err := usecase.ReportResource(ctx, cmd)
+		cmd := fixture(t).WithTransactionId("host", "hbi", "test-instance-4", "test-resource-4", "test-workspace-4", "test-transaction-333")
+		err := h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "First report should succeed")
 
-		// Get the resource key for verification
-		key := createReporterResourceKey(t, localResourceId, resourceType, reporterType, reporterInstance)
-
-		// Verify initial state
-		afterFirst, err := resourceRepo.FindResourceByKeys(nil, key)
+		key := createReporterResourceKey(t, "test-resource-4", "host", "hbi", "test-instance-4")
+		afterFirst, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after first report")
 		require.NotNil(t, afterFirst)
 		firstState := afterFirst.ReporterResources()[0].Serialize()
-		initialRepVersion := firstState.RepresentationVersion
-		initialGeneration := firstState.Generation
-		assert.Equal(t, uint(0), initialRepVersion, "Initial representationVersion should be 0")
-		assert.Equal(t, uint(0), initialGeneration, "Initial generation should be 0")
+		assert.Equal(t, uint(0), firstState.RepresentationVersion, "Initial representationVersion should be 0")
+		assert.Equal(t, uint(0), firstState.Generation, "Initial generation should be 0")
 		assert.False(t, firstState.Tombstone, "Initial tombstone should be false")
 
-		// 2. Second report with SAME transaction ID - should be idempotent
-		cmd = fixture(t).WithTransactionId(resourceType, reporterType, reporterInstance, localResourceId, workspaceId, transactionId)
-		err = usecase.ReportResource(ctx, cmd)
+		cmd = fixture(t).WithTransactionId("host", "hbi", "test-instance-4", "test-resource-4", "test-workspace-4", "test-transaction-333")
+		err = h.usecase.ReportResource(h.ctx, cmd)
 		require.NoError(t, err, "Second report with same transaction ID should succeed (idempotent)")
 
-		// Verify state hasn't changed (idempotent)
-		afterSecond, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterSecond, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find resource after second report")
 		require.NotNil(t, afterSecond)
 		secondState := afterSecond.ReporterResources()[0].Serialize()
-		assert.Equal(t, initialRepVersion, secondState.RepresentationVersion, "RepresentationVersion should not change for idempotent request")
-		assert.Equal(t, initialGeneration, secondState.Generation, "Generation should not change for idempotent request")
+		assert.Equal(t, firstState.RepresentationVersion, secondState.RepresentationVersion, "RepresentationVersion should not change for idempotent request")
+		assert.Equal(t, firstState.Generation, secondState.Generation, "Generation should not change for idempotent request")
 		assert.False(t, secondState.Tombstone, "Resource should remain active")
 
-		// 3. Delete resource (no transaction ID) - should update representations
-		err = usecase.Delete(ctx, key)
+		err = h.usecase.Delete(h.ctx, key)
 		require.NoError(t, err, "Delete should succeed")
 
-		// Verify state after delete
-		afterDelete, err := resourceRepo.FindResourceByKeys(nil, key)
+		afterDelete, err := h.resourceRepo.FindResourceByKeys(nil, key)
 		require.NoError(t, err, "Should find tombstoned resource after delete")
 		require.NotNil(t, afterDelete)
 		deleteState := afterDelete.ReporterResources()[0].Serialize()
@@ -1685,22 +1259,8 @@ func TestTransactionIdIdempotency(t *testing.T) {
 	})
 }
 
-// TestReportResource_ValidationSuccess tests that a valid request passes validation.
 func TestReportResource_ValidationSuccess(t *testing.T) {
-	ctx := testAuthzContext()
-	schemaRepo := newFakeSchemaRepository(t)
-	usecase := New(
-		data.NewFakeResourceRepository(),
-		schemaRepo,
-		&data.AllowAllRelationsRepository{},
-		"test-topic",
-		log.DefaultLogger,
-		nil, nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		nil,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withNamespace("test-topic"))
 
 	cmd := fixture(t).WithData("host", "hbi", "instance-1", "test-host",
 		map[string]interface{}{
@@ -1712,26 +1272,12 @@ func TestReportResource_ValidationSuccess(t *testing.T) {
 		},
 	)
 
-	err := usecase.ReportResource(ctx, cmd)
+	err := h.usecase.ReportResource(h.ctx, cmd)
 	require.NoError(t, err)
 }
 
-// TestReportResource_ValidationErrors tests field validation errors.
 func TestReportResource_ValidationErrors(t *testing.T) {
-	ctx := testAuthzContext()
-	schemaRepo := newFakeSchemaRepository(t)
-	usecase := New(
-		data.NewFakeResourceRepository(),
-		schemaRepo,
-		&data.AllowAllRelationsRepository{},
-		"test-topic",
-		log.DefaultLogger,
-		nil, nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		nil,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withNamespace("test-topic"))
 
 	tests := []struct {
 		name        string
@@ -1742,7 +1288,7 @@ func TestReportResource_ValidationErrors(t *testing.T) {
 			name: "missing type",
 			cmd: func() ReportResourceCommand {
 				cmd := fixture(t).Basic("host", "hbi", "instance-1", "test-host", "ws-123")
-				cmd.ResourceType = "" // empty type
+				cmd.ResourceType = ""
 				return cmd
 			}(),
 			expectError: "missing 'type' field",
@@ -1751,7 +1297,7 @@ func TestReportResource_ValidationErrors(t *testing.T) {
 			name: "missing reporterType",
 			cmd: func() ReportResourceCommand {
 				cmd := fixture(t).Basic("host", "hbi", "instance-1", "test-host", "ws-123")
-				cmd.ReporterType = "" // empty reporter type
+				cmd.ReporterType = ""
 				return cmd
 			}(),
 			expectError: "missing 'reporterType' field",
@@ -1775,7 +1321,7 @@ func TestReportResource_ValidationErrors(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := usecase.ReportResource(ctx, tc.cmd)
+			err := h.usecase.ReportResource(h.ctx, tc.cmd)
 			if tc.expectError != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tc.expectError)
@@ -1974,24 +1520,8 @@ func TestReportResource_SchemaValidation(t *testing.T) {
 // These tests verify the exact error message format returned by the usecase layer.
 // They serve as a contract and must be updated if error formats change.
 
-// TestReportResource_RepresentationRequiredError tests that nil representations
-// TestReportResource_BothRepresentationsNil tests that when both representations
-// are nil, the domain rejects the request.
 func TestReportResource_BothRepresentationsNil(t *testing.T) {
-	ctx := testAuthzContext()
-	schemaRepo := newFakeSchemaRepository(t)
-	usecase := New(
-		data.NewFakeResourceRepository(),
-		schemaRepo,
-		&data.AllowAllRelationsRepository{},
-		"test-topic",
-		log.DefaultLogger,
-		nil, nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		nil,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withNamespace("test-topic"))
 
 	localResId, _ := model.NewLocalResourceId("test-host")
 	resType, _ := model.NewResourceType("host")
@@ -2010,28 +1540,13 @@ func TestReportResource_BothRepresentationsNil(t *testing.T) {
 		WriteVisibility:        WriteVisibilityMinimizeLatency,
 	}
 
-	err := usecase.ReportResource(ctx, cmd)
+	err := h.usecase.ReportResource(h.ctx, cmd)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one of reporterRepresentation or commonRepresentation must be provided")
 }
 
-// TestReportResource_ValidationErrorFormat tests that validation failures
-// return errors with the expected message format.
 func TestReportResource_ValidationErrorFormat(t *testing.T) {
-	ctx := testAuthzContext()
-	schemaRepo := newFakeSchemaRepository(t)
-	usecase := New(
-		data.NewFakeResourceRepository(),
-		schemaRepo,
-		&data.AllowAllRelationsRepository{},
-		"test-topic",
-		log.DefaultLogger,
-		nil, nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		nil,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withNamespace("test-topic"))
 
 	tests := []struct {
 		name           string
@@ -2065,7 +1580,7 @@ func TestReportResource_ValidationErrorFormat(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := usecase.ReportResource(ctx, tc.cmd)
+			err := h.usecase.ReportResource(h.ctx, tc.cmd)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tc.expectErrorMsg)
 		})
@@ -2166,43 +1681,19 @@ func TestResolveConsistencyToken(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Use testAuthzContext so ReportResource (when resourceExists) can pass meta-authz
-			ctx := testAuthzContext()
-			logger := log.DefaultLogger
-
-			resourceRepo := data.NewFakeResourceRepository()
-			schemaRepo := newFakeSchemaRepository(t)
-			relationsRepo := &data.AllowAllRelationsRepository{}
-			usecaseConfig := &UsecaseConfig{
-				ReadAfterWriteEnabled:          false,
-				ConsumerEnabled:                false,
+			h := newTestHarness(t, withNamespace("test-topic"), withUsecaseConfig(&UsecaseConfig{
 				DefaultToAtLeastAsAcknowledged: tt.featureFlagEnabled,
-			}
-			mc := metricscollector.NewFakeMetricsCollector()
-			uc := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
+			}))
 
-			// Create test reporter resource key
-			localResourceId, err := model.NewLocalResourceId("test-resource-123")
-			require.NoError(t, err)
-			resourceType, err := model.NewResourceType("host")
-			require.NoError(t, err)
-			reporterType, err := model.NewReporterType("hbi")
-			require.NoError(t, err)
-			reporterInstanceId, err := model.NewReporterInstanceId("test-instance")
-			require.NoError(t, err)
+			reporterResourceKey := createReporterResourceKey(t, "test-resource-123", "host", "hbi", "test-instance")
 
-			reporterResourceKey, err := model.NewReporterResourceKey(localResourceId, resourceType, reporterType, reporterInstanceId)
-			require.NoError(t, err)
-
-			// If resource should exist, create it first
 			if tt.resourceExists {
 				cmd := fixture(t).Basic("host", "hbi", "test-instance", "test-resource-123", "test-workspace")
-				err := uc.ReportResource(ctx, cmd)
+				err := h.usecase.ReportResource(h.ctx, cmd)
 				require.NoError(t, err)
 			}
 
-			// Call the function under test
-			token, err := uc.resolveConsistencyToken(ctx, tt.consistency, reporterResourceKey, false)
+			token, err := h.usecase.resolveConsistencyToken(h.ctx, tt.consistency, reporterResourceKey, false)
 
 			if tt.expectedError {
 				assert.Error(t, err)
@@ -2259,39 +1750,19 @@ func TestResolveConsistencyToken_OverrideFeatureFlag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := testAuthzContext()
-			logger := log.DefaultLogger
-
-			resourceRepo := data.NewFakeResourceRepository()
-			schemaRepo := newFakeSchemaRepository(t)
-			relationsRepo := &data.AllowAllRelationsRepository{}
-			usecaseConfig := &UsecaseConfig{
-				ReadAfterWriteEnabled:          false,
-				ConsumerEnabled:                false,
+			h := newTestHarness(t, withNamespace("test-topic"), withUsecaseConfig(&UsecaseConfig{
 				DefaultToAtLeastAsAcknowledged: tt.featureFlagEnabled,
-			}
-			mc := metricscollector.NewFakeMetricsCollector()
-			uc := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
+			}))
 
-			localResourceId, err := model.NewLocalResourceId("test-resource-override")
-			require.NoError(t, err)
-			resourceType, err := model.NewResourceType("host")
-			require.NoError(t, err)
-			reporterType, err := model.NewReporterType("hbi")
-			require.NoError(t, err)
-			reporterInstanceId, err := model.NewReporterInstanceId("test-instance")
-			require.NoError(t, err)
-
-			reporterResourceKey, err := model.NewReporterResourceKey(localResourceId, resourceType, reporterType, reporterInstanceId)
-			require.NoError(t, err)
+			reporterResourceKey := createReporterResourceKey(t, "test-resource-override", "host", "hbi", "test-instance")
 
 			if tt.resourceExists {
 				cmd := fixture(t).Basic("host", "hbi", "test-instance", "test-resource-override", "test-workspace")
-				err := uc.ReportResource(ctx, cmd)
+				err := h.usecase.ReportResource(h.ctx, cmd)
 				require.NoError(t, err)
 			}
 
-			token, err := uc.resolveConsistencyToken(ctx, tt.consistency, reporterResourceKey, true)
+			token, err := h.usecase.resolveConsistencyToken(h.ctx, tt.consistency, reporterResourceKey, true)
 			if tt.expectedError {
 				assert.Error(t, err)
 			} else {
@@ -2303,114 +1774,55 @@ func TestResolveConsistencyToken_OverrideFeatureFlag(t *testing.T) {
 }
 
 func TestResolveConsistencyToken_NilConsistencyDefaultsToUnspecified(t *testing.T) {
-	// Nil consistency should behave like unspecified for backward compatibility.
-	ctx := testAuthzContext()
-	logger := log.DefaultLogger
+	h := newTestHarness(t, withNamespace("test-topic"))
 
-	resourceRepo := data.NewFakeResourceRepository()
-	schemaRepo := newFakeSchemaRepository(t)
-	relationsRepo := &data.AllowAllRelationsRepository{}
-	usecaseConfig := &UsecaseConfig{
-		ReadAfterWriteEnabled:          false,
-		ConsumerEnabled:                false,
-		DefaultToAtLeastAsAcknowledged: false,
-	}
-
-	mc := metricscollector.NewFakeMetricsCollector()
-	uc := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
-
-	// Create test reporter resource key
-	localResourceId, err := model.NewLocalResourceId("test-resource-456")
-	require.NoError(t, err)
-	resourceType, err := model.NewResourceType("host")
-	require.NoError(t, err)
-	reporterType, err := model.NewReporterType("hbi")
-	require.NoError(t, err)
-	reporterInstanceId, err := model.NewReporterInstanceId("test-instance")
-	require.NoError(t, err)
-
-	reporterResourceKey, err := model.NewReporterResourceKey(localResourceId, resourceType, reporterType, reporterInstanceId)
-	require.NoError(t, err)
-
-	token, err := uc.resolveConsistencyToken(ctx, nil, reporterResourceKey, false)
+	reporterResourceKey := createReporterResourceKey(t, "test-resource-456", "host", "hbi", "test-instance")
+	token, err := h.usecase.resolveConsistencyToken(h.ctx, nil, reporterResourceKey, false)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "", token)
 }
 
 func TestResolveConsistencyToken_OverrideFeatureFlag_LogsBypassWhenEnabled(t *testing.T) {
-	ctx := testAuthzContext()
-
 	var logBuf bytes.Buffer
-	logger := log.NewStdLogger(&logBuf)
-
-	resourceRepo := data.NewFakeResourceRepository()
-	schemaRepo := newFakeSchemaRepository(t)
-	relationsRepo := &data.AllowAllRelationsRepository{}
-	usecaseConfig := &UsecaseConfig{
-		ReadAfterWriteEnabled:          false,
-		ConsumerEnabled:                false,
-		DefaultToAtLeastAsAcknowledged: true,
-	}
-
-	mc := metricscollector.NewFakeMetricsCollector()
-	uc := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
+	h := newTestHarness(t,
+		withNamespace("test-topic"),
+		withLogger(log.NewStdLogger(&logBuf)),
+		withUsecaseConfig(&UsecaseConfig{DefaultToAtLeastAsAcknowledged: true}),
+	)
 
 	reporterResourceKey := createReporterResourceKey(t, "host-123", "host", "hbi", "instance-1")
-
-	token, err := uc.resolveConsistencyToken(ctx, model.NewConsistencyUnspecified(), reporterResourceKey, true)
+	token, err := h.usecase.resolveConsistencyToken(h.ctx, model.NewConsistencyUnspecified(), reporterResourceKey, true)
 	require.NoError(t, err)
 	assert.Equal(t, "", token)
 	assert.Contains(t, strings.ToLower(logBuf.String()), "enabled but bypassed for this call")
 }
 
 func TestResolveConsistencyToken_OverrideFeatureFlag_LogsEnabledWhenNotBypassed(t *testing.T) {
-	ctx := testAuthzContext()
-
 	var logBuf bytes.Buffer
-	logger := log.NewStdLogger(&logBuf)
-
-	resourceRepo := data.NewFakeResourceRepository()
-	schemaRepo := newFakeSchemaRepository(t)
-	relationsRepo := &data.AllowAllRelationsRepository{}
-	usecaseConfig := &UsecaseConfig{
-		ReadAfterWriteEnabled:          false,
-		ConsumerEnabled:                false,
-		DefaultToAtLeastAsAcknowledged: true,
-	}
-
-	mc := metricscollector.NewFakeMetricsCollector()
-	uc := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
+	h := newTestHarness(t,
+		withNamespace("test-topic"),
+		withLogger(log.NewStdLogger(&logBuf)),
+		withUsecaseConfig(&UsecaseConfig{DefaultToAtLeastAsAcknowledged: true}),
+	)
 
 	reporterResourceKey := createReporterResourceKey(t, "host-456", "host", "hbi", "instance-1")
-
-	token, err := uc.resolveConsistencyToken(ctx, model.NewConsistencyUnspecified(), reporterResourceKey, false)
+	token, err := h.usecase.resolveConsistencyToken(h.ctx, model.NewConsistencyUnspecified(), reporterResourceKey, false)
 	require.NoError(t, err)
 	assert.Equal(t, "", token)
 	assert.Contains(t, strings.ToLower(logBuf.String()), "feature flag default-to-at-least-as-acknowledged is enabled")
 }
 
 func TestResolveConsistencyToken_OverrideFeatureFlag_LogsDisabledWhenFeatureOff(t *testing.T) {
-	ctx := testAuthzContext()
-
 	var logBuf bytes.Buffer
-	logger := log.NewStdLogger(&logBuf)
-
-	resourceRepo := data.NewFakeResourceRepository()
-	schemaRepo := newFakeSchemaRepository(t)
-	relationsRepo := &data.AllowAllRelationsRepository{}
-	usecaseConfig := &UsecaseConfig{
-		ReadAfterWriteEnabled:          false,
-		ConsumerEnabled:                false,
-		DefaultToAtLeastAsAcknowledged: false,
-	}
-
-	mc := metricscollector.NewFakeMetricsCollector()
-	uc := New(resourceRepo, schemaRepo, relationsRepo, "test-topic", logger, nil, nil, usecaseConfig, mc, nil, newTestSelfSubjectStrategy())
+	h := newTestHarness(t,
+		withNamespace("test-topic"),
+		withLogger(log.NewStdLogger(&logBuf)),
+		withUsecaseConfig(&UsecaseConfig{DefaultToAtLeastAsAcknowledged: false}),
+	)
 
 	reporterResourceKey := createReporterResourceKey(t, "host-789", "host", "hbi", "instance-1")
-
-	token, err := uc.resolveConsistencyToken(ctx, model.NewConsistencyUnspecified(), reporterResourceKey, true)
+	token, err := h.usecase.resolveConsistencyToken(h.ctx, model.NewConsistencyUnspecified(), reporterResourceKey, true)
 	require.NoError(t, err)
 	assert.Equal(t, "", token)
 	assert.Contains(t, strings.ToLower(logBuf.String()), "feature flag default-to-at-least-as-acknowledged is disabled")
@@ -2578,27 +1990,11 @@ func TestCheck_AuthzDecisions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := testAuthzContext()
-			meta := &recordingMetaAuthorizer{allowed: true}
-
 			simpleAuthz := data.NewSimpleRelationsRepository()
 			if tt.grantSubjectID != "" {
 				simpleAuthz.Grant(tt.grantSubjectID, "view", "hbi", "host", "host-1")
 			}
-
-			uc := New(
-				data.NewFakeResourceRepository(),
-				newFakeSchemaRepository(t),
-				simpleAuthz,
-				"rbac",
-				log.DefaultLogger,
-				nil,
-				nil,
-				&UsecaseConfig{},
-				metricscollector.NewFakeMetricsCollector(),
-				meta,
-				newTestSelfSubjectStrategy(),
-			)
+			h := newTestHarness(t, withMeta(true), withRelations(simpleAuthz))
 
 			subject, err := buildTestSubjectReference("user-1")
 			require.NoError(t, err)
@@ -2606,11 +2002,11 @@ func TestCheck_AuthzDecisions(t *testing.T) {
 			relation, err := model.NewRelation("view")
 			require.NoError(t, err)
 
-			allowed, token, err := uc.Check(ctx, relation, subject, key, model.NewConsistencyUnspecified())
+			allowed, token, err := h.usecase.Check(h.ctx, relation, subject, key, model.NewConsistencyUnspecified())
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantAllowed, allowed)
 			assert.NotEmpty(t, token)
-			assert.Equal(t, 1, meta.calls)
+			assert.Equal(t, 1, h.meta.calls)
 		})
 	}
 }
@@ -2627,27 +2023,11 @@ func TestCheckForUpdate_AuthzDecisions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := testAuthzContext()
-			meta := &recordingMetaAuthorizer{allowed: true}
-
 			simpleAuthz := data.NewSimpleRelationsRepository()
 			if tt.grantSubjectID != "" {
 				simpleAuthz.Grant(tt.grantSubjectID, "update", "hbi", "host", "host-1")
 			}
-
-			uc := New(
-				data.NewFakeResourceRepository(),
-				newFakeSchemaRepository(t),
-				simpleAuthz,
-				"rbac",
-				log.DefaultLogger,
-				nil,
-				nil,
-				&UsecaseConfig{},
-				metricscollector.NewFakeMetricsCollector(),
-				meta,
-				newTestSelfSubjectStrategy(),
-			)
+			h := newTestHarness(t, withMeta(true), withRelations(simpleAuthz))
 
 			subject, err := buildTestSubjectReference("user-1")
 			require.NoError(t, err)
@@ -2655,37 +2035,20 @@ func TestCheckForUpdate_AuthzDecisions(t *testing.T) {
 			relation, err := model.NewRelation("update")
 			require.NoError(t, err)
 
-			allowed, token, err := uc.CheckForUpdate(ctx, relation, subject, key)
+			allowed, token, err := h.usecase.CheckForUpdate(h.ctx, relation, subject, key)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantAllowed, allowed)
 			assert.NotEmpty(t, token)
-			assert.Equal(t, 1, meta.calls)
+			assert.Equal(t, 1, h.meta.calls)
 		})
 	}
 }
 
-// TestCheckBulk_RelationsMixedResults verifies that CheckBulk returns per-item allowed/denied results.
 func TestCheckBulk_RelationsMixedResults(t *testing.T) {
-	ctx := testAuthzContext()
-	meta := &recordingMetaAuthorizer{allowed: true}
-
 	simpleAuthz := data.NewSimpleRelationsRepository()
 	simpleAuthz.Grant("user-1", "view", "hbi", "host", "host-1")
-	// No grant for host-2
 
-	uc := New(
-		data.NewFakeResourceRepository(),
-		newFakeSchemaRepository(t),
-		simpleAuthz,
-		"rbac",
-		log.DefaultLogger,
-		nil,
-		nil,
-		&UsecaseConfig{},
-		metricscollector.NewFakeMetricsCollector(),
-		meta,
-		newTestSelfSubjectStrategy(),
-	)
+	h := newTestHarness(t, withMeta(true), withRelations(simpleAuthz))
 
 	subject, err := buildTestSubjectReference("user-1")
 	require.NoError(t, err)
@@ -2694,7 +2057,7 @@ func TestCheckBulk_RelationsMixedResults(t *testing.T) {
 	relation, err := model.NewRelation("view")
 	require.NoError(t, err)
 
-	result, err := uc.CheckBulk(ctx, CheckBulkCommand{
+	result, err := h.usecase.CheckBulk(h.ctx, CheckBulkCommand{
 		Items: []CheckBulkItem{
 			{Resource: key1, Relation: relation, Subject: subject},
 			{Resource: key2, Relation: relation, Subject: subject},
@@ -2707,7 +2070,7 @@ func TestCheckBulk_RelationsMixedResults(t *testing.T) {
 	assert.Nil(t, result.Pairs[0].Result.Error)
 	assert.False(t, result.Pairs[1].Result.Allowed, "host-2 should be denied")
 	assert.Nil(t, result.Pairs[1].Result.Error)
-	assert.Equal(t, 2, meta.calls)
+	assert.Equal(t, 2, h.meta.calls)
 }
 
 func TestLookupResources_StreamResults(t *testing.T) {
@@ -2733,27 +2096,11 @@ func TestLookupResources_StreamResults(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := testAuthzContext()
-			meta := &recordingMetaAuthorizer{allowed: true}
-
 			simpleAuthz := data.NewSimpleRelationsRepository()
 			for _, g := range tt.grants {
 				simpleAuthz.Grant(g.subjectID, "view", "hbi", "host", g.resourceID)
 			}
-
-			uc := New(
-				data.NewFakeResourceRepository(),
-				newFakeSchemaRepository(t),
-				simpleAuthz,
-				"rbac",
-				log.DefaultLogger,
-				nil,
-				nil,
-				&UsecaseConfig{},
-				metricscollector.NewFakeMetricsCollector(),
-				meta,
-				newTestSelfSubjectStrategy(),
-			)
+			h := newTestHarness(t, withMeta(true), withRelations(simpleAuthz))
 
 			subject, err := buildTestSubjectReference("user-1")
 			require.NoError(t, err)
@@ -2764,7 +2111,7 @@ func TestLookupResources_StreamResults(t *testing.T) {
 			relation, err := model.NewRelation("view")
 			require.NoError(t, err)
 
-			stream, err := uc.LookupResources(ctx, LookupResourcesCommand{
+			stream, err := h.usecase.LookupResources(h.ctx, LookupResourcesCommand{
 				ResourceType: resourceType,
 				ReporterType: reporterType,
 				Relation:     relation,
@@ -2787,7 +2134,7 @@ func TestLookupResources_StreamResults(t *testing.T) {
 			wantSorted := slices.Clone(tt.wantIDs)
 			slices.Sort(wantSorted)
 			assert.Equal(t, wantSorted, resourceIds)
-			assert.Equal(t, 1, meta.calls)
+			assert.Equal(t, 1, h.meta.calls)
 		})
 	}
 }
@@ -2812,27 +2159,11 @@ func TestLookupSubjects_StreamResults(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := testAuthzContext()
-			meta := &recordingMetaAuthorizer{allowed: true}
-
 			simpleAuthz := data.NewSimpleRelationsRepository()
 			for _, subjectID := range tt.grantSubjectIDs {
 				simpleAuthz.Grant(subjectID, "view", "hbi", "host", "host-1")
 			}
-
-			uc := New(
-				data.NewFakeResourceRepository(),
-				newFakeSchemaRepository(t),
-				simpleAuthz,
-				"rbac",
-				log.DefaultLogger,
-				nil,
-				nil,
-				&UsecaseConfig{},
-				metricscollector.NewFakeMetricsCollector(),
-				meta,
-				newTestSelfSubjectStrategy(),
-			)
+			h := newTestHarness(t, withMeta(true), withRelations(simpleAuthz))
 
 			key := createReporterResourceKey(t, "host-1", "host", "hbi", "instance-1")
 			relation, err := model.NewRelation("view")
@@ -2842,7 +2173,7 @@ func TestLookupSubjects_StreamResults(t *testing.T) {
 			subjectReporter, err := model.NewReporterType("rbac")
 			require.NoError(t, err)
 
-			stream, err := uc.LookupSubjects(ctx, LookupSubjectsCommand{
+			stream, err := h.usecase.LookupSubjects(h.ctx, LookupSubjectsCommand{
 				Resource:        key,
 				Relation:        relation,
 				SubjectType:     subjectType,
@@ -2865,7 +2196,7 @@ func TestLookupSubjects_StreamResults(t *testing.T) {
 			wantSorted := slices.Clone(tt.wantIDs)
 			slices.Sort(wantSorted)
 			assert.Equal(t, wantSorted, subjectIds)
-			assert.Equal(t, 1, meta.calls)
+			assert.Equal(t, 1, h.meta.calls)
 		})
 	}
 }

--- a/internal/config/relations/config_test.go
+++ b/internal/config/relations/config_test.go
@@ -1,0 +1,111 @@
+package relations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/project-kessel/inventory-api/internal/config/relations/kessel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Complete_AllowAll_Success(t *testing.T) {
+	cfg := &Config{
+		Authz:  AllowAll,
+		Kessel: nil,
+	}
+
+	completed, errs := cfg.Complete(context.Background())
+
+	assert.Nil(t, errs, "AllowAll config should complete without errors")
+	assert.NotNil(t, completed.completedConfig, "Completed config should not be nil")
+	assert.Equal(t, AllowAll, completed.Authz, "Authz should be AllowAll")
+}
+
+func TestConfig_Complete_Kessel_SwallowsErrors(t *testing.T) {
+	// This test documents the buggy behavior where Complete swallows
+	// errors from kessel.Config.Complete() and returns nil instead.
+	// See config.go line 41-42:
+	//   if ksl, errs := c.Kessel.Complete(ctx); errs != nil {
+	//       return CompletedConfig{}, nil  // BUG: should return errs
+	//   }
+	//
+	// This bug means that if kessel.Config.Complete ever returns an error
+	// (e.g., grpc.NewClient fails), the error is silently swallowed and
+	// nil is returned instead, giving the caller no indication of failure.
+	//
+	// NOTE: In practice, grpc.NewClient rarely fails during creation (it defers
+	// connection establishment), so this bug may not manifest often, but the
+	// principle is wrong: errors should be propagated, not swallowed.
+
+	// For now, we test the happy path (no error from kessel.Complete)
+	// and document that the error-swallowing code path exists but is
+	// difficult to trigger in tests.
+	kesselCfg := kessel.NewConfig(&kessel.Options{
+		URL:            "localhost:9000",
+		Insecure:       true,
+		ClientId:       "test-client",
+		ClientSecret:   "test-secret",
+		TokenEndpoint:  "http://localhost:8080/token",
+		EnableOidcAuth: false,
+	})
+
+	cfg := &Config{
+		Authz:  Kessel,
+		Kessel: kesselCfg,
+	}
+
+	completed, errs := cfg.Complete(context.Background())
+
+	// Current behavior: when kessel.Complete succeeds, no errors
+	assert.Nil(t, errs, "When kessel.Complete succeeds, no errors should be returned")
+	assert.NotNil(t, completed.completedConfig, "Completed config should not be nil")
+	assert.Equal(t, Kessel, completed.Authz, "Authz should be Kessel")
+	assert.NotNil(t, completed.Kessel, "Kessel config should be present")
+
+	// The bug exists in the code but is documented here in comments:
+	// IF kessel.Complete were to return errors, they would be swallowed
+	// and nil would be returned instead (see config.go:42).
+}
+
+func TestCheckRelationsImpl_AllCases(t *testing.T) {
+	tests := []struct {
+		name         string
+		authz        string
+		expectedType string
+	}{
+		{
+			name:         "AllowAll returns AllowAll",
+			authz:        AllowAll,
+			expectedType: "AllowAll",
+		},
+		{
+			name:         "Kessel returns Kessel",
+			authz:        Kessel,
+			expectedType: "Kessel",
+		},
+		{
+			name:         "Unknown value returns Unknown",
+			authz:        "some-random-value",
+			expectedType: "Unknown",
+		},
+		{
+			name:         "Empty string returns Unknown",
+			authz:        "",
+			expectedType: "Unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := CompletedConfig{
+				completedConfig: &completedConfig{
+					Authz: tt.authz,
+				},
+			}
+
+			result := CheckRelationsImpl(config)
+			require.Equal(t, tt.expectedType, result)
+		})
+	}
+}

--- a/internal/consumer/consumer_test.go
+++ b/internal/consumer/consumer_test.go
@@ -994,7 +994,8 @@ func TestInventoryConsumer_UpdateWithSameWorkspace_NoOp(t *testing.T) {
 
 	tester.inv.ResourceRepository = fakeRepo
 
-	relationsRepo := &mocks.MockRelationsRepository{}
+	// Use SimpleRelationsRepository to verify no operations occur
+	relationsRepo := data.NewSimpleRelationsRepository()
 	tester.inv.Relations = relationsRepo
 	msg := &kafka.Message{
 		Key:   []byte(testMessageKey),
@@ -1009,6 +1010,6 @@ func TestInventoryConsumer_UpdateWithSameWorkspace_NoOp(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, "", resp)
-	relationsRepo.AssertNumberOfCalls(t, "CreateTuples", 0)
-	relationsRepo.AssertNumberOfCalls(t, "DeleteTuples", 0)
+	// Verify no relations operations occurred - version should still be 1 (initial)
+	assert.Equal(t, int64(1), relationsRepo.Version(), "No relations operations should occur when workspace doesn't change")
 }

--- a/internal/consumer/consumer_test.go
+++ b/internal/consumer/consumer_test.go
@@ -82,11 +82,8 @@ func (t *TestCase) TestSetup(testingT *testing.T) []error {
 
 	notifier := &pubsub.NotifierMock{}
 
-	relationsRepo := &mocks.MockRelationsRepository{}
-	createTupleResponse := &v1beta1.CreateTuplesResponse{ConsistencyToken: &v1beta1.ConsistencyToken{Token: "test-token"}}
-	deleteTupleResponse := &v1beta1.DeleteTuplesResponse{ConsistencyToken: &v1beta1.ConsistencyToken{Token: "test-token"}}
-	relationsRepo.On("CreateTuples", mock.Anything, mock.Anything).Return(createTupleResponse, nil)
-	relationsRepo.On("DeleteTuples", mock.Anything, mock.Anything).Return(deleteTupleResponse, nil)
+	// Use SimpleRelationsRepository instead of mock - actually stores tuples in memory
+	relationsRepo := data.NewSimpleRelationsRepository()
 
 	consumer := &mocks.MockConsumer{}
 	db := setupInMemoryDB(testingT)
@@ -399,7 +396,7 @@ func TestInventoryConsumer_ProcessMessage(t *testing.T) {
 			if (test.expectedOperation == string(model.OperationTypeCreated) || test.expectedOperation == string(model.OperationTypeUpdated)) && test.relationsEnabled {
 				resp, err := tester.inv.ProcessMessage(parsedHeaders, test.relationsEnabled, test.msg)
 				assert.Nil(t, err)
-				assert.Equal(t, "test-token", resp)
+				assert.NotEmpty(t, resp, "Should return consistency token for create/update operations")
 			} else {
 				resp, err := tester.inv.ProcessMessage(parsedHeaders, test.relationsEnabled, test.msg)
 				assert.Nil(t, err)
@@ -567,11 +564,11 @@ func TestRebalanceCallback_AssignedPartitions(t *testing.T) {
 			errs := tester.TestSetup(t)
 			assert.Nil(t, errs)
 
-			relationsRepo := &mocks.MockRelationsRepository{}
-			if test.expectAcquireLockCall {
-				relationsRepo.On("AcquireLock", mock.Anything, mock.MatchedBy(func(req *v1beta1.AcquireLockRequest) bool {
-					return req.LockId == test.expectedLockId
-				})).Return(test.lockResponse, test.lockError)
+			// Use SimpleRelationsRepository instead of mock
+			relationsRepo := data.NewSimpleRelationsRepository()
+			if test.expectAcquireLockCall && test.lockError != nil {
+				// Configure error for failure case
+				relationsRepo.SetAcquireLockError(test.lockError)
 			}
 			tester.inv.Relations = relationsRepo
 
@@ -583,10 +580,11 @@ func TestRebalanceCallback_AssignedPartitions(t *testing.T) {
 
 			assert.Equal(t, test.expectedError, err)
 			assert.Equal(t, test.expectedLockId, tester.inv.lockId)
-			assert.Equal(t, test.expectedLockToken, tester.inv.lockToken)
-
-			if test.expectAcquireLockCall {
-				relationsRepo.AssertExpectations(t)
+			// For successful case, verify token was set (SimpleRelationsRepository generates token-{lockId})
+			if test.expectedError == nil && test.expectAcquireLockCall {
+				assert.NotEmpty(t, tester.inv.lockToken)
+			} else {
+				assert.Equal(t, test.expectedLockToken, tester.inv.lockToken)
 			}
 		})
 	}
@@ -804,8 +802,9 @@ func TestInventoryConsumer_CreateTuple_FailedPrecondition(t *testing.T) {
 	errs := tester.TestSetup(t)
 	assert.Nil(t, errs)
 
-	relationsRepo := &mocks.MockRelationsRepository{}
-	relationsRepo.On("CreateTuples", mock.Anything, mock.Anything).Return((*v1beta1.CreateTuplesResponse)(nil), status.Error(codes.FailedPrecondition, "invalid fencing token"))
+	// Use SimpleRelationsRepository with configured error instead of mock
+	relationsRepo := data.NewSimpleRelationsRepository()
+	relationsRepo.SetCreateTuplesError(status.Error(codes.FailedPrecondition, "invalid fencing token"))
 
 	tester.inv.Relations = relationsRepo
 	tester.inv.lockToken = "test-token"
@@ -830,8 +829,6 @@ func TestInventoryConsumer_CreateTuple_FailedPrecondition(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, "", resp)
 	assert.Contains(t, err.Error(), "invalid fencing token")
-
-	relationsRepo.AssertExpectations(t)
 }
 
 func TestInventoryConsumer_UpdateTuple_FailedPrecondition(t *testing.T) {
@@ -839,8 +836,9 @@ func TestInventoryConsumer_UpdateTuple_FailedPrecondition(t *testing.T) {
 	errs := tester.TestSetup(t)
 	assert.Nil(t, errs)
 
-	relationsRepo := &mocks.MockRelationsRepository{}
-	relationsRepo.On("CreateTuples", mock.Anything, mock.Anything).Return((*v1beta1.CreateTuplesResponse)(nil), status.Error(codes.FailedPrecondition, "invalid fencing token"))
+	// Use SimpleRelationsRepository with configured error instead of mock
+	relationsRepo := data.NewSimpleRelationsRepository()
+	relationsRepo.SetCreateTuplesError(status.Error(codes.FailedPrecondition, "invalid fencing token"))
 
 	tester.inv.Relations = relationsRepo
 	tester.inv.lockToken = "test-token"
@@ -865,8 +863,6 @@ func TestInventoryConsumer_UpdateTuple_FailedPrecondition(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, "", resp)
 	assert.Contains(t, err.Error(), "invalid fencing token")
-
-	relationsRepo.AssertExpectations(t)
 }
 
 func TestInventoryConsumer_DeleteTuple_FailedPrecondition(t *testing.T) {
@@ -874,8 +870,9 @@ func TestInventoryConsumer_DeleteTuple_FailedPrecondition(t *testing.T) {
 	errs := tester.TestSetup(t)
 	assert.Nil(t, errs)
 
-	relationsRepo := &mocks.MockRelationsRepository{}
-	relationsRepo.On("DeleteTuples", mock.Anything, mock.Anything).Return((*v1beta1.DeleteTuplesResponse)(nil), status.Error(codes.FailedPrecondition, "invalid fencing token"))
+	// Use SimpleRelationsRepository with configured error instead of mock
+	relationsRepo := data.NewSimpleRelationsRepository()
+	relationsRepo.SetDeleteTuplesError(status.Error(codes.FailedPrecondition, "invalid fencing token"))
 
 	tester.inv.Relations = relationsRepo
 	tester.inv.lockToken = "test-token"
@@ -900,8 +897,6 @@ func TestInventoryConsumer_DeleteTuple_FailedPrecondition(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, "", resp)
 	assert.Contains(t, err.Error(), "invalid fencing token")
-
-	relationsRepo.AssertExpectations(t)
 }
 
 func TestUpdateConsistencyTokenIfPresent(t *testing.T) {

--- a/internal/data/health/healthrepository_test.go
+++ b/internal/data/health/healthrepository_test.go
@@ -5,9 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/project-kessel/inventory-api/internal/mocks"
-	kesselv1 "github.com/project-kessel/relations-api/api/kessel/relations/v1"
-
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -77,22 +74,22 @@ func TestHealthRepo_IsBackendAvailable_AllCases(t *testing.T) {
 	assert.Contains(t, resp.Status, "RELATIONS-API UNHEALTHY")
 
 	db1 := setupGorm(t)
-	mockRelations1 := &mocks.MockRelationsRepository{}
-	mockRelations1.On("Health", ctx).Return(&kesselv1.GetReadyzResponse{Status: "OK"}, nil)
-	healthRepo1 := New(db1, mockRelations1, relationsConfig)
+	simpleRelations1 := data.NewSimpleRelationsRepository()
+	// Healthy relations (default state)
+	healthRepo1 := New(db1, simpleRelations1, relationsConfig)
 	resp, err = healthRepo1.IsBackendAvailable(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(200), resp.Code)
 	assert.Contains(t, resp.Status, "Storage type sqlite")
 
 	db2 := setupGorm(t)
-	mockRelations2 := &mocks.MockRelationsRepository{}
-	mockRelations2.On("Health", ctx).Return(&kesselv1.GetReadyzResponse{Status: "OK"}, nil)
+	simpleRelations2 := data.NewSimpleRelationsRepository()
+	// Healthy relations, but DB closed
 	sqlDB2, _ := db2.DB()
 	if err := sqlDB2.Close(); err != nil {
 		t.Logf("Warning: failed to close db: %v", err)
 	}
-	healthRepo2 := New(db2, mockRelations2, relationsConfig)
+	healthRepo2 := New(db2, simpleRelations2, relationsConfig)
 	resp, err = healthRepo2.IsBackendAvailable(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(500), resp.Code)
@@ -100,9 +97,9 @@ func TestHealthRepo_IsBackendAvailable_AllCases(t *testing.T) {
 	assert.NotContains(t, resp.Status, "RELATIONS-API UNHEALTHY")
 
 	db3 := setupGorm(t)
-	mockRelations3 := &mocks.MockRelationsRepository{}
-	mockRelations3.On("Health", ctx).Return((*kesselv1.GetReadyzResponse)(nil), errors.New("RELATIONS-API UNHEALTHY"))
-	healthRepo3 := New(db3, mockRelations3, relationsConfig)
+	simpleRelations3 := data.NewSimpleRelationsRepository()
+	simpleRelations3.SetHealthError(errors.New("RELATIONS-API UNHEALTHY"))
+	healthRepo3 := New(db3, simpleRelations3, relationsConfig)
 	resp, err = healthRepo3.IsBackendAvailable(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(500), resp.Code)

--- a/internal/data/relations_simple.go
+++ b/internal/data/relations_simple.go
@@ -38,11 +38,21 @@ type simpleTupleKey struct {
 // Tests can retain old snapshots via RetainCurrentSnapshot() to test consistency
 // token behavior. Check operations with an "at least as fresh" token will use
 // the oldest retained snapshot that is >= the requested version.
+//
+// # Failure Simulation
+//
+// Tests can configure failure modes via SetHealthError(), SetCreateTuplesError(),
+// SetDeleteTuplesError(), and SetAcquireLockError() to simulate Relations API failures.
 type SimpleRelationsRepository struct {
-	mu        sync.RWMutex
-	version   int64                             // current version (monotonically increasing)
-	tuples    map[simpleTupleKey]bool           // current/latest tuple state
-	snapshots map[int64]map[simpleTupleKey]bool // retained historical snapshots (version -> tuples)
+	mu                sync.RWMutex
+	version           int64                             // current version (monotonically increasing)
+	tuples            map[simpleTupleKey]bool           // current/latest tuple state
+	snapshots         map[int64]map[simpleTupleKey]bool // retained historical snapshots (version -> tuples)
+	healthError       error                             // if set, Health() returns this error
+	createTuplesError error                             // if set, CreateTuples() returns this error
+	deleteTuplesError error                             // if set, DeleteTuples() returns this error
+	acquireLockError  error                             // if set, AcquireLock() returns this error
+	locks             map[string]string                 // lockId -> token
 }
 
 // NewSimpleRelationsRepository creates a SimpleRelationsRepository with no tuples at version 1.
@@ -51,6 +61,7 @@ func NewSimpleRelationsRepository() *SimpleRelationsRepository {
 		version:   1,
 		tuples:    make(map[simpleTupleKey]bool),
 		snapshots: make(map[int64]map[simpleTupleKey]bool),
+		locks:     make(map[string]string),
 	}
 }
 
@@ -201,9 +212,49 @@ func simpleTupleKeyFromRelationship(rel *kessel.Relationship) simpleTupleKey {
 	return key
 }
 
+// SetHealthError configures the error returned by Health().
+// Pass nil to simulate healthy state (default).
+// This allows tests to simulate Relations API failures.
+func (s *SimpleRelationsRepository) SetHealthError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.healthError = err
+}
+
+// SetCreateTuplesError configures the error that CreateTuples() will return.
+// This allows tests to simulate CreateTuples failures.
+func (s *SimpleRelationsRepository) SetCreateTuplesError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.createTuplesError = err
+}
+
+// SetDeleteTuplesError configures the error that DeleteTuples() will return.
+// This allows tests to simulate DeleteTuples failures.
+func (s *SimpleRelationsRepository) SetDeleteTuplesError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deleteTuplesError = err
+}
+
+// SetAcquireLockError configures the error that AcquireLock() will return.
+// This allows tests to simulate AcquireLock failures.
+func (s *SimpleRelationsRepository) SetAcquireLockError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.acquireLockError = err
+}
+
 // Health implements RelationsRepository.
+// Returns the configured health error if set via SetHealthError, otherwise returns healthy response.
 func (s *SimpleRelationsRepository) Health(_ context.Context) (*kesselv1.GetReadyzResponse, error) {
-	return &kesselv1.GetReadyzResponse{}, nil
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.healthError != nil {
+		return nil, s.healthError
+	}
+	return &kesselv1.GetReadyzResponse{Status: "OK"}, nil
 }
 
 // Check implements RelationsRepository.
@@ -472,9 +523,16 @@ func (s *SimpleRelationsRepository) LookupSubjects(_ context.Context, req *kesse
 
 // CreateTuples implements RelationsRepository by storing the relationship tuples.
 // This advances the version counter.
+// CreateTuples implements RelationsRepository by storing the given tuples.
+// Returns the configured error if set via SetCreateTuplesError.
 func (s *SimpleRelationsRepository) CreateTuples(_ context.Context, req *kessel.CreateTuplesRequest) (*kessel.CreateTuplesResponse, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// Return configured error if set
+	if s.createTuplesError != nil {
+		return nil, s.createTuplesError
+	}
 
 	for _, rel := range req.GetTuples() {
 		key := simpleTupleKeyFromRelationship(rel)
@@ -482,19 +540,33 @@ func (s *SimpleRelationsRepository) CreateTuples(_ context.Context, req *kessel.
 	}
 	s.advanceVersion()
 
-	return &kessel.CreateTuplesResponse{}, nil
+	return &kessel.CreateTuplesResponse{
+		ConsistencyToken: &kessel.ConsistencyToken{
+			Token: strconv.FormatInt(s.version, 10),
+		},
+	}, nil
 }
 
 // DeleteTuples implements RelationsRepository by removing tuples matching the filter.
 // This advances the version counter.
+// Returns the configured error if set via SetDeleteTuplesError.
 func (s *SimpleRelationsRepository) DeleteTuples(_ context.Context, req *kessel.DeleteTuplesRequest) (*kessel.DeleteTuplesResponse, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// Return configured error if set
+	if s.deleteTuplesError != nil {
+		return nil, s.deleteTuplesError
+	}
+
 	filter := req.GetFilter()
 	if filter == nil {
 		s.advanceVersion()
-		return &kessel.DeleteTuplesResponse{}, nil
+		return &kessel.DeleteTuplesResponse{
+			ConsistencyToken: &kessel.ConsistencyToken{
+				Token: strconv.FormatInt(s.version, 10),
+			},
+		}, nil
 	}
 
 	for key := range s.tuples {
@@ -504,7 +576,11 @@ func (s *SimpleRelationsRepository) DeleteTuples(_ context.Context, req *kessel.
 	}
 	s.advanceVersion()
 
-	return &kessel.DeleteTuplesResponse{}, nil
+	return &kessel.DeleteTuplesResponse{
+		ConsistencyToken: &kessel.ConsistencyToken{
+			Token: strconv.FormatInt(s.version, 10),
+		},
+	}, nil
 }
 
 func simpleMatchesFilter(key simpleTupleKey, filter *kessel.RelationTupleFilter) bool {
@@ -536,8 +612,26 @@ func simpleMatchesFilter(key simpleTupleKey, filter *kessel.RelationTupleFilter)
 }
 
 // AcquireLock implements RelationsRepository.
-func (s *SimpleRelationsRepository) AcquireLock(_ context.Context, _ *kessel.AcquireLockRequest) (*kessel.AcquireLockResponse, error) {
-	return &kessel.AcquireLockResponse{}, nil
+// AcquireLock implements RelationsRepository by simulating lock acquisition.
+// Returns the configured error if set via SetAcquireLockError, otherwise generates
+// a lock token based on the lock ID and stores it.
+func (s *SimpleRelationsRepository) AcquireLock(_ context.Context, req *kessel.AcquireLockRequest) (*kessel.AcquireLockResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Return configured error if set
+	if s.acquireLockError != nil {
+		return nil, s.acquireLockError
+	}
+
+	// Generate lock token from lock ID (simplified - just use the lock ID as the token)
+	lockId := req.GetLockId()
+	token := "token-" + lockId
+	s.locks[lockId] = token
+
+	return &kessel.AcquireLockResponse{
+		LockToken: token,
+	}, nil
 }
 
 // UnsetWorkspace implements RelationsRepository.

--- a/internal/data/relations_simple.go
+++ b/internal/data/relations_simple.go
@@ -521,9 +521,8 @@ func (s *SimpleRelationsRepository) LookupSubjects(_ context.Context, req *kesse
 	return &simpleLookupSubjectsStream{results: results}, nil
 }
 
-// CreateTuples implements RelationsRepository by storing the relationship tuples.
-// This advances the version counter.
 // CreateTuples implements RelationsRepository by storing the given tuples.
+// This advances the version counter.
 // Returns the configured error if set via SetCreateTuplesError.
 func (s *SimpleRelationsRepository) CreateTuples(_ context.Context, req *kessel.CreateTuplesRequest) (*kessel.CreateTuplesResponse, error) {
 	s.mu.Lock()
@@ -611,7 +610,6 @@ func simpleMatchesFilter(key simpleTupleKey, filter *kessel.RelationTupleFilter)
 	return true
 }
 
-// AcquireLock implements RelationsRepository.
 // AcquireLock implements RelationsRepository by simulating lock acquisition.
 // Returns the configured error if set via SetAcquireLockError, otherwise generates
 // a lock token based on the lock ID and stores it.

--- a/internal/data/relations_simple.go
+++ b/internal/data/relations_simple.go
@@ -169,13 +169,18 @@ func (s *SimpleRelationsRepository) Grant(subjectID, relation, namespace, resour
 	s.advanceVersion()
 }
 
-// Reset clears all tuples and snapshots, resetting version to 1.
+// Reset restores the repository to its initial state (equivalent to NewSimpleRelationsRepository).
 func (s *SimpleRelationsRepository) Reset() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.tuples = make(map[simpleTupleKey]bool)
 	s.snapshots = make(map[int64]map[simpleTupleKey]bool)
+	s.locks = make(map[string]string)
 	s.version = 1
+	s.healthError = nil
+	s.createTuplesError = nil
+	s.deleteTuplesError = nil
+	s.acquireLockError = nil
 }
 
 // simpleHasTupleInSnapshot checks if a tuple exists in the given tuple map.

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -51,11 +51,17 @@ type MockRelationsRepository struct {
 
 func (m *MockRelationsRepository) CheckBulk(ctx context.Context, req *v1beta1.CheckBulkRequest) (*v1beta1.CheckBulkResponse, error) {
 	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*v1beta1.CheckBulkResponse), args.Error(1)
 }
 
 func (m *MockRelationsRepository) CheckForUpdateBulk(ctx context.Context, req *v1beta1.CheckForUpdateBulkRequest) (*v1beta1.CheckForUpdateBulkResponse, error) {
 	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*v1beta1.CheckForUpdateBulkResponse), args.Error(1)
 }
 

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -38,10 +38,11 @@ func (m *MockHealthRepo) IsRelationsAvailable(ctx context.Context) (*pb.GetReady
 }
 
 // MockRelationsRepository is a minimal mock for RelationsRepository.
-// It only implements CheckBulk and CheckForUpdateBulk, which are needed for
-// edge-case tests that SimpleRelationsRepository cannot produce:
+// It only implements methods needed for edge-case tests that SimpleRelationsRepository cannot produce:
 //   - CheckBulk: for response length mismatches
 //   - CheckForUpdateBulk: for per-pair errors
+//   - AcquireLock: for complex fencing token validation scenarios
+//   - CreateTuples: for complex fencing token validation scenarios
 //
 // All other tests should use SimpleRelationsRepository (a fake) instead.
 type MockRelationsRepository struct {
@@ -56,6 +57,22 @@ func (m *MockRelationsRepository) CheckBulk(ctx context.Context, req *v1beta1.Ch
 func (m *MockRelationsRepository) CheckForUpdateBulk(ctx context.Context, req *v1beta1.CheckForUpdateBulkRequest) (*v1beta1.CheckForUpdateBulkResponse, error) {
 	args := m.Called(ctx, req)
 	return args.Get(0).(*v1beta1.CheckForUpdateBulkResponse), args.Error(1)
+}
+
+func (m *MockRelationsRepository) AcquireLock(ctx context.Context, req *v1beta1.AcquireLockRequest) (*v1beta1.AcquireLockResponse, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*v1beta1.AcquireLockResponse), args.Error(1)
+}
+
+func (m *MockRelationsRepository) CreateTuples(ctx context.Context, req *v1beta1.CreateTuplesRequest) (*v1beta1.CreateTuplesResponse, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*v1beta1.CreateTuplesResponse), args.Error(1)
 }
 
 // Stub methods that panic to enforce use of SimpleRelationsRepository for normal test cases.
@@ -81,16 +98,8 @@ func (m *MockRelationsRepository) LookupSubjects(ctx context.Context, in *v1beta
 	panic("MockRelationsRepository.LookupSubjects() is not supported - use SimpleRelationsRepository instead")
 }
 
-func (m *MockRelationsRepository) CreateTuples(ctx context.Context, req *v1beta1.CreateTuplesRequest) (*v1beta1.CreateTuplesResponse, error) {
-	panic("MockRelationsRepository.CreateTuples() is not supported - use SimpleRelationsRepository instead")
-}
-
 func (m *MockRelationsRepository) DeleteTuples(ctx context.Context, req *v1beta1.DeleteTuplesRequest) (*v1beta1.DeleteTuplesResponse, error) {
 	panic("MockRelationsRepository.DeleteTuples() is not supported - use SimpleRelationsRepository instead")
-}
-
-func (m *MockRelationsRepository) AcquireLock(ctx context.Context, req *v1beta1.AcquireLockRequest) (*v1beta1.AcquireLockResponse, error) {
-	panic("MockRelationsRepository.AcquireLock() is not supported - use SimpleRelationsRepository instead")
 }
 
 func (m *MockRelationsRepository) UnsetWorkspace(ctx context.Context, namespace string, resourceType string, localResourceId string) (*v1beta1.DeleteTuplesResponse, error) {

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -8,10 +8,10 @@ import (
 	"github.com/go-kratos/kratos/v2/transport"
 	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1"
 	"github.com/project-kessel/inventory-api/internal/pubsub"
-	kesselv1 "github.com/project-kessel/relations-api/api/kessel/relations/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
+	kesselv1 "github.com/project-kessel/relations-api/api/kessel/relations/v1"
 	"github.com/project-kessel/relations-api/api/kessel/relations/v1beta1"
 	"github.com/stretchr/testify/mock"
 )
@@ -37,23 +37,15 @@ func (m *MockHealthRepo) IsRelationsAvailable(ctx context.Context) (*pb.GetReady
 
 }
 
+// MockRelationsRepository is a minimal mock for RelationsRepository.
+// It only implements CheckBulk and CheckForUpdateBulk, which are needed for
+// edge-case tests that SimpleRelationsRepository cannot produce:
+//   - CheckBulk: for response length mismatches
+//   - CheckForUpdateBulk: for per-pair errors
+//
+// All other tests should use SimpleRelationsRepository (a fake) instead.
 type MockRelationsRepository struct {
 	mock.Mock
-}
-
-func (m *MockRelationsRepository) Health(ctx context.Context) (*kesselv1.GetReadyzResponse, error) {
-	args := m.Called(ctx)
-	return args.Get(0).(*kesselv1.GetReadyzResponse), args.Error(1)
-}
-
-func (m *MockRelationsRepository) Check(ctx context.Context, namespace string, permission string, consistencyToken string, resourceType string, localResourceId string, sub *v1beta1.SubjectReference) (v1beta1.CheckResponse_Allowed, *v1beta1.ConsistencyToken, error) {
-	args := m.Called(ctx, namespace, permission, consistencyToken, resourceType, localResourceId, sub)
-	return args.Get(0).(v1beta1.CheckResponse_Allowed), args.Get(1).(*v1beta1.ConsistencyToken), args.Error(2)
-}
-
-func (m *MockRelationsRepository) CheckForUpdate(ctx context.Context, namespace string, permission string, resourceType string, localResourceId string, sub *v1beta1.SubjectReference) (v1beta1.CheckForUpdateResponse_Allowed, *v1beta1.ConsistencyToken, error) {
-	args := m.Called(ctx, namespace, permission, resourceType, localResourceId, sub)
-	return args.Get(0).(v1beta1.CheckForUpdateResponse_Allowed), args.Get(1).(*v1beta1.ConsistencyToken), args.Error(2)
 }
 
 func (m *MockRelationsRepository) CheckBulk(ctx context.Context, req *v1beta1.CheckBulkRequest) (*v1beta1.CheckBulkResponse, error) {
@@ -66,40 +58,47 @@ func (m *MockRelationsRepository) CheckForUpdateBulk(ctx context.Context, req *v
 	return args.Get(0).(*v1beta1.CheckForUpdateBulkResponse), args.Error(1)
 }
 
-func (m *MockRelationsRepository) AcquireLock(ctx context.Context, req *v1beta1.AcquireLockRequest) (*v1beta1.AcquireLockResponse, error) {
-	args := m.Called(ctx, req)
-	return args.Get(0).(*v1beta1.AcquireLockResponse), args.Error(1)
+// Stub methods that panic to enforce use of SimpleRelationsRepository for normal test cases.
+// MockRelationsRepository should only be used for edge cases that cannot be produced by SimpleRelationsRepository.
+
+func (m *MockRelationsRepository) Health(ctx context.Context) (*kesselv1.GetReadyzResponse, error) {
+	panic("MockRelationsRepository.Health() is not supported - use SimpleRelationsRepository instead")
+}
+
+func (m *MockRelationsRepository) Check(ctx context.Context, namespace string, permission string, consistencyToken string, resourceType string, localResourceId string, sub *v1beta1.SubjectReference) (v1beta1.CheckResponse_Allowed, *v1beta1.ConsistencyToken, error) {
+	panic("MockRelationsRepository.Check() is not supported - use SimpleRelationsRepository instead")
+}
+
+func (m *MockRelationsRepository) CheckForUpdate(ctx context.Context, namespace string, permission string, resourceType string, localResourceId string, sub *v1beta1.SubjectReference) (v1beta1.CheckForUpdateResponse_Allowed, *v1beta1.ConsistencyToken, error) {
+	panic("MockRelationsRepository.CheckForUpdate() is not supported - use SimpleRelationsRepository instead")
+}
+
+func (m *MockRelationsRepository) LookupResources(ctx context.Context, in *v1beta1.LookupResourcesRequest) (grpc.ServerStreamingClient[v1beta1.LookupResourcesResponse], error) {
+	panic("MockRelationsRepository.LookupResources() is not supported - use SimpleRelationsRepository instead")
+}
+
+func (m *MockRelationsRepository) LookupSubjects(ctx context.Context, in *v1beta1.LookupSubjectsRequest) (grpc.ServerStreamingClient[v1beta1.LookupSubjectsResponse], error) {
+	panic("MockRelationsRepository.LookupSubjects() is not supported - use SimpleRelationsRepository instead")
 }
 
 func (m *MockRelationsRepository) CreateTuples(ctx context.Context, req *v1beta1.CreateTuplesRequest) (*v1beta1.CreateTuplesResponse, error) {
-	args := m.Called(ctx, req)
-	return args.Get(0).(*v1beta1.CreateTuplesResponse), args.Error(1)
+	panic("MockRelationsRepository.CreateTuples() is not supported - use SimpleRelationsRepository instead")
 }
 
-func (m *MockRelationsRepository) DeleteTuples(ctx context.Context, request *v1beta1.DeleteTuplesRequest) (*v1beta1.DeleteTuplesResponse, error) {
-	args := m.Called(ctx, request)
-	return args.Get(0).(*v1beta1.DeleteTuplesResponse), args.Error(1)
+func (m *MockRelationsRepository) DeleteTuples(ctx context.Context, req *v1beta1.DeleteTuplesRequest) (*v1beta1.DeleteTuplesResponse, error) {
+	panic("MockRelationsRepository.DeleteTuples() is not supported - use SimpleRelationsRepository instead")
 }
 
-func (m *MockRelationsRepository) UnsetWorkspace(ctx context.Context, namespace, localResourceId, resourceType string) (*v1beta1.DeleteTuplesResponse, error) {
-	args := m.Called(ctx, namespace, localResourceId, resourceType)
-	return args.Get(0).(*v1beta1.DeleteTuplesResponse), args.Error(1)
+func (m *MockRelationsRepository) AcquireLock(ctx context.Context, req *v1beta1.AcquireLockRequest) (*v1beta1.AcquireLockResponse, error) {
+	panic("MockRelationsRepository.AcquireLock() is not supported - use SimpleRelationsRepository instead")
 }
 
-func (m *MockRelationsRepository) SetWorkspace(ctx context.Context, local_resource_id, workspace, namespace, name string, upsert bool) (*v1beta1.CreateTuplesResponse, error) {
-	args := m.Called(ctx, local_resource_id, workspace, namespace, name, upsert)
-	return args.Get(0).(*v1beta1.CreateTuplesResponse), args.Error(1)
+func (m *MockRelationsRepository) UnsetWorkspace(ctx context.Context, namespace string, resourceType string, localResourceId string) (*v1beta1.DeleteTuplesResponse, error) {
+	panic("MockRelationsRepository.UnsetWorkspace() is not supported - use SimpleRelationsRepository instead")
 }
 
-// Update the MockRelationsRepository LookupResources method to match the exact signature
-func (m *MockRelationsRepository) LookupResources(ctx context.Context, request *v1beta1.LookupResourcesRequest) (grpc.ServerStreamingClient[v1beta1.LookupResourcesResponse], error) {
-	args := m.Called(ctx, request)
-	return args.Get(0).(grpc.ServerStreamingClient[v1beta1.LookupResourcesResponse]), args.Error(1)
-}
-
-func (m *MockRelationsRepository) LookupSubjects(ctx context.Context, request *v1beta1.LookupSubjectsRequest) (grpc.ServerStreamingClient[v1beta1.LookupSubjectsResponse], error) {
-	args := m.Called(ctx, request)
-	return args.Get(0).(grpc.ServerStreamingClient[v1beta1.LookupSubjectsResponse]), args.Error(1)
+func (m *MockRelationsRepository) SetWorkspace(ctx context.Context, namespace string, resourceType string, localResourceId string, workspaceId string, replace bool) (*v1beta1.CreateTuplesResponse, error) {
+	panic("MockRelationsRepository.SetWorkspace() is not supported - use SimpleRelationsRepository instead")
 }
 
 type MockConsumer struct {

--- a/internal/service/resources/kesselinventoryservice_test.go
+++ b/internal/service/resources/kesselinventoryservice_test.go
@@ -488,26 +488,12 @@ func TestInventoryService_CheckSelf_Allowed_XRhIdentity(t *testing.T) {
 	}
 
 	runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-		mockRelations := &mocks.MockRelationsRepository{}
-		mockRelations.
-			On("Check",
-				mock.Anything,
-				"hbi",
-				"view",
-				mock.Anything,
-				"host",
-				"dd1b73b9-3e33-4264-968c-e3ce55b9afec",
-				mock.MatchedBy(func(sub *relationsV1beta1.SubjectReference) bool {
-					// Verify subject is derived from claims (SubjectId for x-rh-identity).
-					return sub.Subject.Id == "user-123" &&
-						sub.Subject.Type.Name == "principal" &&
-						sub.Subject.Type.Namespace == "rbac"
-				}),
-			).
-			Return(relationsV1beta1.CheckResponse_ALLOWED_TRUE, &relationsV1beta1.ConsistencyToken{Token: "test-token"}, nil).
-			Once()
+		simpleAuthz := data.NewSimpleRelationsRepository()
+		// Grant permission for user-123 to view the host resource
+		// Subject is derived from claims (SubjectId for x-rh-identity): user-123 @ rbac/principal
+		simpleAuthz.Grant("user-123", "view", "hbi", "host", "dd1b73b9-3e33-4264-968c-e3ce55b9afec")
 		return TestServerConfig{
-				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: mockRelations}),
+				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
 				Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
 			}, func(t *testing.T, tr *Transport) {
 				ctx := context.Background()
@@ -515,8 +501,7 @@ func TestInventoryService_CheckSelf_Allowed_XRhIdentity(t *testing.T) {
 				resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfResponse { return &pb.CheckSelfResponse{} }))
 				assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Allowed)
 				assert.NotNil(t, resp.ConsistencyToken)
-				assert.Equal(t, "test-token", resp.ConsistencyToken.GetToken())
-				mockRelations.AssertExpectations(t)
+				assert.NotEmpty(t, resp.ConsistencyToken.GetToken())
 			}
 	})
 }
@@ -537,32 +522,17 @@ func TestInventoryService_CheckSelf_Allowed_XRhIdentity_SubjectIdMatch(t *testin
 	}
 
 	runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-		mockRelations := &mocks.MockRelationsRepository{}
-		mockRelations.
-			On("Check",
-				mock.Anything,
-				"hbi",
-				"view",
-				mock.Anything,
-				"host",
-				"dd1b73b9-3e33-4264-968c-e3ce55b9afec",
-				mock.MatchedBy(func(sub *relationsV1beta1.SubjectReference) bool {
-					return sub.Subject.Id == "testuser" &&
-						sub.Subject.Type.Name == "principal" &&
-						sub.Subject.Type.Namespace == "rbac"
-				}),
-			).
-			Return(relationsV1beta1.CheckResponse_ALLOWED_TRUE, &relationsV1beta1.ConsistencyToken{}, nil).
-			Once()
+		simpleAuthz := data.NewSimpleRelationsRepository()
+		// Grant permission for testuser to view the host resource
+		simpleAuthz.Grant("testuser", "view", "hbi", "host", "dd1b73b9-3e33-4264-968c-e3ce55b9afec")
 		return TestServerConfig{
-				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: mockRelations}),
+				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
 				Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
 			}, func(t *testing.T, tr *Transport) {
 				ctx := context.Background()
 				res := tr.Invoke(ctx, withBody(protoReq, CheckSelf, httpEndpoint("POST /api/kessel/v1beta2/checkself")))
 				resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfResponse { return &pb.CheckSelfResponse{} }))
 				assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Allowed)
-				mockRelations.AssertExpectations(t)
 			}
 	})
 }
@@ -583,28 +553,16 @@ func TestInventoryService_CheckSelf_Denied(t *testing.T) {
 	}
 
 	runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-		mockRelations := &mocks.MockRelationsRepository{}
-		mockRelations.
-			On("Check",
-				mock.Anything,
-				"hbi",
-				"view",
-				mock.Anything,
-				"host",
-				"dd1b73b9-3e33-4264-968c-e3ce55b9afec",
-				mock.Anything,
-			).
-			Return(relationsV1beta1.CheckResponse_ALLOWED_FALSE, &relationsV1beta1.ConsistencyToken{}, nil).
-			Once()
+		simpleAuthz := data.NewSimpleRelationsRepository()
+		// No grants - should return ALLOWED_FALSE
 		return TestServerConfig{
-				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: mockRelations}),
+				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
 				Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
 			}, func(t *testing.T, tr *Transport) {
 				ctx := context.Background()
 				res := tr.Invoke(ctx, withBody(protoReq, CheckSelf, httpEndpoint("POST /api/kessel/v1beta2/checkself")))
 				resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfResponse { return &pb.CheckSelfResponse{} }))
 				assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Allowed)
-				mockRelations.AssertExpectations(t)
 			}
 	})
 }
@@ -659,60 +617,12 @@ func TestInventoryService_CheckSelfBulk_Allowed_XRhIdentity(t *testing.T) {
 	}
 
 	runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-		mockRelations := &mocks.MockRelationsRepository{}
-		mockRelations.
-			On("CheckBulk",
-				mock.Anything,
-				mock.MatchedBy(func(req *relationsV1beta1.CheckBulkRequest) bool {
-					if len(req.Items) != 2 {
-						return false
-					}
-					s1 := req.Items[0].Subject
-					s2 := req.Items[1].Subject
-					return s1.Subject.Id == "user-123" &&
-						s1.Subject.Type.Name == "principal" &&
-						s1.Subject.Type.Namespace == "rbac" &&
-						s2.Subject.Id == "user-123" &&
-						s2.Subject.Type.Name == "principal" &&
-						s2.Subject.Type.Namespace == "rbac"
-				}),
-			).
-			Return(&relationsV1beta1.CheckBulkResponse{
-				Pairs: []*relationsV1beta1.CheckBulkResponsePair{
-					{
-						Request: &relationsV1beta1.CheckBulkRequestItem{
-							Resource: &relationsV1beta1.ObjectReference{
-								Type: &relationsV1beta1.ObjectType{Namespace: "hbi", Name: "host"},
-								Id:   "resource-1",
-							},
-							Relation: "view",
-						},
-						Response: &relationsV1beta1.CheckBulkResponsePair_Item{
-							Item: &relationsV1beta1.CheckBulkResponseItem{
-								Allowed: relationsV1beta1.CheckBulkResponseItem_ALLOWED_TRUE,
-							},
-						},
-					},
-					{
-						Request: &relationsV1beta1.CheckBulkRequestItem{
-							Resource: &relationsV1beta1.ObjectReference{
-								Type: &relationsV1beta1.ObjectType{Namespace: "hbi", Name: "host"},
-								Id:   "resource-2",
-							},
-							Relation: "edit",
-						},
-						Response: &relationsV1beta1.CheckBulkResponsePair_Item{
-							Item: &relationsV1beta1.CheckBulkResponseItem{
-								Allowed: relationsV1beta1.CheckBulkResponseItem_ALLOWED_TRUE,
-							},
-						},
-					},
-				},
-				ConsistencyToken: &relationsV1beta1.ConsistencyToken{Token: "test-token"},
-			}, nil).
-			Once()
+		simpleAuthz := data.NewSimpleRelationsRepository()
+		// Grant permissions for both items
+		simpleAuthz.Grant("user-123", "view", "hbi", "host", "resource-1")
+		simpleAuthz.Grant("user-123", "edit", "hbi", "host", "resource-2")
 		return TestServerConfig{
-				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: mockRelations}),
+				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
 				Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
 			}, func(t *testing.T, tr *Transport) {
 				ctx := context.Background()
@@ -722,8 +632,7 @@ func TestInventoryService_CheckSelfBulk_Allowed_XRhIdentity(t *testing.T) {
 				assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
 				assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[1].GetItem().Allowed)
 				assert.NotNil(t, resp.ConsistencyToken)
-				assert.Equal(t, "test-token", resp.ConsistencyToken.GetToken())
-				mockRelations.AssertExpectations(t)
+				assert.NotEmpty(t, resp.ConsistencyToken.GetToken())
 			}
 	})
 }
@@ -756,45 +665,11 @@ func TestInventoryService_CheckSelfBulk_MixedResults(t *testing.T) {
 	}
 
 	runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-		mockRelations := &mocks.MockRelationsRepository{}
-		mockRelations.
-			On("CheckBulk", mock.Anything, mock.Anything).
-			Return(&relationsV1beta1.CheckBulkResponse{
-				Pairs: []*relationsV1beta1.CheckBulkResponsePair{
-					{
-						Request: &relationsV1beta1.CheckBulkRequestItem{
-							Resource: &relationsV1beta1.ObjectReference{
-								Type: &relationsV1beta1.ObjectType{Namespace: "hbi", Name: "host"},
-								Id:   "resource-1",
-							},
-							Relation: "view",
-						},
-						Response: &relationsV1beta1.CheckBulkResponsePair_Item{
-							Item: &relationsV1beta1.CheckBulkResponseItem{
-								Allowed: relationsV1beta1.CheckBulkResponseItem_ALLOWED_TRUE,
-							},
-						},
-					},
-					{
-						Request: &relationsV1beta1.CheckBulkRequestItem{
-							Resource: &relationsV1beta1.ObjectReference{
-								Type: &relationsV1beta1.ObjectType{Namespace: "hbi", Name: "host"},
-								Id:   "resource-2",
-							},
-							Relation: "edit",
-						},
-						Response: &relationsV1beta1.CheckBulkResponsePair_Item{
-							Item: &relationsV1beta1.CheckBulkResponseItem{
-								Allowed: relationsV1beta1.CheckBulkResponseItem_ALLOWED_FALSE,
-							},
-						},
-					},
-				},
-				ConsistencyToken: &relationsV1beta1.ConsistencyToken{Token: "test-token"},
-			}, nil).
-			Once()
+		simpleAuthz := data.NewSimpleRelationsRepository()
+		// Grant permission for resource-1/view only - resource-2/edit will be denied
+		simpleAuthz.Grant("user-123", "view", "hbi", "host", "resource-1")
 		return TestServerConfig{
-				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: mockRelations}),
+				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
 				Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
 			}, func(t *testing.T, tr *Transport) {
 				ctx := context.Background()
@@ -807,7 +682,6 @@ func TestInventoryService_CheckSelfBulk_MixedResults(t *testing.T) {
 				assert.Equal(t, "view", resp.Pairs[0].Request.Relation)
 				assert.Equal(t, "resource-2", resp.Pairs[1].Request.Object.ResourceId)
 				assert.Equal(t, "edit", resp.Pairs[1].Request.Relation)
-				mockRelations.AssertExpectations(t)
 			}
 	})
 }
@@ -832,6 +706,8 @@ func TestInventoryService_CheckSelfBulk_ResponseLengthMismatch(t *testing.T) {
 	}
 
 	runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
+		// Edge case: CheckBulk returns more responses than requests (2 responses for 1 request)
+		// This should cause an Internal error since response length doesn't match request length
 		mockRelations := &mocks.MockRelationsRepository{}
 		mockRelations.
 			On("CheckBulk", mock.Anything, mock.Anything).
@@ -868,6 +744,7 @@ func TestInventoryService_CheckSelfBulk_ResponseLengthMismatch(t *testing.T) {
 				},
 			}, nil).
 			Once()
+
 		return TestServerConfig{
 				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: mockRelations}),
 				Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
@@ -2859,6 +2736,8 @@ func TestInventoryService_CheckForUpdateBulk_AllAllowed(t *testing.T) {
 	}
 
 	runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
+		// Edge case: Testing consistency token handling in CheckForUpdateBulk
+		// SimpleRelationsRepository doesn't support consistency tokens, so we mock CheckForUpdateBulk
 		mockRelations := &mocks.MockRelationsRepository{}
 		mockRelations.
 			On("CheckForUpdateBulk",
@@ -2911,6 +2790,7 @@ func TestInventoryService_CheckForUpdateBulk_AllAllowed(t *testing.T) {
 				ConsistencyToken: &relationsV1beta1.ConsistencyToken{Token: "update-bulk-token"},
 			}, nil).
 			Once()
+
 		return TestServerConfig{
 				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: mockRelations}),
 				Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
@@ -3985,6 +3865,138 @@ func TestInventoryService_ReportResource_MetaAuthzDenied(t *testing.T) {
 				Assert(t, res, requireError(codes.PermissionDenied))
 			}
 	})
+}
+
+// TestInventoryService_StreamedListSubjects_Success verifies that StreamedListSubjects returns granted subjects.
+func TestInventoryService_StreamedListSubjects_Success(t *testing.T) {
+	claims := &authnapi.Claims{
+		SubjectId: authnapi.SubjectId("user-abc"),
+		AuthType:  authnapi.AuthTypeXRhIdentity,
+	}
+
+	// Set up SimpleAuthorizer with tuples granting two subjects view on host-1
+	simpleAuthz := data.NewSimpleRelationsRepository()
+	simpleAuthz.Grant("user-1", "view", "hbi", "host", "host-1")
+	simpleAuthz.Grant("user-2", "view", "hbi", "host", "host-1")
+
+	uc := newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz})
+	client := newTestServer(t, TestServerConfig{
+		Usecase:       uc,
+		Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+	})
+
+	reporterType := "hbi"
+	subjectReporterType := "rbac"
+	req := &pb.StreamedListSubjectsRequest{
+		Resource: &pb.ResourceReference{
+			ResourceType: "host",
+			ResourceId:   "host-1",
+			Reporter:     &pb.ReporterReference{Type: reporterType},
+		},
+		Relation: "view",
+		SubjectType: &pb.RepresentationType{
+			ResourceType: "principal",
+			ReporterType: &subjectReporterType,
+		},
+	}
+
+	stream, err := client.StreamedListSubjects(context.Background(), req)
+	require.NoError(t, err)
+
+	// Collect all streamed results
+	var subjectIDs []string
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		subjectIDs = append(subjectIDs, resp.Subject.Resource.ResourceId)
+	}
+
+	// Should receive 2 subjects
+	assert.Len(t, subjectIDs, 2)
+	assert.Contains(t, subjectIDs, "user-1")
+	assert.Contains(t, subjectIDs, "user-2")
+}
+
+// TestInventoryService_StreamedListObjects_Empty verifies that StreamedListObjects returns EOF when no tuples are granted.
+func TestInventoryService_StreamedListObjects_Empty(t *testing.T) {
+	claims := &authnapi.Claims{
+		SubjectId: authnapi.SubjectId("user-abc"),
+		AuthType:  authnapi.AuthTypeXRhIdentity,
+	}
+
+	// Set up SimpleAuthorizer with no grants
+	simpleAuthz := data.NewSimpleRelationsRepository()
+
+	uc := newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz})
+	client := newTestServer(t, TestServerConfig{
+		Usecase:       uc,
+		Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+	})
+
+	reporterType := "hbi"
+	req := &pb.StreamedListObjectsRequest{
+		ObjectType: &pb.RepresentationType{
+			ReporterType: &reporterType,
+			ResourceType: "host",
+		},
+		Relation: "view",
+		Subject: &pb.SubjectReference{
+			Resource: &pb.ResourceReference{
+				ResourceId:   "subject-xyz",
+				ResourceType: "principal",
+				Reporter:     &pb.ReporterReference{Type: "rbac"},
+			},
+		},
+	}
+
+	stream, err := client.StreamedListObjects(context.Background(), req)
+	require.NoError(t, err)
+
+	// First Recv should return EOF
+	_, err = stream.Recv()
+	assert.Equal(t, io.EOF, err, "empty stream should return EOF immediately")
+}
+
+// TestInventoryService_StreamedListSubjects_Empty verifies that StreamedListSubjects returns EOF when no tuples are granted.
+func TestInventoryService_StreamedListSubjects_Empty(t *testing.T) {
+	claims := &authnapi.Claims{
+		SubjectId: authnapi.SubjectId("user-abc"),
+		AuthType:  authnapi.AuthTypeXRhIdentity,
+	}
+
+	// Set up SimpleAuthorizer with no grants
+	simpleAuthz := data.NewSimpleRelationsRepository()
+
+	uc := newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz})
+	client := newTestServer(t, TestServerConfig{
+		Usecase:       uc,
+		Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+	})
+
+	reporterType := "hbi"
+	subjectReporterType := "rbac"
+	req := &pb.StreamedListSubjectsRequest{
+		Resource: &pb.ResourceReference{
+			ResourceType: "host",
+			ResourceId:   "host-1",
+			Reporter:     &pb.ReporterReference{Type: reporterType},
+		},
+		Relation: "view",
+		SubjectType: &pb.RepresentationType{
+			ResourceType: "principal",
+			ReporterType: &subjectReporterType,
+		},
+	}
+
+	stream, err := client.StreamedListSubjects(context.Background(), req)
+	require.NoError(t, err)
+
+	// First Recv should return EOF
+	_, err = stream.Recv()
+	assert.Equal(t, io.EOF, err, "empty stream should return EOF immediately")
 }
 
 func newFakeSchemaRepository(t *testing.T) model.SchemaRepository {

--- a/internal/service/resources/kesselinventoryservice_test.go
+++ b/internal/service/resources/kesselinventoryservice_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"slices"
 	"testing"
 
 	krlog "github.com/go-kratos/kratos/v2/log"
@@ -472,99 +473,52 @@ func TestToLookupResourceResponse(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
-func TestInventoryService_CheckSelf_Allowed_XRhIdentity(t *testing.T) {
-	claims := &authnapi.Claims{
-		SubjectId: authnapi.SubjectId("user-123"),
-		AuthType:  authnapi.AuthTypeXRhIdentity,
+func TestInventoryService_CheckSelf_AuthzDecisions(t *testing.T) {
+	cases := []struct {
+		name           string
+		subjectID      string
+		grantSubjectID string
+		wantAllowed    pb.Allowed
+	}{
+		{"allowed - user-123", "user-123", "user-123", pb.Allowed_ALLOWED_TRUE},
+		{"allowed - testuser subject match", "testuser", "testuser", pb.Allowed_ALLOWED_TRUE},
+		{"denied - no grant", "user-123", "", pb.Allowed_ALLOWED_FALSE},
 	}
 
-	protoReq := &pb.CheckSelfRequest{
-		Relation: "view",
-		Object: &pb.ResourceReference{
-			ResourceId:   "dd1b73b9-3e33-4264-968c-e3ce55b9afec",
-			ResourceType: "host",
-			Reporter:     &pb.ReporterReference{Type: "hbi"},
-		},
-	}
-
-	runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-		simpleAuthz := data.NewSimpleRelationsRepository()
-		// Grant permission for user-123 to view the host resource
-		// Subject is derived from claims (SubjectId for x-rh-identity): user-123 @ rbac/principal
-		simpleAuthz.Grant("user-123", "view", "hbi", "host", "dd1b73b9-3e33-4264-968c-e3ce55b9afec")
-		return TestServerConfig{
-				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-				Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-			}, func(t *testing.T, tr *Transport) {
-				ctx := context.Background()
-				res := tr.Invoke(ctx, withBody(protoReq, CheckSelf, httpEndpoint("POST /api/kessel/v1beta2/checkself")))
-				resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfResponse { return &pb.CheckSelfResponse{} }))
-				assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Allowed)
-				assert.NotNil(t, resp.ConsistencyToken)
-				assert.NotEmpty(t, resp.ConsistencyToken.GetToken())
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			claims := &authnapi.Claims{
+				SubjectId: authnapi.SubjectId(tc.subjectID),
+				AuthType:  authnapi.AuthTypeXRhIdentity,
 			}
-	})
-}
 
-func TestInventoryService_CheckSelf_Allowed_XRhIdentity_SubjectIdMatch(t *testing.T) {
-	claims := &authnapi.Claims{
-		SubjectId: authnapi.SubjectId("testuser"),
-		AuthType:  authnapi.AuthTypeXRhIdentity,
-	}
-
-	protoReq := &pb.CheckSelfRequest{
-		Relation: "view",
-		Object: &pb.ResourceReference{
-			ResourceId:   "dd1b73b9-3e33-4264-968c-e3ce55b9afec",
-			ResourceType: "host",
-			Reporter:     &pb.ReporterReference{Type: "hbi"},
-		},
-	}
-
-	runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-		simpleAuthz := data.NewSimpleRelationsRepository()
-		// Grant permission for testuser to view the host resource
-		simpleAuthz.Grant("testuser", "view", "hbi", "host", "dd1b73b9-3e33-4264-968c-e3ce55b9afec")
-		return TestServerConfig{
-				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-				Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-			}, func(t *testing.T, tr *Transport) {
-				ctx := context.Background()
-				res := tr.Invoke(ctx, withBody(protoReq, CheckSelf, httpEndpoint("POST /api/kessel/v1beta2/checkself")))
-				resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfResponse { return &pb.CheckSelfResponse{} }))
-				assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Allowed)
+			protoReq := &pb.CheckSelfRequest{
+				Relation: "view",
+				Object: &pb.ResourceReference{
+					ResourceId:   "dd1b73b9-3e33-4264-968c-e3ce55b9afec",
+					ResourceType: "host",
+					Reporter:     &pb.ReporterReference{Type: "hbi"},
+				},
 			}
-	})
-}
 
-func TestInventoryService_CheckSelf_Denied(t *testing.T) {
-	claims := &authnapi.Claims{
-		SubjectId: authnapi.SubjectId("user-123"),
-		AuthType:  authnapi.AuthTypeXRhIdentity,
+			runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
+				simpleAuthz := data.NewSimpleRelationsRepository()
+				if tc.grantSubjectID != "" {
+					simpleAuthz.Grant(tc.grantSubjectID, "view", "hbi", "host", "dd1b73b9-3e33-4264-968c-e3ce55b9afec")
+				}
+				return TestServerConfig{
+						Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
+						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+					}, func(t *testing.T, tr *Transport) {
+						ctx := context.Background()
+						res := tr.Invoke(ctx, withBody(protoReq, CheckSelf, httpEndpoint("POST /api/kessel/v1beta2/checkself")))
+						resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfResponse { return &pb.CheckSelfResponse{} }))
+						assert.Equal(t, tc.wantAllowed, resp.Allowed)
+						assert.NotEmpty(t, resp.ConsistencyToken.GetToken())
+					}
+			})
+		})
 	}
-
-	protoReq := &pb.CheckSelfRequest{
-		Relation: "view",
-		Object: &pb.ResourceReference{
-			ResourceId:   "dd1b73b9-3e33-4264-968c-e3ce55b9afec",
-			ResourceType: "host",
-			Reporter:     &pb.ReporterReference{Type: "hbi"},
-		},
-	}
-
-	runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-		simpleAuthz := data.NewSimpleRelationsRepository()
-		// No grants - should return ALLOWED_FALSE
-		return TestServerConfig{
-				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-				Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-			}, func(t *testing.T, tr *Transport) {
-				ctx := context.Background()
-				res := tr.Invoke(ctx, withBody(protoReq, CheckSelf, httpEndpoint("POST /api/kessel/v1beta2/checkself")))
-				resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfResponse { return &pb.CheckSelfResponse{} }))
-				assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Allowed)
-			}
-	})
 }
 
 func TestInventoryService_CheckSelf_NoIdentity(t *testing.T) {
@@ -589,101 +543,94 @@ func TestInventoryService_CheckSelf_NoIdentity(t *testing.T) {
 	})
 }
 
-func TestInventoryService_CheckSelfBulk_Allowed_XRhIdentity(t *testing.T) {
-	claims := &authnapi.Claims{
-		SubjectId: authnapi.SubjectId("user-123"),
-		AuthType:  authnapi.AuthTypeXRhIdentity,
+func TestInventoryService_CheckSelfBulk_AuthzDecisions(t *testing.T) {
+	type grantSpec struct {
+		subjectID, relation, resourceID string
 	}
-
-	protoReq := &pb.CheckSelfBulkRequest{
-		Items: []*pb.CheckSelfBulkRequestItem{
-			{
-				Object: &pb.ResourceReference{
-					ResourceId:   "resource-1",
-					ResourceType: "host",
-					Reporter:     &pb.ReporterReference{Type: "hbi"},
-				},
-				Relation: "view",
+	type wantPair struct {
+		allowed    pb.Allowed
+		resourceID string
+		relation   string
+	}
+	cases := []struct {
+		name      string
+		grants    []grantSpec
+		wantPairs []wantPair
+	}{
+		{
+			"all allowed",
+			[]grantSpec{
+				{"user-123", "view", "resource-1"},
+				{"user-123", "edit", "resource-2"},
 			},
-			{
-				Object: &pb.ResourceReference{
-					ResourceId:   "resource-2",
-					ResourceType: "host",
-					Reporter:     &pb.ReporterReference{Type: "hbi"},
-				},
-				Relation: "edit",
+			[]wantPair{
+				{pb.Allowed_ALLOWED_TRUE, "resource-1", "view"},
+				{pb.Allowed_ALLOWED_TRUE, "resource-2", "edit"},
+			},
+		},
+		{
+			"mixed - first allowed, second denied",
+			[]grantSpec{
+				{"user-123", "view", "resource-1"},
+			},
+			[]wantPair{
+				{pb.Allowed_ALLOWED_TRUE, "resource-1", "view"},
+				{pb.Allowed_ALLOWED_FALSE, "resource-2", "edit"},
 			},
 		},
 	}
 
-	runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-		simpleAuthz := data.NewSimpleRelationsRepository()
-		// Grant permissions for both items
-		simpleAuthz.Grant("user-123", "view", "hbi", "host", "resource-1")
-		simpleAuthz.Grant("user-123", "edit", "hbi", "host", "resource-2")
-		return TestServerConfig{
-				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-				Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-			}, func(t *testing.T, tr *Transport) {
-				ctx := context.Background()
-				res := tr.Invoke(ctx, withBody(protoReq, CheckSelfBulk, httpEndpoint("POST /api/kessel/v1beta2/checkselfbulk")))
-				resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfBulkResponse { return &pb.CheckSelfBulkResponse{} }))
-				require.Len(t, resp.Pairs, 2)
-				assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
-				assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[1].GetItem().Allowed)
-				assert.NotNil(t, resp.ConsistencyToken)
-				assert.NotEmpty(t, resp.ConsistencyToken.GetToken())
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			claims := &authnapi.Claims{
+				SubjectId: authnapi.SubjectId("user-123"),
+				AuthType:  authnapi.AuthTypeXRhIdentity,
 			}
-	})
-}
 
-func TestInventoryService_CheckSelfBulk_MixedResults(t *testing.T) {
-	claims := &authnapi.Claims{
-		SubjectId: authnapi.SubjectId("user-123"),
-		AuthType:  authnapi.AuthTypeXRhIdentity,
-	}
-
-	protoReq := &pb.CheckSelfBulkRequest{
-		Items: []*pb.CheckSelfBulkRequestItem{
-			{
-				Object: &pb.ResourceReference{
-					ResourceId:   "resource-1",
-					ResourceType: "host",
-					Reporter:     &pb.ReporterReference{Type: "hbi"},
+			protoReq := &pb.CheckSelfBulkRequest{
+				Items: []*pb.CheckSelfBulkRequestItem{
+					{
+						Object: &pb.ResourceReference{
+							ResourceId:   "resource-1",
+							ResourceType: "host",
+							Reporter:     &pb.ReporterReference{Type: "hbi"},
+						},
+						Relation: "view",
+					},
+					{
+						Object: &pb.ResourceReference{
+							ResourceId:   "resource-2",
+							ResourceType: "host",
+							Reporter:     &pb.ReporterReference{Type: "hbi"},
+						},
+						Relation: "edit",
+					},
 				},
-				Relation: "view",
-			},
-			{
-				Object: &pb.ResourceReference{
-					ResourceId:   "resource-2",
-					ResourceType: "host",
-					Reporter:     &pb.ReporterReference{Type: "hbi"},
-				},
-				Relation: "edit",
-			},
-		},
-	}
-
-	runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-		simpleAuthz := data.NewSimpleRelationsRepository()
-		// Grant permission for resource-1/view only - resource-2/edit will be denied
-		simpleAuthz.Grant("user-123", "view", "hbi", "host", "resource-1")
-		return TestServerConfig{
-				Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-				Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-			}, func(t *testing.T, tr *Transport) {
-				ctx := context.Background()
-				res := tr.Invoke(ctx, withBody(protoReq, CheckSelfBulk, httpEndpoint("POST /api/kessel/v1beta2/checkselfbulk")))
-				resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfBulkResponse { return &pb.CheckSelfBulkResponse{} }))
-				require.Len(t, resp.Pairs, 2)
-				assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
-				assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
-				assert.Equal(t, "resource-1", resp.Pairs[0].Request.Object.ResourceId)
-				assert.Equal(t, "view", resp.Pairs[0].Request.Relation)
-				assert.Equal(t, "resource-2", resp.Pairs[1].Request.Object.ResourceId)
-				assert.Equal(t, "edit", resp.Pairs[1].Request.Relation)
 			}
-	})
+
+			runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
+				simpleAuthz := data.NewSimpleRelationsRepository()
+				for _, g := range tc.grants {
+					simpleAuthz.Grant(g.subjectID, g.relation, "hbi", "host", g.resourceID)
+				}
+				return TestServerConfig{
+						Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
+						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+					}, func(t *testing.T, tr *Transport) {
+						ctx := context.Background()
+						res := tr.Invoke(ctx, withBody(protoReq, CheckSelfBulk, httpEndpoint("POST /api/kessel/v1beta2/checkselfbulk")))
+						resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfBulkResponse { return &pb.CheckSelfBulkResponse{} }))
+						require.Len(t, resp.Pairs, len(tc.wantPairs))
+						for i, want := range tc.wantPairs {
+							assert.Equal(t, want.allowed, resp.Pairs[i].GetItem().Allowed, "pair %d allowed", i)
+							assert.Equal(t, want.resourceID, resp.Pairs[i].Request.Object.ResourceId, "pair %d resourceID", i)
+							assert.Equal(t, want.relation, resp.Pairs[i].Request.Relation, "pair %d relation", i)
+						}
+						assert.NotEmpty(t, resp.ConsistencyToken.GetToken())
+					}
+			})
+		})
+	}
 }
 
 func TestInventoryService_CheckSelfBulk_ResponseLengthMismatch(t *testing.T) {
@@ -1244,57 +1191,80 @@ func TestInventoryService_DeleteResource_Success(t *testing.T) {
 	})
 }
 
-func TestInventoryService_StreamedListObjects_Success(t *testing.T) {
-	claims := &authnapi.Claims{
-		SubjectId: authnapi.SubjectId("user-abc"),
-		AuthType:  authnapi.AuthTypeXRhIdentity,
+func TestInventoryService_StreamedListObjects_StreamResults(t *testing.T) {
+	type grantSpec struct {
+		subjectID, resourceID string
 	}
-
-	// Set up SimpleAuthorizer with tuples that grant subject-xyz view on two hosts
-	simpleAuthz := data.NewSimpleRelationsRepository()
-	simpleAuthz.Grant("subject-xyz", "view", "hbi", "host", "host-1")
-	simpleAuthz.Grant("subject-xyz", "view", "hbi", "host", "host-2")
-
-	uc := newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz})
-	client := newTestServer(t, TestServerConfig{
-		Usecase:       uc,
-		Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-	})
-
-	reporterType := "hbi"
-	req := &pb.StreamedListObjectsRequest{
-		ObjectType: &pb.RepresentationType{
-			ReporterType: &reporterType,
-			ResourceType: "host",
+	cases := []struct {
+		name    string
+		grants  []grantSpec
+		wantIDs []string
+	}{
+		{
+			"success - two objects",
+			[]grantSpec{{"subject-xyz", "host-1"}, {"subject-xyz", "host-2"}},
+			[]string{"host-1", "host-2"},
 		},
-		Relation: "view",
-		Subject: &pb.SubjectReference{
-			Resource: &pb.ResourceReference{
-				ResourceId:   "subject-xyz",
-				ResourceType: "principal",
-				Reporter:     &pb.ReporterReference{Type: "rbac"},
-			},
+		{
+			"empty - no grants",
+			nil,
+			nil,
 		},
 	}
 
-	stream, err := client.StreamedListObjects(context.Background(), req)
-	require.NoError(t, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			claims := &authnapi.Claims{
+				SubjectId: authnapi.SubjectId("user-abc"),
+				AuthType:  authnapi.AuthTypeXRhIdentity,
+			}
 
-	// Collect all streamed results
-	var resourceIDs []string
-	for {
-		resp, err := stream.Recv()
-		if err == io.EOF {
-			break
-		}
-		require.NoError(t, err)
-		resourceIDs = append(resourceIDs, resp.Object.ResourceId)
+			simpleAuthz := data.NewSimpleRelationsRepository()
+			for _, g := range tc.grants {
+				simpleAuthz.Grant(g.subjectID, "view", "hbi", "host", g.resourceID)
+			}
+
+			uc := newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz})
+			client := newTestServer(t, TestServerConfig{
+				Usecase:       uc,
+				Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+			})
+
+			reporterType := "hbi"
+			req := &pb.StreamedListObjectsRequest{
+				ObjectType: &pb.RepresentationType{
+					ReporterType: &reporterType,
+					ResourceType: "host",
+				},
+				Relation: "view",
+				Subject: &pb.SubjectReference{
+					Resource: &pb.ResourceReference{
+						ResourceId:   "subject-xyz",
+						ResourceType: "principal",
+						Reporter:     &pb.ReporterReference{Type: "rbac"},
+					},
+				},
+			}
+
+			stream, err := client.StreamedListObjects(context.Background(), req)
+			require.NoError(t, err)
+
+			var resourceIDs []string
+			for {
+				resp, err := stream.Recv()
+				if err == io.EOF {
+					break
+				}
+				require.NoError(t, err)
+				resourceIDs = append(resourceIDs, resp.Object.ResourceId)
+			}
+
+			slices.Sort(resourceIDs)
+			wantSorted := slices.Clone(tc.wantIDs)
+			slices.Sort(wantSorted)
+			assert.Equal(t, wantSorted, resourceIDs)
+		})
 	}
-
-	// Should receive 2 resources
-	assert.Len(t, resourceIDs, 2)
-	assert.Contains(t, resourceIDs, "host-1")
-	assert.Contains(t, resourceIDs, "host-2")
 }
 
 // --- Update Path Tests ---
@@ -3867,136 +3837,76 @@ func TestInventoryService_ReportResource_MetaAuthzDenied(t *testing.T) {
 	})
 }
 
-// TestInventoryService_StreamedListSubjects_Success verifies that StreamedListSubjects returns granted subjects.
-func TestInventoryService_StreamedListSubjects_Success(t *testing.T) {
-	claims := &authnapi.Claims{
-		SubjectId: authnapi.SubjectId("user-abc"),
-		AuthType:  authnapi.AuthTypeXRhIdentity,
-	}
-
-	// Set up SimpleAuthorizer with tuples granting two subjects view on host-1
-	simpleAuthz := data.NewSimpleRelationsRepository()
-	simpleAuthz.Grant("user-1", "view", "hbi", "host", "host-1")
-	simpleAuthz.Grant("user-2", "view", "hbi", "host", "host-1")
-
-	uc := newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz})
-	client := newTestServer(t, TestServerConfig{
-		Usecase:       uc,
-		Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-	})
-
-	reporterType := "hbi"
-	subjectReporterType := "rbac"
-	req := &pb.StreamedListSubjectsRequest{
-		Resource: &pb.ResourceReference{
-			ResourceType: "host",
-			ResourceId:   "host-1",
-			Reporter:     &pb.ReporterReference{Type: reporterType},
+func TestInventoryService_StreamedListSubjects_StreamResults(t *testing.T) {
+	cases := []struct {
+		name            string
+		grantSubjectIDs []string
+		wantIDs         []string
+	}{
+		{
+			"success - two subjects",
+			[]string{"user-1", "user-2"},
+			[]string{"user-1", "user-2"},
 		},
-		Relation: "view",
-		SubjectType: &pb.RepresentationType{
-			ResourceType: "principal",
-			ReporterType: &subjectReporterType,
+		{
+			"empty - no grants",
+			nil,
+			nil,
 		},
 	}
 
-	stream, err := client.StreamedListSubjects(context.Background(), req)
-	require.NoError(t, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			claims := &authnapi.Claims{
+				SubjectId: authnapi.SubjectId("user-abc"),
+				AuthType:  authnapi.AuthTypeXRhIdentity,
+			}
 
-	// Collect all streamed results
-	var subjectIDs []string
-	for {
-		resp, err := stream.Recv()
-		if err == io.EOF {
-			break
-		}
-		require.NoError(t, err)
-		subjectIDs = append(subjectIDs, resp.Subject.Resource.ResourceId)
+			simpleAuthz := data.NewSimpleRelationsRepository()
+			for _, subjectID := range tc.grantSubjectIDs {
+				simpleAuthz.Grant(subjectID, "view", "hbi", "host", "host-1")
+			}
+
+			uc := newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz})
+			client := newTestServer(t, TestServerConfig{
+				Usecase:       uc,
+				Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+			})
+
+			reporterType := "hbi"
+			subjectReporterType := "rbac"
+			req := &pb.StreamedListSubjectsRequest{
+				Resource: &pb.ResourceReference{
+					ResourceType: "host",
+					ResourceId:   "host-1",
+					Reporter:     &pb.ReporterReference{Type: reporterType},
+				},
+				Relation: "view",
+				SubjectType: &pb.RepresentationType{
+					ResourceType: "principal",
+					ReporterType: &subjectReporterType,
+				},
+			}
+
+			stream, err := client.StreamedListSubjects(context.Background(), req)
+			require.NoError(t, err)
+
+			var subjectIDs []string
+			for {
+				resp, err := stream.Recv()
+				if err == io.EOF {
+					break
+				}
+				require.NoError(t, err)
+				subjectIDs = append(subjectIDs, resp.Subject.Resource.ResourceId)
+			}
+
+			slices.Sort(subjectIDs)
+			wantSorted := slices.Clone(tc.wantIDs)
+			slices.Sort(wantSorted)
+			assert.Equal(t, wantSorted, subjectIDs)
+		})
 	}
-
-	// Should receive 2 subjects
-	assert.Len(t, subjectIDs, 2)
-	assert.Contains(t, subjectIDs, "user-1")
-	assert.Contains(t, subjectIDs, "user-2")
-}
-
-// TestInventoryService_StreamedListObjects_Empty verifies that StreamedListObjects returns EOF when no tuples are granted.
-func TestInventoryService_StreamedListObjects_Empty(t *testing.T) {
-	claims := &authnapi.Claims{
-		SubjectId: authnapi.SubjectId("user-abc"),
-		AuthType:  authnapi.AuthTypeXRhIdentity,
-	}
-
-	// Set up SimpleAuthorizer with no grants
-	simpleAuthz := data.NewSimpleRelationsRepository()
-
-	uc := newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz})
-	client := newTestServer(t, TestServerConfig{
-		Usecase:       uc,
-		Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-	})
-
-	reporterType := "hbi"
-	req := &pb.StreamedListObjectsRequest{
-		ObjectType: &pb.RepresentationType{
-			ReporterType: &reporterType,
-			ResourceType: "host",
-		},
-		Relation: "view",
-		Subject: &pb.SubjectReference{
-			Resource: &pb.ResourceReference{
-				ResourceId:   "subject-xyz",
-				ResourceType: "principal",
-				Reporter:     &pb.ReporterReference{Type: "rbac"},
-			},
-		},
-	}
-
-	stream, err := client.StreamedListObjects(context.Background(), req)
-	require.NoError(t, err)
-
-	// First Recv should return EOF
-	_, err = stream.Recv()
-	assert.Equal(t, io.EOF, err, "empty stream should return EOF immediately")
-}
-
-// TestInventoryService_StreamedListSubjects_Empty verifies that StreamedListSubjects returns EOF when no tuples are granted.
-func TestInventoryService_StreamedListSubjects_Empty(t *testing.T) {
-	claims := &authnapi.Claims{
-		SubjectId: authnapi.SubjectId("user-abc"),
-		AuthType:  authnapi.AuthTypeXRhIdentity,
-	}
-
-	// Set up SimpleAuthorizer with no grants
-	simpleAuthz := data.NewSimpleRelationsRepository()
-
-	uc := newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz})
-	client := newTestServer(t, TestServerConfig{
-		Usecase:       uc,
-		Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-	})
-
-	reporterType := "hbi"
-	subjectReporterType := "rbac"
-	req := &pb.StreamedListSubjectsRequest{
-		Resource: &pb.ResourceReference{
-			ResourceType: "host",
-			ResourceId:   "host-1",
-			Reporter:     &pb.ReporterReference{Type: reporterType},
-		},
-		Relation: "view",
-		SubjectType: &pb.RepresentationType{
-			ResourceType: "principal",
-			ReporterType: &subjectReporterType,
-		},
-	}
-
-	stream, err := client.StreamedListSubjects(context.Background(), req)
-	require.NoError(t, err)
-
-	// First Recv should return EOF
-	_, err = stream.Recv()
-	assert.Equal(t, io.EOF, err, "empty stream should return EOF immediately")
 }
 
 func newFakeSchemaRepository(t *testing.T) model.SchemaRepository {


### PR DESCRIPTION
## Summary

Build comprehensive test safety net using SimpleRelationsRepository (fake) before refactoring RelationsRepository interface.

**This PR contains test changes only** - no production code changes except stripping MockRelationsRepository to enforce "Fakes Over Mocks" pattern.

## Changes

### 1. Config Tests (NEW)
- **File:** `internal/config/relations/config_test.go`
- 3 tests documenting current config completion behavior
- Documents bug where Kessel errors are swallowed

### 2. Migrated Tests  
- **File:** `internal/service/resources/kesselinventoryservice_test.go`
- Migrated 5 tests from MockRelationsRepository to SimpleRelationsRepository
- Tests: CheckSelf (allowed/denied), CheckSelfBulk (allowed/mixed)

### 3. Stripped MockRelationsRepository
- **File:** `internal/mocks/mocks.go`
- Removed 11 methods, kept only CheckBulk and CheckForUpdateBulk  
- Added panic stubs for removed methods
- Only 3 edge-case tests still use mock

### 4. Biz Layer Tests (NEW)
- **File:** `internal/biz/usecase/resources/resource_service_test.go`
- Added 9 tests: Check, CheckForUpdate, CheckBulk, LookupResources, LookupSubjects

### 5. API Layer Tests (NEW)  
- **File:** `internal/service/resources/kesselinventoryservice_test.go`
- Added 3 tests: StreamedListSubjects, empty stream tests

## Test Pattern: Fakes Over Mocks

All tests use SimpleRelationsRepository.Grant() pattern:
```go
simpleAuthz := data.NewSimpleRelationsRepository()
simpleAuthz.Grant("user-1", "view", "hbi", "host", "host-1")
```

## Test Summary
- Config tests: 3 new
- Biz layer: +9 tests  
- API layer: 5 migrated + 3 new
- **Total: 20 tests added/improved**

All tests passing ✅

## Next Steps
Follow-up PR will refactor RelationsRepository interface from Relations API protobuf types to Inventory domain types. The test coverage here ensures that refactor will be safe and regression-free.

## Related
- Jira: RHCLOUD-45010
- Implementation plan attached to PR and Jira ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Broadened authorization coverage with table-driven allowed/denied cases, consolidated authz decision tests, deterministic streaming assertions, and a shared test harness to simplify per-test setup.
  * Replaced many heavy mocks with an in-memory relations helper and added config tests documenting implementation-selection behavior.

* **Chores**
  * Reduced mock surface to a minimal stub for select operations.
  * Enhanced the in-memory relations helper with injectable errors, lock-token behavior, and realistic consistency-token responses for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->