### PR TITLE
RHCLOUD-44390: Adds idempotency toggle configuration

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -262,12 +262,12 @@ func NewCommand(
 				return err
 			}
 
-			usecaseConfig := &resourcesctl.UsecaseConfig{
-				ReadAfterWriteEnabled:          consistencyConfig.ReadAfterWriteEnabled,
-				ReadAfterWriteAllowlist:        consistencyConfig.ReadAfterWriteAllowlist,
-				ConsumerEnabled:                consumerOptions.Enabled,
-				DefaultToAtLeastAsAcknowledged: consistencyConfig.DefaultToAtLeastAsAcknowledged,
-			}
+			usecaseConfig := resourcesctl.NewUsecaseConfig()
+			usecaseConfig.ReadAfterWriteEnabled = consistencyConfig.ReadAfterWriteEnabled
+			usecaseConfig.ReadAfterWriteAllowlist = consistencyConfig.ReadAfterWriteAllowlist
+			usecaseConfig.ConsumerEnabled = consumerOptions.Enabled
+			usecaseConfig.DefaultToAtLeastAsAcknowledged = consistencyConfig.DefaultToAtLeastAsAcknowledged
+			usecaseConfig.IdempotencyCheckEnabled = consistencyConfig.IdempotencyCheckEnabled
 
 			// This circuit breaker is used to prevent request handlers from being blocked
 			// indefinitely if the consumer is not responding via notifications.

--- a/internal/biz/model/errors.go
+++ b/internal/biz/model/errors.go
@@ -28,6 +28,11 @@ var (
 	ErrNoRepresentationProvided = errors.New("at least one of reporterRepresentation or commonRepresentation must be provided")
 )
 
+// Error reasons used in kratos errors across layers
+const (
+	ReasonNonUniqueTransactionID = "NON-UNIQUE TRANSACTION ID"
+)
+
 // Service-level sentinel errors - operation failures
 var (
 	// ErrResourceAlreadyExists indicates the resource already exists when creating.

--- a/internal/biz/usecase/resources/resource_service.go
+++ b/internal/biz/usecase/resources/resource_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	kratosErrors "github.com/go-kratos/kratos/v2/errors"
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/google/uuid"
 	"github.com/project-kessel/inventory-api/cmd/common"
@@ -49,6 +50,13 @@ type UsecaseConfig struct {
 	ReadAfterWriteAllowlist        []string
 	ConsumerEnabled                bool
 	DefaultToAtLeastAsAcknowledged bool
+	IdempotencyCheckEnabled        bool
+}
+
+func NewUsecaseConfig() *UsecaseConfig {
+	return &UsecaseConfig{
+		IdempotencyCheckEnabled: true,
+	}
 }
 
 // Usecase provides business logic operations for resource management in the inventory system.
@@ -141,7 +149,7 @@ func (uc *Usecase) ReportResource(ctx context.Context, cmd ReportResourceCommand
 	// predicate locks on the transaction_id indexes. The unique constraint on transaction_id
 	// provides the actual correctness guarantee, if a duplicate sneaks past this
 	// advisory check due to a concurrent commit.
-	if cmd.TransactionId != nil {
+	if uc.Config.IdempotencyCheckEnabled && cmd.TransactionId != nil {
 		alreadyProcessed, err := uc.resourceRepository.HasTransactionIdBeenProcessed(uc.resourceRepository.GetDB(), cmd.TransactionId.String())
 		if err != nil {
 			return fmt.Errorf("failed to check transaction ID: %w", err)
@@ -153,26 +161,39 @@ func (uc *Usecase) ReportResource(ctx context.Context, cmd ReportResourceCommand
 	}
 
 	var operationType model.EventOperationType
-	err = uc.resourceRepository.GetTransactionManager().HandleSerializableTransaction(
-		ReportResourceOperationName,
-		uc.resourceRepository.GetDB(),
-		func(tx *gorm.DB) error {
-			res, err := uc.resourceRepository.FindResourceByKeys(tx, reporterResourceKey)
-			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-				return fmt.Errorf("failed to lookup existing resource: %w", err)
-			}
+	reportResource := func() error {
+		return uc.resourceRepository.GetTransactionManager().HandleSerializableTransaction(
+			ReportResourceOperationName,
+			uc.resourceRepository.GetDB(),
+			func(tx *gorm.DB) error {
+				res, err := uc.resourceRepository.FindResourceByKeys(tx, reporterResourceKey)
+				if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+					return fmt.Errorf("failed to lookup existing resource: %w", err)
+				}
 
-			if err == nil && res != nil {
-				log.Info("Resource already exists, updating: ")
-				operationType = model.OperationTypeUpdated
-				return uc.updateResource(tx, cmd, res, txid.String())
-			}
+				if err == nil && res != nil {
+					log.Info("Resource already exists, updating: ")
+					operationType = model.OperationTypeUpdated
+					return uc.updateResource(tx, cmd, res, txid.String())
+				}
 
-			log.Info("Creating new resource")
-			operationType = model.OperationTypeCreated
-			return uc.createResource(tx, cmd, txid.String())
-		},
-	)
+				log.Info("Creating new resource")
+				operationType = model.OperationTypeCreated
+				return uc.createResource(tx, cmd, txid.String())
+			},
+		)
+	}
+
+	err = reportResource()
+	if err != nil && !uc.Config.IdempotencyCheckEnabled && isDuplicateTransactionError(err) {
+		log.Debugf("Idempotency check disabled and duplicate transaction ID detected, retrying with new transaction ID: %s", cmd.TransactionId.String())
+		retryTxid, retryErr := getNextTransactionID()
+		if retryErr != nil {
+			return retryErr
+		}
+		cmd.TransactionId = &retryTxid
+		err = reportResource()
+	}
 
 	if err != nil {
 		return err
@@ -599,6 +620,14 @@ func (uc *Usecase) validateReportResourceCommand(ctx context.Context, cmd Report
 	}
 
 	return nil
+}
+
+func isDuplicateTransactionError(err error) bool {
+	var kratosErr *kratosErrors.Error
+	if errors.As(err, &kratosErr) {
+		return kratosErr.Reason == model.ReasonNonUniqueTransactionID
+	}
+	return false
 }
 
 func getNextTransactionID() (model.TransactionId, error) {

--- a/internal/biz/usecase/resources/resource_service_test.go
+++ b/internal/biz/usecase/resources/resource_service_test.go
@@ -47,7 +47,7 @@ func newTestHarness(t *testing.T, opts ...harnessOption) *testHarness {
 	t.Helper()
 	cfg := &harnessConfig{
 		relationsRepo: &data.AllowAllRelationsRepository{},
-		usecaseConfig: &UsecaseConfig{},
+		usecaseConfig: NewUsecaseConfig(),
 		logger:        log.DefaultLogger,
 		namespace:     "rbac",
 	}
@@ -1503,7 +1503,7 @@ func TestReportResource_SchemaValidation(t *testing.T) {
 				"test-topic",
 				log.DefaultLogger,
 				nil, nil,
-				&UsecaseConfig{},
+				NewUsecaseConfig(),
 				metricscollector.NewFakeMetricsCollector(),
 				nil,
 				newTestSelfSubjectStrategy(),
@@ -1693,9 +1693,9 @@ func TestResolveConsistency(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := newTestHarness(t, withNamespace("test-topic"), withUsecaseConfig(&UsecaseConfig{
-				DefaultToAtLeastAsAcknowledged: tt.featureFlagEnabled,
-			}))
+			cfg := NewUsecaseConfig()
+			cfg.DefaultToAtLeastAsAcknowledged = tt.featureFlagEnabled
+			h := newTestHarness(t, withNamespace("test-topic"), withUsecaseConfig(cfg))
 
 			reporterResourceKey := createReporterResourceKey(t, "test-resource-123", "host", "hbi", "test-instance")
 
@@ -1767,9 +1767,9 @@ func TestResolveConsistency_OverrideFeatureFlag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := newTestHarness(t, withNamespace("test-topic"), withUsecaseConfig(&UsecaseConfig{
-				DefaultToAtLeastAsAcknowledged: tt.featureFlagEnabled,
-			}))
+			cfg := NewUsecaseConfig()
+			cfg.DefaultToAtLeastAsAcknowledged = tt.featureFlagEnabled
+			h := newTestHarness(t, withNamespace("test-topic"), withUsecaseConfig(cfg))
 
 			reporterResourceKey := createReporterResourceKey(t, "test-resource-override", "host", "hbi", "test-instance")
 
@@ -1807,10 +1807,12 @@ func TestResolveConsistency_NilConsistencyDefaultsToUnspecified(t *testing.T) {
 
 func TestResolveConsistency_OverrideFeatureFlag_LogsBypassWhenEnabled(t *testing.T) {
 	var logBuf bytes.Buffer
+	cfg := NewUsecaseConfig()
+	cfg.DefaultToAtLeastAsAcknowledged = true
 	h := newTestHarness(t,
 		withNamespace("test-topic"),
 		withLogger(log.NewStdLogger(&logBuf)),
-		withUsecaseConfig(&UsecaseConfig{DefaultToAtLeastAsAcknowledged: true}),
+		withUsecaseConfig(cfg),
 	)
 
 	reporterResourceKey := createReporterResourceKey(t, "host-123", "host", "hbi", "instance-1")
@@ -1821,10 +1823,12 @@ func TestResolveConsistency_OverrideFeatureFlag_LogsBypassWhenEnabled(t *testing
 
 func TestResolveConsistency_OverrideFeatureFlag_LogsEnabledWhenNotBypassed(t *testing.T) {
 	var logBuf bytes.Buffer
+	cfg := NewUsecaseConfig()
+	cfg.DefaultToAtLeastAsAcknowledged = true
 	h := newTestHarness(t,
 		withNamespace("test-topic"),
 		withLogger(log.NewStdLogger(&logBuf)),
-		withUsecaseConfig(&UsecaseConfig{DefaultToAtLeastAsAcknowledged: true}),
+		withUsecaseConfig(cfg),
 	)
 
 	reporterResourceKey := createReporterResourceKey(t, "host-456", "host", "hbi", "instance-1")
@@ -1838,7 +1842,11 @@ func TestResolveConsistency_OverrideFeatureFlag_LogsDisabledWhenFeatureOff(t *te
 	h := newTestHarness(t,
 		withNamespace("test-topic"),
 		withLogger(log.NewStdLogger(&logBuf)),
-		withUsecaseConfig(&UsecaseConfig{DefaultToAtLeastAsAcknowledged: false}),
+		withUsecaseConfig(func() *UsecaseConfig {
+			cfg := NewUsecaseConfig()
+			cfg.DefaultToAtLeastAsAcknowledged = false
+			return cfg
+		}()),
 	)
 
 	reporterResourceKey := createReporterResourceKey(t, "host-789", "host", "hbi", "instance-1")

--- a/internal/consistency/config.go
+++ b/internal/consistency/config.go
@@ -10,6 +10,7 @@ type completedConfig struct {
 	ReadAfterWriteEnabled          bool
 	ReadAfterWriteAllowlist        []string
 	DefaultToAtLeastAsAcknowledged bool
+	IdempotencyCheckEnabled        bool
 }
 
 type CompletedConfig struct {
@@ -29,5 +30,6 @@ func (c *Config) Complete() (CompletedConfig, []error) {
 		ReadAfterWriteEnabled:          c.ReadAfterWriteEnabled,
 		ReadAfterWriteAllowlist:        c.ReadAfterWriteAllowlist,
 		DefaultToAtLeastAsAcknowledged: c.DefaultToAtLeastAsAcknowledged,
+		IdempotencyCheckEnabled:        c.IdempotencyCheckEnabled,
 	}}, nil
 }

--- a/internal/consistency/options.go
+++ b/internal/consistency/options.go
@@ -8,6 +8,7 @@ type Options struct {
 	ReadAfterWriteEnabled          bool     `mapstructure:"read-after-write-enabled"`
 	ReadAfterWriteAllowlist        []string `mapstructure:"read-after-write-allowlist"`
 	DefaultToAtLeastAsAcknowledged bool     `mapstructure:"default-to-at-least-as-acknowledged"`
+	IdempotencyCheckEnabled        bool     `mapstructure:"idempotency-check-enabled"`
 }
 
 func NewOptions() *Options {
@@ -15,6 +16,7 @@ func NewOptions() *Options {
 		ReadAfterWriteEnabled:          true,
 		ReadAfterWriteAllowlist:        []string{},
 		DefaultToAtLeastAsAcknowledged: true,
+		IdempotencyCheckEnabled:        true,
 	}
 }
 
@@ -25,6 +27,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 	fs.BoolVar(&o.ReadAfterWriteEnabled, prefix+"read-after-write-enabled", o.ReadAfterWriteEnabled, "Toggle for enabling or disabling the read after write consistency workflow (default: true)")
 	fs.StringArrayVar(&o.ReadAfterWriteAllowlist, prefix+"read-after-write-allowlist", o.ReadAfterWriteAllowlist, "List of services that require all requests to be read-after-write enabled (default: [])")
 	fs.BoolVar(&o.DefaultToAtLeastAsAcknowledged, prefix+"default-to-at-least-as-acknowledged", o.DefaultToAtLeastAsAcknowledged, "Default to at_least_as_acknowledged consistency for Check operations (default: true)")
+	fs.BoolVar(&o.IdempotencyCheckEnabled, prefix+"idempotency-check-enabled", o.IdempotencyCheckEnabled, "Toggle for enabling or disabling transaction ID idempotency checks. Disable to allow reprocessing of events with duplicate transaction IDs (default: true)")
 }
 
 func (o *Options) Validate() []error {

--- a/internal/consistency/options_test.go
+++ b/internal/consistency/options_test.go
@@ -18,6 +18,7 @@ func TestNewOptions(t *testing.T) {
 			ReadAfterWriteEnabled:          true,
 			ReadAfterWriteAllowlist:        []string{},
 			DefaultToAtLeastAsAcknowledged: true,
+			IdempotencyCheckEnabled:        true,
 		},
 	}
 	assert.Equal(t, test.expectedOptions, NewOptions())

--- a/internal/data/resource_repository.go
+++ b/internal/data/resource_repository.go
@@ -151,7 +151,7 @@ func (r *resourceRepository) Save(tx *gorm.DB, resource bizmodel.Resource, opera
 		dataReporterRepresentation := datamodel.DeserializeReporterRepresentationFromSnapshot(*reporterRepresentationSnapshot)
 		if err := tx.Create(&dataReporterRepresentation).Error; err != nil {
 			if errors.Is(err, gorm.ErrDuplicatedKey) {
-				return errors.BadRequest("NON-UNIQUE TRANSACTION ID", err.Error()).WithCause(err)
+				return errors.BadRequest(bizmodel.ReasonNonUniqueTransactionID, err.Error()).WithCause(err)
 			}
 			return fmt.Errorf("failed to save reporter representation: %w", err)
 		}
@@ -161,7 +161,7 @@ func (r *resourceRepository) Save(tx *gorm.DB, resource bizmodel.Resource, opera
 		dataCommonRepresentation := datamodel.DeserializeCommonRepresentationFromSnapshot(*commonRepresentationSnapshot)
 		if err := tx.Create(&dataCommonRepresentation).Error; err != nil {
 			if errors.Is(err, gorm.ErrDuplicatedKey) {
-				return errors.BadRequest("NON-UNIQUE TRANSACTION ID", err.Error()).WithCause(err)
+				return errors.BadRequest(bizmodel.ReasonNonUniqueTransactionID, err.Error()).WithCause(err)
 			}
 			return fmt.Errorf("failed to save common representation: %w", err)
 		}

--- a/internal/data/resource_repository_test.go
+++ b/internal/data/resource_repository_test.go
@@ -181,7 +181,7 @@ func testRepositoryContract(t *testing.T, repo bizmodel.ResourceRepository, db *
 
 		// Error should indicate constraint violation
 		errorMsg := err.Error()
-		constraintViolation := strings.Contains(errorMsg, "duplicate") || strings.Contains(errorMsg, "NON-UNIQUE TRANSACTION ID")
+		constraintViolation := strings.Contains(errorMsg, "duplicate") || strings.Contains(errorMsg, bizmodel.ReasonNonUniqueTransactionID)
 		assert.True(t, constraintViolation, "Error should mention constraint violation, got: %s", errorMsg)
 	})
 
@@ -842,8 +842,8 @@ func TestUniqueConstraint_ReporterResourceCompositeKey(t *testing.T) {
 
 				// Error should indicate a constraint violation
 				errorMsg := err.Error()
-				// Both "duplicate" (fake repo) and "NON-UNIQUE TRANSACTION ID" (real DB) are acceptable
-				constraintViolation := strings.Contains(errorMsg, "duplicate") || strings.Contains(errorMsg, "NON-UNIQUE TRANSACTION ID")
+				// Both "duplicate" (fake repo) and ReasonNonUniqueTransactionID (real DB) are acceptable
+				constraintViolation := strings.Contains(errorMsg, "duplicate") || strings.Contains(errorMsg, bizmodel.ReasonNonUniqueTransactionID)
 				assert.True(t, constraintViolation, "Error should mention constraint violation, got: %s", errorMsg)
 			})
 
@@ -2506,7 +2506,7 @@ func testTransactionIDUniqueConstraint(t *testing.T, repo bizmodel.ResourceRepos
 		// This should fail due to unique constraint violation
 		err = repo.Save(db, resource2, bizmodel.OperationTypeCreated, "tx-duplicate-2")
 		require.Error(t, err, "Second save should fail due to duplicate TransactionID")
-		assert.Contains(t, err.Error(), "NON-UNIQUE TRANSACTION ID")
+		assert.Contains(t, err.Error(), bizmodel.ReasonNonUniqueTransactionID)
 	})
 
 	t.Run("should enforce unique TransactionID constraint on CommonRepresentation", func(t *testing.T) {

--- a/internal/service/resources/kesselinventoryservice_test.go
+++ b/internal/service/resources/kesselinventoryservice_test.go
@@ -171,7 +171,7 @@ func newTestUsecase(t *testing.T, cfg testUsecaseConfig) *usecase.Usecase {
 
 	usecaseCfg := cfg.Config
 	if usecaseCfg == nil {
-		usecaseCfg = &usecase.UsecaseConfig{}
+		usecaseCfg = usecase.NewUsecaseConfig()
 	}
 
 	// Default to PermissiveMetaAuthorizer for tests unless explicitly overridden
@@ -3762,6 +3762,80 @@ func TestInventoryService_ReportResource_TransactionIdIdempotency(t *testing.T) 
 
 				assert.Equal(t, apiHrefAfterFirst, apiHrefAfterSecond,
 					"second report with same transaction_id should be a no-op; api_href should not change")
+			}
+	})
+}
+
+func TestInventoryService_ReportResource_IdempotencyDisabled(t *testing.T) {
+	claims := &authnapi.Claims{
+		SubjectId: authnapi.SubjectId("reporter-service"),
+		AuthType:  authnapi.AuthTypeXRhIdentity,
+	}
+
+	txId := "txn-idempotency-disabled-test"
+	makeReq := func(apiHref string) *pb.ReportResourceRequest {
+		return &pb.ReportResourceRequest{
+			Type:               "host",
+			ReporterType:       "hbi",
+			ReporterInstanceId: "instance-001",
+			Representations: &pb.ResourceRepresentations{
+				Metadata: &pb.RepresentationMetadata{
+					LocalResourceId: "host-replay",
+					ApiHref:         apiHref,
+					IdempotencyKey: &pb.RepresentationMetadata_TransactionId{
+						TransactionId: txId,
+					},
+				},
+				Common: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"workspace_id": structpb.NewStringValue("ws-replay"),
+					},
+				},
+				Reporter: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"reporter_key": structpb.NewStringValue("reporter-val"),
+					},
+				},
+			},
+		}
+	}
+
+	runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
+		repo, _ := newSQLiteTestRepo(t)
+		idempotencyOff := usecase.NewUsecaseConfig()
+		idempotencyOff.IdempotencyCheckEnabled = false
+		uc := newTestUsecase(t, testUsecaseConfig{
+			Repo:   repo,
+			Config: idempotencyOff,
+		})
+		return TestServerConfig{
+				Usecase:       uc,
+				Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+			}, func(t *testing.T, tr *Transport) {
+				ctx := context.Background()
+				key := buildReporterResourceKey(t, "host-replay", "host", "hbi", "instance-001")
+
+				// First report
+				res1 := tr.Invoke(ctx, withBody(makeReq("https://api.example.com/v1"), ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
+				Assert(t, res1, requireSuccess())
+
+				resource1, err := repo.FindResourceByKeys(repo.GetDB(), key)
+				require.NoError(t, err)
+				require.NotNil(t, resource1)
+				apiHrefAfterFirst := resource1.ReporterResources()[0].ApiHref().String()
+				assert.Equal(t, "https://api.example.com/v1", apiHrefAfterFirst)
+
+				// Second report with same transaction_id but different api_href — should NOT be skipped
+				res2 := tr.Invoke(ctx, withBody(makeReq("https://api.example.com/v2-replayed"), ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
+				Assert(t, res2, requireSuccess())
+
+				resource2, err := repo.FindResourceByKeys(repo.GetDB(), key)
+				require.NoError(t, err)
+				require.NotNil(t, resource2)
+				apiHrefAfterSecond := resource2.ReporterResources()[0].ApiHref().String()
+
+				assert.Equal(t, "https://api.example.com/v2-replayed", apiHrefAfterSecond,
+					"with idempotency disabled, replayed event should update the resource")
 			}
 	})
 }

--- a/test/e2e/inventory_v1beta2_grpc_test.go
+++ b/test/e2e/inventory_v1beta2_grpc_test.go
@@ -1401,6 +1401,114 @@ func TestInventoryAPIHTTP_v1beta2_CheckForUpdate_AllowedFalse(t *testing.T) {
 	assert.Equal(t, pbv1beta2.Allowed_ALLOWED_FALSE, resp.GetAllowed(), "Expected ALLOWED_FALSE for non-matching workspace")
 }
 
+func TestInventoryAPIHTTP_v1beta2_TransactionIdIdempotency(t *testing.T) {
+	enableShortMode(t)
+
+	ctx := context.Background()
+
+	conn, err := grpc.NewClient(
+		inventoryapi_grpc_url,
+		grpc.WithTransportCredentials(grpcinsecure.NewCredentials()),
+		grpc.WithPerRPCCredentials(&bearerAuth{token: "1234"}),
+	)
+	require.NoError(t, err, "Failed to create gRPC client")
+	defer func() {
+		if connErr := conn.Close(); connErr != nil {
+			t.Logf("Failed to close gRPC connection: %v", connErr)
+		}
+	}()
+
+	conn.Connect()
+
+	client := pbv1beta2.NewKesselInventoryServiceClient(conn)
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	resourceId := "idempotency-host-" + suffix
+	reporterType := "hbi"
+	reporterInstanceId := "testuser-example-com"
+	txId := "e2e-txn-idempotency-test-" + suffix
+
+	resourceCreated := false
+	defer func() {
+		if !resourceCreated {
+			return
+		}
+		_, cleanupErr := client.DeleteResource(ctx, &pbv1beta2.DeleteResourceRequest{
+			Reference: &pbv1beta2.ResourceReference{
+				ResourceType: "host",
+				ResourceId:   resourceId,
+				Reporter: &pbv1beta2.ReporterReference{
+					Type:       reporterType,
+					InstanceId: proto.String(reporterInstanceId),
+				},
+			},
+		})
+		assert.NoError(t, cleanupErr, "Failed to Delete Resource during cleanup")
+	}()
+
+	reporterStruct, err := structpb.NewStruct(map[string]interface{}{
+		"ansible_host": "idempotency-host.example.com",
+	})
+	require.NoError(t, err, "Failed to create structpb for reporter")
+
+	makeReq := func(apiHref string) *pbv1beta2.ReportResourceRequest {
+		return &pbv1beta2.ReportResourceRequest{
+			WriteVisibility:    pbv1beta2.WriteVisibility_MINIMIZE_LATENCY,
+			Type:               "host",
+			ReporterType:       reporterType,
+			ReporterInstanceId: reporterInstanceId,
+			Representations: &pbv1beta2.ResourceRepresentations{
+				Metadata: &pbv1beta2.RepresentationMetadata{
+					LocalResourceId: resourceId,
+					ApiHref:         apiHref,
+					IdempotencyKey: &pbv1beta2.RepresentationMetadata_TransactionId{
+						TransactionId: txId,
+					},
+				},
+				Common: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"workspace_id": structpb.NewStringValue("ws-idempotency"),
+					},
+				},
+				Reporter: reporterStruct,
+			},
+		}
+	}
+
+	// First report — should succeed and store the transaction ID
+	_, err = client.ReportResource(ctx, makeReq("https://api.example.com/v1"))
+	require.NoError(t, err, "First report should succeed")
+	resourceCreated = true
+
+	// Verify transaction ID is stored in the DB
+	var txCount int64
+	err = db.Table("reporter_representations").Where("transaction_id = ?", txId).Count(&txCount).Error
+	require.NoError(t, err, "Failed to query reporter_representations")
+	assert.Greater(t, txCount, int64(0), "transaction_id should be stored in reporter_representations")
+
+	// Verify the api_href from the first report
+	var apiHref string
+	err = db.Table("reporter_resources").
+		Where("local_resource_id = ?", resourceId).
+		Select("api_href").
+		Scan(&apiHref).Error
+	require.NoError(t, err, "Failed to query api_href")
+	assert.Equal(t, "https://api.example.com/v1", apiHref)
+
+	// Second report with same transaction_id but different api_href — should be skipped
+	_, err = client.ReportResource(ctx, makeReq("https://api.example.com/v2-should-be-ignored"))
+	require.NoError(t, err, "Second report should succeed (silently skipped)")
+
+	// Verify api_href was NOT updated
+	err = db.Table("reporter_resources").
+		Where("local_resource_id = ?", resourceId).
+		Select("api_href").
+		Scan(&apiHref).Error
+	require.NoError(t, err, "Failed to query api_href after second report")
+	assert.Equal(t, "https://api.example.com/v1", apiHref,
+		"second report with same transaction_id should be a no-op; api_href should not change")
+}
+
 func TestInventoryAPIHTTP_v1beta2_CheckBulk_OrderAndEcho(t *testing.T) {
 	enableShortMode(t)
 


### PR DESCRIPTION
- Adds `consistency.idempotency-check-enabled` configuration option (default: `true`) to control transaction ID deduplication for resource reports
- When enabled, duplicate transaction IDs are detected by an advisory pre-check and rejected by the database unique constraint; existing behavior, unchanged
- When disabled (for event replay), the advisory check is skipped and duplicate transaction IDs are handled by retrying the transaction with a fresh `UUIDv7`. Records are always preserved with a valid transaction ID.
- Introduces NewUsecaseConfig() constructor so `IdempotencyCheckEnabled` defaults to true, removing the need to set it at each call site
- Extracts the `NON-UNIQUE TRANSACTION ID` error reason into a shared constant (model.ReasonNonUniqueTransactionID) used across repository, usecase, and tests
- All replay retry logic lives in the usecase layer, keeping the repository interface and data layer unchanged

Local test output
**Idempotency enabled (default):**

```
msg=Creating new resource
msg=Tuple event to write to outbox : &{...Operation:created TxId:019dd9b0-c2dd-7eb1-aed9-b35c4bf1986d...}
operation=/kessel.inventory.v1beta2.KesselInventoryService/ReportResource code=200 latency=0.016923667

# Same request again:
msg=Transaction already processed, skipping update: transaction_id=txn-12345
operation=/kessel.inventory.v1beta2.KesselInventoryService/ReportResource code=200 latency=0.003994334
```

**Idempotency disabled (`idempotency-check-enabled: false`):**

```
# Same duplicate txn-12345 now processes as an update:
msg=Resource already exists, updating:
msg=Tuple event to write to outbox : &{...Operation:updated TxId:019dd9b1-84c8-796e-ae77-53b876caf298...}
operation=/kessel.inventory.v1beta2.KesselInventoryService/ReportResource code=200 latency=0.027845334
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an idempotency toggle (CLI flag default: enabled) to control transaction-ID deduplication for resource reports; disabling allows replayed reports with the same transaction ID to be reprocessed.
  * System now retries a failed non-unique-transaction handling path once when idempotency checks are disabled.

* **Tests**
  * Added unit and end-to-end tests covering idempotency enabled/disabled behavior and v1beta2 transaction-ID scenarios.

* **Other**
  * Introduced a shared reason constant for non-unique transaction ID errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->