### PR TITLE
RHCLOUD-45005: Add normalization safety tests before moving to model

### DIFF
--- a/internal/biz/model/common_test.go
+++ b/internal/biz/model/common_test.go
@@ -528,6 +528,7 @@ func TestReporterInstanceId_Initialization(t *testing.T) {
 			t.Error("Expected error for whitespace string, got none")
 		}
 	})
+
 }
 
 func TestConsistencyToken_Initialization(t *testing.T) {

--- a/internal/biz/model/common_test.go
+++ b/internal/biz/model/common_test.go
@@ -528,7 +528,6 @@ func TestReporterInstanceId_Initialization(t *testing.T) {
 			t.Error("Expected error for whitespace string, got none")
 		}
 	})
-
 }
 
 func TestConsistencyToken_Initialization(t *testing.T) {

--- a/internal/data/schema_inmemory_test.go
+++ b/internal/data/schema_inmemory_test.go
@@ -79,7 +79,10 @@ func TestInMemorySchemaRepository_GetResource(t *testing.T) {
 
 			retrieved, err := repo.GetResourceSchema(ctx, tc.lookupType)
 			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedType, retrieved.ResourceType)
+			assert.Equal(t, bizmodel.ResourceSchema{
+				ResourceType:     tc.expectedType,
+				ValidationSchema: validateSchemaTypeObject,
+			}, retrieved)
 		})
 	}
 }
@@ -210,8 +213,11 @@ func TestInMemorySchemaRepository_CreateResourceReporter(t *testing.T) {
 
 			retrieved, err := repo.GetReporterSchema(ctx, "host", tc.lookupReporterType)
 			assert.NoError(t, err)
-			assert.Equal(t, "host", retrieved.ResourceType)
-			assert.Equal(t, tc.expectedReporterType, retrieved.ReporterType)
+			assert.Equal(t, bizmodel.ReporterSchema{
+				ResourceType:     "host",
+				ReporterType:     tc.expectedReporterType,
+				ValidationSchema: reporterValidation,
+			}, retrieved)
 		})
 	}
 }

--- a/internal/data/schema_inmemory_test.go
+++ b/internal/data/schema_inmemory_test.go
@@ -51,20 +51,37 @@ func TestInMemorySchemaRepository_CreateResource_AlreadyExists(t *testing.T) {
 }
 
 func TestInMemorySchemaRepository_GetResource(t *testing.T) {
-	repo := NewInMemorySchemaRepository()
-	ctx := context.Background()
-
-	resource := bizmodel.ResourceSchema{
-		ResourceType:     "k8s_cluster",
-		ValidationSchema: validateSchemaTypeObject,
+	// NormalizeResourceType does ToLower + slash->underscore on both create and get paths.
+	cases := []struct {
+		name       string
+		createType string
+		lookupType string
+	}{
+		{"lowercase lookup", "k8s_cluster", "k8s_cluster"},
+		{"uppercase lookup normalizes", "k8s_cluster", "K8S_CLUSTER"},
+		{"mixed-case lookup", "k8s_cluster", "K8s_Cluster"},
+		{"slash normalizes to underscore", "rhel_host", "rhel/host"},
+		{"uppercase + slash", "rhel_host", "RHEL/Host"},
+		{"create uppercase, lookup lowercase", "HOST", "host"},
 	}
 
-	err := repo.CreateResourceSchema(ctx, resource)
-	assert.NoError(t, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			repo := NewInMemorySchemaRepository()
+			ctx := context.Background()
 
-	retrieved, err := repo.GetResourceSchema(ctx, "k8s_cluster")
-	assert.NoError(t, err)
-	assert.Equal(t, "k8s_cluster", retrieved.ResourceType)
+			err := repo.CreateResourceSchema(ctx, bizmodel.ResourceSchema{
+				ResourceType:     tc.createType,
+				ValidationSchema: validateSchemaTypeObject,
+			})
+			assert.NoError(t, err)
+
+			retrieved, err := repo.GetResourceSchema(ctx, tc.lookupType)
+			assert.NoError(t, err)
+			assert.Equal(t, NormalizeResourceType(tc.createType), retrieved.ResourceType)
+		})
+	}
 }
 
 func TestInMemorySchemaRepository_GetResource_NotFound(t *testing.T) {
@@ -159,32 +176,44 @@ func TestInMemorySchemaRepository_GetResources(t *testing.T) {
 }
 
 func TestInMemorySchemaRepository_CreateResourceReporter(t *testing.T) {
-	repo := NewInMemorySchemaRepository()
-	ctx := context.Background()
+	// NormalizeResourceType does ToLower + slash->underscore; normalizeReporterType does ToLower only.
+	reporterValidation := bizmodel.NewJsonSchemaValidatorFromString(`{"type": "object", "properties": {"satellite_id": {"type": "string"}}}`)
 
-	// Create resource first
-	resource := bizmodel.ResourceSchema{
-		ResourceType:     "host",
-		ValidationSchema: validateSchemaTypeObject,
-	}
-	err := repo.CreateResourceSchema(ctx, resource)
-	assert.NoError(t, err)
-
-	// Create reporter
-	reporter := bizmodel.ReporterSchema{
-		ResourceType:     "host",
-		ReporterType:     "hbi",
-		ValidationSchema: bizmodel.NewJsonSchemaValidatorFromString(`{"type": "object", "properties": {"satellite_id": {"type": "string"}}}`),
+	cases := []struct {
+		name               string
+		createReporterType string
+		lookupReporterType string
+	}{
+		{"lowercase reporter", "hbi", "hbi"},
+		{"uppercase reporter lookup", "hbi", "HBI"},
+		{"create uppercase, lookup lowercase", "HBI", "hbi"},
 	}
 
-	err = repo.CreateReporterSchema(ctx, reporter)
-	assert.NoError(t, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			repo := NewInMemorySchemaRepository()
+			ctx := context.Background()
 
-	// Verify reporter was created
-	retrieved, err := repo.GetReporterSchema(ctx, "host", "hbi")
-	assert.NoError(t, err)
-	assert.Equal(t, "host", retrieved.ResourceType)
-	assert.Equal(t, "hbi", retrieved.ReporterType)
+			err := repo.CreateResourceSchema(ctx, bizmodel.ResourceSchema{
+				ResourceType:     "host",
+				ValidationSchema: validateSchemaTypeObject,
+			})
+			assert.NoError(t, err)
+
+			err = repo.CreateReporterSchema(ctx, bizmodel.ReporterSchema{
+				ResourceType:     "host",
+				ReporterType:     tc.createReporterType,
+				ValidationSchema: reporterValidation,
+			})
+			assert.NoError(t, err)
+
+			retrieved, err := repo.GetReporterSchema(ctx, "host", tc.lookupReporterType)
+			assert.NoError(t, err)
+			assert.Equal(t, "host", retrieved.ResourceType)
+			assert.Equal(t, normalizeReporterType(tc.createReporterType), retrieved.ReporterType)
+		})
+	}
 }
 
 func TestInMemorySchemaRepository_GetResourceReporter_NotFound(t *testing.T) {

--- a/internal/data/schema_inmemory_test.go
+++ b/internal/data/schema_inmemory_test.go
@@ -51,18 +51,18 @@ func TestInMemorySchemaRepository_CreateResource_AlreadyExists(t *testing.T) {
 }
 
 func TestInMemorySchemaRepository_GetResource(t *testing.T) {
-	// NormalizeResourceType does ToLower + slash->underscore on both create and get paths.
 	cases := []struct {
-		name       string
-		createType string
-		lookupType string
+		name         string
+		createType   string
+		lookupType   string
+		expectedType string
 	}{
-		{"lowercase lookup", "k8s_cluster", "k8s_cluster"},
-		{"uppercase lookup normalizes", "k8s_cluster", "K8S_CLUSTER"},
-		{"mixed-case lookup", "k8s_cluster", "K8s_Cluster"},
-		{"slash normalizes to underscore", "rhel_host", "rhel/host"},
-		{"uppercase + slash", "rhel_host", "RHEL/Host"},
-		{"create uppercase, lookup lowercase", "HOST", "host"},
+		{"lowercase lookup", "k8s_cluster", "k8s_cluster", "k8s_cluster"},
+		{"uppercase lookup normalizes", "k8s_cluster", "K8S_CLUSTER", "k8s_cluster"},
+		{"mixed-case lookup", "k8s_cluster", "K8s_Cluster", "k8s_cluster"},
+		{"slash normalizes to underscore", "rhel_host", "rhel/host", "rhel_host"},
+		{"uppercase + slash", "rhel_host", "RHEL/Host", "rhel_host"},
+		{"create uppercase, lookup lowercase", "HOST", "host", "host"},
 	}
 
 	for _, tc := range cases {
@@ -79,7 +79,7 @@ func TestInMemorySchemaRepository_GetResource(t *testing.T) {
 
 			retrieved, err := repo.GetResourceSchema(ctx, tc.lookupType)
 			assert.NoError(t, err)
-			assert.Equal(t, NormalizeResourceType(tc.createType), retrieved.ResourceType)
+			assert.Equal(t, tc.expectedType, retrieved.ResourceType)
 		})
 	}
 }
@@ -176,17 +176,17 @@ func TestInMemorySchemaRepository_GetResources(t *testing.T) {
 }
 
 func TestInMemorySchemaRepository_CreateResourceReporter(t *testing.T) {
-	// NormalizeResourceType does ToLower + slash->underscore; normalizeReporterType does ToLower only.
 	reporterValidation := bizmodel.NewJsonSchemaValidatorFromString(`{"type": "object", "properties": {"satellite_id": {"type": "string"}}}`)
 
 	cases := []struct {
-		name               string
-		createReporterType string
-		lookupReporterType string
+		name                 string
+		createReporterType   string
+		lookupReporterType   string
+		expectedReporterType string
 	}{
-		{"lowercase reporter", "hbi", "hbi"},
-		{"uppercase reporter lookup", "hbi", "HBI"},
-		{"create uppercase, lookup lowercase", "HBI", "hbi"},
+		{"lowercase reporter", "hbi", "hbi", "hbi"},
+		{"uppercase reporter lookup", "hbi", "HBI", "hbi"},
+		{"create uppercase, lookup lowercase", "HBI", "hbi", "hbi"},
 	}
 
 	for _, tc := range cases {
@@ -211,7 +211,7 @@ func TestInMemorySchemaRepository_CreateResourceReporter(t *testing.T) {
 			retrieved, err := repo.GetReporterSchema(ctx, "host", tc.lookupReporterType)
 			assert.NoError(t, err)
 			assert.Equal(t, "host", retrieved.ResourceType)
-			assert.Equal(t, normalizeReporterType(tc.createReporterType), retrieved.ReporterType)
+			assert.Equal(t, tc.expectedReporterType, retrieved.ReporterType)
 		})
 	}
 }

--- a/internal/service/resources/kesselinventoryservice_test.go
+++ b/internal/service/resources/kesselinventoryservice_test.go
@@ -3918,597 +3918,345 @@ func newFakeSchemaRepository(t *testing.T) model.SchemaRepository {
 	return schemaRepository
 }
 
+// --- Case-insensitive test helpers ---
+
+type caseVariant struct {
+	name         string
+	resourceType string
+	reporterType string
+}
+
+var caseVariants = []caseVariant{
+	{"lowercase types", "host", "hbi"},
+	{"uppercase types", "HOST", "HBI"},
+	{"mixed case", "Host", "Hbi"},
+}
+
+func makeResourceRef(resourceId, resourceType, reporterType string) *pb.ResourceReference {
+	return &pb.ResourceReference{
+		ResourceId:   resourceId,
+		ResourceType: resourceType,
+		Reporter:     &pb.ReporterReference{Type: reporterType},
+	}
+}
+
+func makeSubjectRef(subjectId string) *pb.SubjectReference {
+	return &pb.SubjectReference{
+		Resource: makeResourceRef(subjectId, "principal", "rbac"),
+	}
+}
+
+func makeAuthzConfig(t *testing.T, authz *data.SimpleRelationsRepository, subjectId string) TestServerConfig {
+	t.Helper()
+	return TestServerConfig{
+		Usecase: newTestUsecase(t, testUsecaseConfig{Relations: authz}),
+		Authenticator: &StubAuthenticator{
+			Claims:   &authnapi.Claims{SubjectId: authnapi.SubjectId(subjectId), AuthType: authnapi.AuthTypeXRhIdentity},
+			Decision: authnapi.Allow,
+		},
+	}
+}
+
+func makeReportConfig(t *testing.T) TestServerConfig {
+	t.Helper()
+	return TestServerConfig{
+		Usecase: newTestUsecase(t, testUsecaseConfig{}),
+		Authenticator: &StubAuthenticator{
+			Claims:   &authnapi.Claims{SubjectId: authnapi.SubjectId("reporter-service"), AuthType: authnapi.AuthTypeXRhIdentity},
+			Decision: authnapi.Allow,
+		},
+	}
+}
+
+func makeReportReq(resourceType, reporterType, instanceId, localResourceId, hostname string) *pb.ReportResourceRequest {
+	return &pb.ReportResourceRequest{
+		Type:               resourceType,
+		ReporterType:       reporterType,
+		ReporterInstanceId: instanceId,
+		Representations: &pb.ResourceRepresentations{
+			Metadata: &pb.RepresentationMetadata{
+				LocalResourceId: localResourceId,
+				ApiHref:         "https://api.example.com/hosts/" + localResourceId,
+			},
+			Common: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"hostname": structpb.NewStringValue(hostname),
+				},
+			},
+		},
+	}
+}
+
+// --- Normalization tests ---
+
 func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Report", func(t *testing.T) {
+		t.Parallel()
+		// Resource and reporter types are normalized to lowercase by the service layer.
 		cases := []struct {
-			name               string
-			resourceType       string
-			reporterType       string
-			reporterInstanceId string
+			name         string
+			resourceType string
+			reporterType string
 		}{
-			{"lowercase types", "host", "hbi", "instance-001"},
-			{"uppercase resource type", "HOST", "hbi", "instance-001"},
-			{"uppercase reporter type", "host", "HBI", "instance-001"},
-			{"all uppercase", "HOST", "HBI", "INSTANCE-001"},
-			{"mixed case instance id", "host", "hbi", "Instance-001"},
+			{"lowercase types", "host", "hbi"},
+			{"uppercase resource type", "HOST", "hbi"},
+			{"uppercase reporter type", "host", "HBI"},
+			{"all uppercase", "HOST", "HBI"},
 		}
 
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-					claims := &authnapi.Claims{
-						SubjectId: authnapi.SubjectId("reporter-service"),
-						AuthType:  authnapi.AuthTypeXRhIdentity,
+					return makeReportConfig(t), func(t *testing.T, tr *Transport) {
+						res := tr.Invoke(context.Background(), withBody(
+							makeReportReq(tc.resourceType, tc.reporterType, "instance-001", "my-host-123", "example-host"),
+							ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
+						Assert(t, res, requireSuccess())
 					}
-					uc := newTestUsecase(t, testUsecaseConfig{})
-					protoReq := &pb.ReportResourceRequest{
-						Type:               tc.resourceType,
-						ReporterType:       tc.reporterType,
-						ReporterInstanceId: tc.reporterInstanceId,
-						Representations: &pb.ResourceRepresentations{
-							Metadata: &pb.RepresentationMetadata{
-								LocalResourceId: "my-host-123",
-								ApiHref:         "https://api.example.com/hosts/my-host-123",
-							},
-							Common: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"hostname": structpb.NewStringValue("example-host"),
-								},
-							},
-						},
-					}
-
-					return TestServerConfig{
-							Usecase:       uc,
-							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-						}, func(t *testing.T, tr *Transport) {
-							ctx := context.Background()
-							res := tr.Invoke(ctx, withBody(protoReq, ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
-							Assert(t, res, requireSuccess())
-						}
 				})
 			})
 		}
 	})
 
 	t.Run("ReportUpdate", func(t *testing.T) {
+		t.Parallel()
 		cases := []struct {
 			name           string
 			createType     string
 			createReporter string
-			createInstance string
 			updateType     string
 			updateReporter string
-			updateInstance string
 		}{
-			{"create uppercase, update lowercase", "HOST", "HBI", "INSTANCE-001", "host", "hbi", "instance-001"},
-			{"create lowercase, update uppercase", "host", "hbi", "instance-001", "HOST", "HBI", "INSTANCE-001"},
-			{"create mixed, update lowercase", "Host", "Hbi", "Instance-001", "host", "hbi", "instance-001"},
+			{"create uppercase, update lowercase", "HOST", "HBI", "host", "hbi"},
+			{"create lowercase, update uppercase", "host", "hbi", "HOST", "HBI"},
+			{"create mixed, update lowercase", "Host", "Hbi", "host", "hbi"},
 		}
 
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-					claims := &authnapi.Claims{
-						SubjectId: authnapi.SubjectId("reporter-service"),
-						AuthType:  authnapi.AuthTypeXRhIdentity,
-					}
-					uc := newTestUsecase(t, testUsecaseConfig{})
+					return makeReportConfig(t), func(t *testing.T, tr *Transport) {
+						ctx := context.Background()
+						res1 := tr.Invoke(ctx, withBody(
+							makeReportReq(tc.createType, tc.createReporter, "instance-001", "my-host-123", "original-host"),
+							ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
+						Assert(t, res1, requireSuccess())
 
-					createReq := &pb.ReportResourceRequest{
-						Type:               tc.createType,
-						ReporterType:       tc.createReporter,
-						ReporterInstanceId: tc.createInstance,
-						Representations: &pb.ResourceRepresentations{
-							Metadata: &pb.RepresentationMetadata{
-								LocalResourceId: "my-host-123",
-								ApiHref:         "https://api.example.com/hosts/my-host-123",
-							},
-							Common: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"hostname": structpb.NewStringValue("original-host"),
-								},
-							},
-						},
+						res2 := tr.Invoke(ctx, withBody(
+							makeReportReq(tc.updateType, tc.updateReporter, "instance-001", "my-host-123", "updated-host"),
+							ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
+						Assert(t, res2, requireSuccess())
 					}
-					updateReq := &pb.ReportResourceRequest{
-						Type:               tc.updateType,
-						ReporterType:       tc.updateReporter,
-						ReporterInstanceId: tc.updateInstance,
-						Representations: &pb.ResourceRepresentations{
-							Metadata: &pb.RepresentationMetadata{
-								LocalResourceId: "my-host-123",
-								ApiHref:         "https://api.example.com/hosts/my-host-123",
-							},
-							Common: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"hostname": structpb.NewStringValue("updated-host"),
-								},
-							},
-						},
-					}
-
-					return TestServerConfig{
-							Usecase:       uc,
-							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-						}, func(t *testing.T, tr *Transport) {
-							ctx := context.Background()
-							res1 := tr.Invoke(ctx, withBody(createReq, ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
-							Assert(t, res1, requireSuccess())
-
-							res2 := tr.Invoke(ctx, withBody(updateReq, ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
-							Assert(t, res2, requireSuccess())
-						}
 				})
 			})
 		}
 	})
 
 	t.Run("Delete", func(t *testing.T) {
+		t.Parallel()
 		cases := []struct {
 			name           string
 			reportType     string
 			reportReporter string
-			reportInstance string
 			deleteType     string
 			deleteReporter string
-			deleteInstance string
 		}{
-			{"report uppercase, delete lowercase", "HOST", "HBI", "INSTANCE-001", "host", "hbi", "instance-001"},
-			{"report lowercase, delete uppercase", "host", "hbi", "instance-001", "HOST", "HBI", "INSTANCE-001"},
+			{"report uppercase, delete lowercase", "HOST", "HBI", "host", "hbi"},
+			{"report lowercase, delete uppercase", "host", "hbi", "HOST", "HBI"},
 		}
 
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-					claims := &authnapi.Claims{
-						SubjectId: authnapi.SubjectId("reporter-service"),
-						AuthType:  authnapi.AuthTypeXRhIdentity,
-					}
-					uc := newTestUsecase(t, testUsecaseConfig{})
+					instanceId := "instance-001"
+					return makeReportConfig(t), func(t *testing.T, tr *Transport) {
+						ctx := context.Background()
+						res1 := tr.Invoke(ctx, withBody(
+							makeReportReq(tc.reportType, tc.reportReporter, instanceId, "my-host-123", "example-host"),
+							ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
+						Assert(t, res1, requireSuccess())
 
-					reportReq := &pb.ReportResourceRequest{
-						Type:               tc.reportType,
-						ReporterType:       tc.reportReporter,
-						ReporterInstanceId: tc.reportInstance,
-						Representations: &pb.ResourceRepresentations{
-							Metadata: &pb.RepresentationMetadata{
-								LocalResourceId: "my-host-123",
-								ApiHref:         "https://api.example.com/hosts/my-host-123",
-							},
-							Common: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"hostname": structpb.NewStringValue("example-host"),
+						res2 := tr.Invoke(ctx, withBody(&pb.DeleteResourceRequest{
+							Reference: &pb.ResourceReference{
+								ResourceType: tc.deleteType,
+								ResourceId:   "my-host-123",
+								Reporter: &pb.ReporterReference{
+									Type:       tc.deleteReporter,
+									InstanceId: &instanceId,
 								},
 							},
-						},
+						}, DeleteResource, httpEndpoint("DELETE /api/kessel/v1beta2/resources")))
+						Assert(t, res2, requireSuccess())
 					}
-					deleteInstance := tc.deleteInstance
-					deleteReq := &pb.DeleteResourceRequest{
-						Reference: &pb.ResourceReference{
-							ResourceType: tc.deleteType,
-							ResourceId:   "my-host-123",
-							Reporter: &pb.ReporterReference{
-								Type:       tc.deleteReporter,
-								InstanceId: &deleteInstance,
-							},
-						},
-					}
-
-					return TestServerConfig{
-							Usecase:       uc,
-							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-						}, func(t *testing.T, tr *Transport) {
-							ctx := context.Background()
-							res1 := tr.Invoke(ctx, withBody(reportReq, ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
-							Assert(t, res1, requireSuccess())
-
-							res2 := tr.Invoke(ctx, withBody(deleteReq, DeleteResource, httpEndpoint("DELETE /api/kessel/v1beta2/resources")))
-							Assert(t, res2, requireSuccess())
-						}
 				})
 			})
 		}
 	})
 
 	t.Run("Check", func(t *testing.T) {
-		cases := []struct {
-			name            string
-			resourceType    string
-			reporterType    string
-			expectedAllowed pb.Allowed
-		}{
-			{"lowercase types", "host", "hbi", pb.Allowed_ALLOWED_TRUE},
-			{"uppercase types", "HOST", "HBI", pb.Allowed_ALLOWED_TRUE},
-			{"mixed case", "Host", "Hbi", pb.Allowed_ALLOWED_TRUE},
-		}
-
-		for _, tc := range cases {
+		t.Parallel()
+		for _, tc := range caseVariants {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-					claims := &authnapi.Claims{
-						SubjectId: authnapi.SubjectId("user-123"),
-						AuthType:  authnapi.AuthTypeXRhIdentity,
+					authz := data.NewSimpleRelationsRepository()
+					authz.Grant("subject-456", "view", "hbi", "host", "resource-abc")
+					return makeAuthzConfig(t, authz, "user-123"), func(t *testing.T, tr *Transport) {
+						res := tr.Invoke(context.Background(), withBody(&pb.CheckRequest{
+							Relation: "view",
+							Object:   makeResourceRef("resource-abc", tc.resourceType, tc.reporterType),
+							Subject:  makeSubjectRef("subject-456"),
+						}, Check, httpEndpoint("POST /api/kessel/v1beta2/check")))
+						resp := Extract(t, res, expectSuccess(func() *pb.CheckResponse { return &pb.CheckResponse{} }))
+						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Allowed)
 					}
-					simpleAuthz := data.NewSimpleRelationsRepository()
-					simpleAuthz.Grant("subject-456", "view", "hbi", "host", "resource-abc")
-
-					protoReq := &pb.CheckRequest{
-						Relation: "view",
-						Object: &pb.ResourceReference{
-							ResourceId:   "resource-abc",
-							ResourceType: tc.resourceType,
-							Reporter:     &pb.ReporterReference{Type: tc.reporterType},
-						},
-						Subject: &pb.SubjectReference{
-							Resource: &pb.ResourceReference{
-								ResourceId:   "subject-456",
-								ResourceType: "principal",
-								Reporter:     &pb.ReporterReference{Type: "rbac"},
-							},
-						},
-					}
-
-					return TestServerConfig{
-							Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-						}, func(t *testing.T, tr *Transport) {
-							ctx := context.Background()
-							res := tr.Invoke(ctx, withBody(protoReq, Check, httpEndpoint("POST /api/kessel/v1beta2/check")))
-							resp := Extract(t, res, expectSuccess(func() *pb.CheckResponse { return &pb.CheckResponse{} }))
-							assert.Equal(t, tc.expectedAllowed, resp.Allowed)
-						}
 				})
 			})
 		}
 	})
 
 	t.Run("CheckForUpdate", func(t *testing.T) {
-		cases := []struct {
-			name            string
-			resourceType    string
-			reporterType    string
-			expectedAllowed pb.Allowed
-		}{
-			{"lowercase types", "host", "hbi", pb.Allowed_ALLOWED_TRUE},
-			{"uppercase types", "HOST", "HBI", pb.Allowed_ALLOWED_TRUE},
-			{"mixed case", "Host", "Hbi", pb.Allowed_ALLOWED_TRUE},
-		}
-
-		for _, tc := range cases {
+		t.Parallel()
+		for _, tc := range caseVariants {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-					claims := &authnapi.Claims{
-						SubjectId: authnapi.SubjectId("user-123"),
-						AuthType:  authnapi.AuthTypeXRhIdentity,
+					authz := data.NewSimpleRelationsRepository()
+					authz.Grant("subject-789", "edit", "hbi", "host", "resource-xyz")
+					return makeAuthzConfig(t, authz, "user-123"), func(t *testing.T, tr *Transport) {
+						res := tr.Invoke(context.Background(), withBody(&pb.CheckForUpdateRequest{
+							Relation: "edit",
+							Object:   makeResourceRef("resource-xyz", tc.resourceType, tc.reporterType),
+							Subject:  makeSubjectRef("subject-789"),
+						}, CheckForUpdate, httpEndpoint("POST /api/kessel/v1beta2/checkforupdate")))
+						resp := Extract(t, res, expectSuccess(func() *pb.CheckForUpdateResponse { return &pb.CheckForUpdateResponse{} }))
+						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Allowed)
 					}
-					simpleAuthz := data.NewSimpleRelationsRepository()
-					simpleAuthz.Grant("subject-789", "edit", "hbi", "host", "resource-xyz")
-
-					protoReq := &pb.CheckForUpdateRequest{
-						Relation: "edit",
-						Object: &pb.ResourceReference{
-							ResourceId:   "resource-xyz",
-							ResourceType: tc.resourceType,
-							Reporter:     &pb.ReporterReference{Type: tc.reporterType},
-						},
-						Subject: &pb.SubjectReference{
-							Resource: &pb.ResourceReference{
-								ResourceId:   "subject-789",
-								ResourceType: "principal",
-								Reporter:     &pb.ReporterReference{Type: "rbac"},
-							},
-						},
-					}
-
-					return TestServerConfig{
-							Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-						}, func(t *testing.T, tr *Transport) {
-							ctx := context.Background()
-							res := tr.Invoke(ctx, withBody(protoReq, CheckForUpdate, httpEndpoint("POST /api/kessel/v1beta2/checkforupdate")))
-							resp := Extract(t, res, expectSuccess(func() *pb.CheckForUpdateResponse { return &pb.CheckForUpdateResponse{} }))
-							assert.Equal(t, tc.expectedAllowed, resp.Allowed)
-						}
 				})
 			})
 		}
 	})
 
 	t.Run("CheckSelf", func(t *testing.T) {
-		cases := []struct {
-			name            string
-			resourceType    string
-			reporterType    string
-			expectedAllowed pb.Allowed
-		}{
-			{"lowercase types", "host", "hbi", pb.Allowed_ALLOWED_TRUE},
-			{"uppercase types", "HOST", "HBI", pb.Allowed_ALLOWED_TRUE},
-			{"mixed case", "Host", "Hbi", pb.Allowed_ALLOWED_TRUE},
-		}
-
-		for _, tc := range cases {
+		t.Parallel()
+		for _, tc := range caseVariants {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-					claims := &authnapi.Claims{
-						SubjectId: authnapi.SubjectId("user-123"),
-						AuthType:  authnapi.AuthTypeXRhIdentity,
+					authz := data.NewSimpleRelationsRepository()
+					authz.Grant("user-123", "view", "hbi", "host", "resource-abc")
+					return makeAuthzConfig(t, authz, "user-123"), func(t *testing.T, tr *Transport) {
+						res := tr.Invoke(context.Background(), withBody(&pb.CheckSelfRequest{
+							Relation: "view",
+							Object:   makeResourceRef("resource-abc", tc.resourceType, tc.reporterType),
+						}, CheckSelf, httpEndpoint("POST /api/kessel/v1beta2/checkself")))
+						resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfResponse { return &pb.CheckSelfResponse{} }))
+						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Allowed)
 					}
-					simpleAuthz := data.NewSimpleRelationsRepository()
-					simpleAuthz.Grant("user-123", "view", "hbi", "host", "resource-abc")
-
-					protoReq := &pb.CheckSelfRequest{
-						Relation: "view",
-						Object: &pb.ResourceReference{
-							ResourceId:   "resource-abc",
-							ResourceType: tc.resourceType,
-							Reporter:     &pb.ReporterReference{Type: tc.reporterType},
-						},
-					}
-
-					return TestServerConfig{
-							Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-						}, func(t *testing.T, tr *Transport) {
-							ctx := context.Background()
-							res := tr.Invoke(ctx, withBody(protoReq, CheckSelf, httpEndpoint("POST /api/kessel/v1beta2/checkself")))
-							resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfResponse { return &pb.CheckSelfResponse{} }))
-							assert.Equal(t, tc.expectedAllowed, resp.Allowed)
-						}
 				})
 			})
 		}
 	})
 
 	t.Run("CheckBulk", func(t *testing.T) {
-		cases := []struct {
-			name         string
-			resourceType string
-			reporterType string
-		}{
-			{"lowercase types", "host", "hbi"},
-			{"uppercase types", "HOST", "HBI"},
-			{"mixed case", "Host", "Hbi"},
-		}
-
-		for _, tc := range cases {
+		t.Parallel()
+		for _, tc := range caseVariants {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-					claims := &authnapi.Claims{
-						SubjectId: authnapi.SubjectId("user-123"),
-						AuthType:  authnapi.AuthTypeXRhIdentity,
-					}
-					simpleAuthz := data.NewSimpleRelationsRepository()
-					simpleAuthz.Grant("subject-a", "view", "hbi", "host", "resource-1")
-
-					protoReq := &pb.CheckBulkRequest{
-						Items: []*pb.CheckBulkRequestItem{
-							{
-								Object: &pb.ResourceReference{
-									ResourceId:   "resource-1",
-									ResourceType: tc.resourceType,
-									Reporter:     &pb.ReporterReference{Type: tc.reporterType},
-								},
-								Subject: &pb.SubjectReference{
-									Resource: &pb.ResourceReference{
-										ResourceId:   "subject-a",
-										ResourceType: "principal",
-										Reporter:     &pb.ReporterReference{Type: "rbac"},
-									},
-								},
-								Relation: "view",
+					authz := data.NewSimpleRelationsRepository()
+					authz.Grant("subject-a", "view", "hbi", "host", "resource-1")
+					return makeAuthzConfig(t, authz, "user-123"), func(t *testing.T, tr *Transport) {
+						res := tr.Invoke(context.Background(), withBody(&pb.CheckBulkRequest{
+							Items: []*pb.CheckBulkRequestItem{
+								{Object: makeResourceRef("resource-1", tc.resourceType, tc.reporterType), Subject: makeSubjectRef("subject-a"), Relation: "view"},
+								{Object: makeResourceRef("resource-2", tc.resourceType, tc.reporterType), Subject: makeSubjectRef("subject-b"), Relation: "edit"},
 							},
-							{
-								Object: &pb.ResourceReference{
-									ResourceId:   "resource-2",
-									ResourceType: tc.resourceType,
-									Reporter:     &pb.ReporterReference{Type: tc.reporterType},
-								},
-								Subject: &pb.SubjectReference{
-									Resource: &pb.ResourceReference{
-										ResourceId:   "subject-b",
-										ResourceType: "principal",
-										Reporter:     &pb.ReporterReference{Type: "rbac"},
-									},
-								},
-								Relation: "edit",
-							},
-						},
+						}, CheckBulk, httpEndpoint("POST /api/kessel/v1beta2/checkbulk")))
+						resp := Extract(t, res, expectSuccess(func() *pb.CheckBulkResponse { return &pb.CheckBulkResponse{} }))
+						require.Len(t, resp.Pairs, 2)
+						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
+						assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
 					}
-
-					return TestServerConfig{
-							Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-						}, func(t *testing.T, tr *Transport) {
-							ctx := context.Background()
-							res := tr.Invoke(ctx, withBody(protoReq, CheckBulk, httpEndpoint("POST /api/kessel/v1beta2/checkbulk")))
-							resp := Extract(t, res, expectSuccess(func() *pb.CheckBulkResponse { return &pb.CheckBulkResponse{} }))
-							require.Len(t, resp.Pairs, 2)
-							assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
-							assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
-						}
 				})
 			})
 		}
 	})
 
 	t.Run("CheckForUpdateBulk", func(t *testing.T) {
-		cases := []struct {
-			name         string
-			resourceType string
-			reporterType string
-		}{
-			{"lowercase types", "host", "hbi"},
-			{"uppercase types", "HOST", "HBI"},
-			{"mixed case", "Host", "Hbi"},
-		}
-
-		for _, tc := range cases {
+		t.Parallel()
+		for _, tc := range caseVariants {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-					claims := &authnapi.Claims{
-						SubjectId: authnapi.SubjectId("user-123"),
-						AuthType:  authnapi.AuthTypeXRhIdentity,
-					}
-					simpleAuthz := data.NewSimpleRelationsRepository()
-					simpleAuthz.Grant("subject-a", "update", "hbi", "host", "resource-1")
-
-					protoReq := &pb.CheckForUpdateBulkRequest{
-						Items: []*pb.CheckBulkRequestItem{
-							{
-								Object: &pb.ResourceReference{
-									ResourceId:   "resource-1",
-									ResourceType: tc.resourceType,
-									Reporter:     &pb.ReporterReference{Type: tc.reporterType},
-								},
-								Subject: &pb.SubjectReference{
-									Resource: &pb.ResourceReference{
-										ResourceId:   "subject-a",
-										ResourceType: "principal",
-										Reporter:     &pb.ReporterReference{Type: "rbac"},
-									},
-								},
-								Relation: "update",
+					authz := data.NewSimpleRelationsRepository()
+					authz.Grant("subject-a", "update", "hbi", "host", "resource-1")
+					return makeAuthzConfig(t, authz, "user-123"), func(t *testing.T, tr *Transport) {
+						res := tr.Invoke(context.Background(), withBody(&pb.CheckForUpdateBulkRequest{
+							Items: []*pb.CheckBulkRequestItem{
+								{Object: makeResourceRef("resource-1", tc.resourceType, tc.reporterType), Subject: makeSubjectRef("subject-a"), Relation: "update"},
+								{Object: makeResourceRef("resource-2", tc.resourceType, tc.reporterType), Subject: makeSubjectRef("subject-b"), Relation: "update"},
 							},
-							{
-								Object: &pb.ResourceReference{
-									ResourceId:   "resource-2",
-									ResourceType: tc.resourceType,
-									Reporter:     &pb.ReporterReference{Type: tc.reporterType},
-								},
-								Subject: &pb.SubjectReference{
-									Resource: &pb.ResourceReference{
-										ResourceId:   "subject-b",
-										ResourceType: "principal",
-										Reporter:     &pb.ReporterReference{Type: "rbac"},
-									},
-								},
-								Relation: "update",
-							},
-						},
+						}, CheckForUpdateBulk, httpEndpoint("POST /api/kessel/v1beta2/checkforupdatebulk")))
+						resp := Extract(t, res, expectSuccess(func() *pb.CheckForUpdateBulkResponse { return &pb.CheckForUpdateBulkResponse{} }))
+						require.Len(t, resp.Pairs, 2)
+						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
+						assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
 					}
-
-					return TestServerConfig{
-							Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-						}, func(t *testing.T, tr *Transport) {
-							ctx := context.Background()
-							res := tr.Invoke(ctx, withBody(protoReq, CheckForUpdateBulk, httpEndpoint("POST /api/kessel/v1beta2/checkforupdatebulk")))
-							resp := Extract(t, res, expectSuccess(func() *pb.CheckForUpdateBulkResponse { return &pb.CheckForUpdateBulkResponse{} }))
-							require.Len(t, resp.Pairs, 2)
-							assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
-							assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
-						}
 				})
 			})
 		}
 	})
 
 	t.Run("CheckSelfBulk", func(t *testing.T) {
-		cases := []struct {
-			name         string
-			resourceType string
-			reporterType string
-		}{
-			{"lowercase types", "host", "hbi"},
-			{"uppercase types", "HOST", "HBI"},
-			{"mixed case", "Host", "Hbi"},
-		}
-
-		for _, tc := range cases {
+		t.Parallel()
+		for _, tc := range caseVariants {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
-					claims := &authnapi.Claims{
-						SubjectId: authnapi.SubjectId("user-123"),
-						AuthType:  authnapi.AuthTypeXRhIdentity,
-					}
-					simpleAuthz := data.NewSimpleRelationsRepository()
-					simpleAuthz.Grant("user-123", "view", "hbi", "host", "resource-1")
-
-					protoReq := &pb.CheckSelfBulkRequest{
-						Items: []*pb.CheckSelfBulkRequestItem{
-							{
-								Object: &pb.ResourceReference{
-									ResourceId:   "resource-1",
-									ResourceType: tc.resourceType,
-									Reporter:     &pb.ReporterReference{Type: tc.reporterType},
-								},
-								Relation: "view",
+					authz := data.NewSimpleRelationsRepository()
+					authz.Grant("user-123", "view", "hbi", "host", "resource-1")
+					return makeAuthzConfig(t, authz, "user-123"), func(t *testing.T, tr *Transport) {
+						res := tr.Invoke(context.Background(), withBody(&pb.CheckSelfBulkRequest{
+							Items: []*pb.CheckSelfBulkRequestItem{
+								{Object: makeResourceRef("resource-1", tc.resourceType, tc.reporterType), Relation: "view"},
+								{Object: makeResourceRef("resource-2", tc.resourceType, tc.reporterType), Relation: "edit"},
 							},
-							{
-								Object: &pb.ResourceReference{
-									ResourceId:   "resource-2",
-									ResourceType: tc.resourceType,
-									Reporter:     &pb.ReporterReference{Type: tc.reporterType},
-								},
-								Relation: "edit",
-							},
-						},
+						}, CheckSelfBulk, httpEndpoint("POST /api/kessel/v1beta2/checkselfbulk")))
+						resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfBulkResponse { return &pb.CheckSelfBulkResponse{} }))
+						require.Len(t, resp.Pairs, 2)
+						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
+						assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
 					}
-
-					return TestServerConfig{
-							Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-						}, func(t *testing.T, tr *Transport) {
-							ctx := context.Background()
-							res := tr.Invoke(ctx, withBody(protoReq, CheckSelfBulk, httpEndpoint("POST /api/kessel/v1beta2/checkselfbulk")))
-							resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfBulkResponse { return &pb.CheckSelfBulkResponse{} }))
-							require.Len(t, resp.Pairs, 2)
-							assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
-							assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
-						}
 				})
 			})
 		}
 	})
 
 	t.Run("StreamedListObjects", func(t *testing.T) {
-		cases := []struct {
-			name         string
-			resourceType string
-			reporterType string
-			expectedIDs  []string
-		}{
-			{"lowercase types", "host", "hbi", []string{"host-1", "host-2"}},
-			{"uppercase types", "HOST", "HBI", []string{"host-1", "host-2"}},
-			{"mixed case", "Host", "Hbi", []string{"host-1", "host-2"}},
-		}
-
-		for _, tc := range cases {
+		t.Parallel()
+		for _, tc := range caseVariants {
 			t.Run(tc.name, func(t *testing.T) {
-				claims := &authnapi.Claims{
-					SubjectId: authnapi.SubjectId("user-abc"),
-					AuthType:  authnapi.AuthTypeXRhIdentity,
-				}
-				simpleAuthz := data.NewSimpleRelationsRepository()
-				simpleAuthz.Grant("subject-xyz", "view", "hbi", "host", "host-1")
-				simpleAuthz.Grant("subject-xyz", "view", "hbi", "host", "host-2")
-
-				uc := newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz})
-				client := newTestServer(t, TestServerConfig{
-					Usecase:       uc,
-					Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-				})
+				t.Parallel()
+				authz := data.NewSimpleRelationsRepository()
+				authz.Grant("subject-xyz", "view", "hbi", "host", "host-1")
+				authz.Grant("subject-xyz", "view", "hbi", "host", "host-2")
 
 				reporterType := tc.reporterType
-				req := &pb.StreamedListObjectsRequest{
+				client := newTestServer(t, makeAuthzConfig(t, authz, "user-abc"))
+				stream, err := client.StreamedListObjects(context.Background(), &pb.StreamedListObjectsRequest{
 					ObjectType: &pb.RepresentationType{
 						ReporterType: &reporterType,
 						ResourceType: tc.resourceType,
 					},
 					Relation: "view",
-					Subject: &pb.SubjectReference{
-						Resource: &pb.ResourceReference{
-							ResourceId:   "subject-xyz",
-							ResourceType: "principal",
-							Reporter:     &pb.ReporterReference{Type: "rbac"},
-						},
-					},
-				}
-
-				stream, err := client.StreamedListObjects(context.Background(), req)
+					Subject:  makeSubjectRef("subject-xyz"),
+				})
 				require.NoError(t, err)
 
 				var resourceIDs []string
@@ -4518,48 +4266,30 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 						break
 					}
 					require.NoError(t, err)
+					assert.Equal(t, "host", resp.Object.ResourceType)
+					assert.Equal(t, "hbi", resp.Object.Reporter.Type)
 					resourceIDs = append(resourceIDs, resp.Object.ResourceId)
 				}
 
 				slices.Sort(resourceIDs)
-				wantSorted := slices.Clone(tc.expectedIDs)
-				slices.Sort(wantSorted)
-				assert.Equal(t, wantSorted, resourceIDs)
+				assert.Equal(t, []string{"host-1", "host-2"}, resourceIDs)
 			})
 		}
 	})
 
 	t.Run("StreamedListSubjects", func(t *testing.T) {
-		cases := []struct {
-			name         string
-			resourceType string
-			reporterType string
-			expectedIDs  []string
-		}{
-			{"lowercase types", "host", "hbi", []string{"user-1", "user-2"}},
-			{"uppercase types", "HOST", "HBI", []string{"user-1", "user-2"}},
-			{"mixed case", "Host", "Hbi", []string{"user-1", "user-2"}},
-		}
-
-		for _, tc := range cases {
+		t.Parallel()
+		for _, tc := range caseVariants {
 			t.Run(tc.name, func(t *testing.T) {
-				claims := &authnapi.Claims{
-					SubjectId: authnapi.SubjectId("user-abc"),
-					AuthType:  authnapi.AuthTypeXRhIdentity,
-				}
-				simpleAuthz := data.NewSimpleRelationsRepository()
-				simpleAuthz.Grant("user-1", "view", "hbi", "host", "host-1")
-				simpleAuthz.Grant("user-2", "view", "hbi", "host", "host-1")
-
-				uc := newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz})
-				client := newTestServer(t, TestServerConfig{
-					Usecase:       uc,
-					Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-				})
+				t.Parallel()
+				authz := data.NewSimpleRelationsRepository()
+				authz.Grant("user-1", "view", "hbi", "host", "host-1")
+				authz.Grant("user-2", "view", "hbi", "host", "host-1")
 
 				reporterType := tc.reporterType
 				subjectReporterType := "rbac"
-				req := &pb.StreamedListSubjectsRequest{
+				client := newTestServer(t, makeAuthzConfig(t, authz, "user-abc"))
+				stream, err := client.StreamedListSubjects(context.Background(), &pb.StreamedListSubjectsRequest{
 					Resource: &pb.ResourceReference{
 						ResourceType: tc.resourceType,
 						ResourceId:   "host-1",
@@ -4570,9 +4300,7 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 						ResourceType: "principal",
 						ReporterType: &subjectReporterType,
 					},
-				}
-
-				stream, err := client.StreamedListSubjects(context.Background(), req)
+				})
 				require.NoError(t, err)
 
 				var subjectIDs []string
@@ -4582,13 +4310,40 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 						break
 					}
 					require.NoError(t, err)
+					assert.Equal(t, "principal", resp.Subject.Resource.ResourceType)
+					assert.Equal(t, "rbac", resp.Subject.Resource.Reporter.Type)
 					subjectIDs = append(subjectIDs, resp.Subject.Resource.ResourceId)
 				}
 
 				slices.Sort(subjectIDs)
-				wantSorted := slices.Clone(tc.expectedIDs)
-				slices.Sort(wantSorted)
-				assert.Equal(t, wantSorted, subjectIDs)
+				assert.Equal(t, []string{"user-1", "user-2"}, subjectIDs)
+			})
+		}
+	})
+
+	t.Run("ReportEmptyType", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name         string
+			resourceType string
+			reporterType string
+		}{
+			{"empty resource type", "", "hbi"},
+			{"empty reporter type", "host", ""},
+			{"whitespace resource type", "   ", "hbi"},
+			{"whitespace reporter type", "host", "   "},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
+					return makeReportConfig(t), func(t *testing.T, tr *Transport) {
+						res := tr.Invoke(context.Background(), withBody(
+							makeReportReq(tc.resourceType, tc.reporterType, "instance-001", "my-host-123", "example-host"),
+							ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
+						Assert(t, res, requireError(codes.InvalidArgument))
+					}
+				})
 			})
 		}
 	})

--- a/internal/service/resources/kesselinventoryservice_test.go
+++ b/internal/service/resources/kesselinventoryservice_test.go
@@ -3918,6 +3918,13 @@ func newFakeSchemaRepository(t *testing.T) model.SchemaRepository {
 	return schemaRepository
 }
 
+func assertProtoEqual(t *testing.T, expected, actual proto.Message) {
+	t.Helper()
+	if !proto.Equal(expected, actual) {
+		t.Errorf("proto mismatch\nwant: %v\n got: %v", expected, actual)
+	}
+}
+
 // --- Case-insensitive test helpers ---
 
 type caseVariant struct {
@@ -4113,7 +4120,11 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 							Subject:  makeSubjectRef("subject-456"),
 						}, Check, httpEndpoint("POST /api/kessel/v1beta2/check")))
 						resp := Extract(t, res, expectSuccess(func() *pb.CheckResponse { return &pb.CheckResponse{} }))
-						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Allowed)
+						require.NotEmpty(t, resp.ConsistencyToken.GetToken())
+						assertProtoEqual(t, &pb.CheckResponse{
+							Allowed:          pb.Allowed_ALLOWED_TRUE,
+							ConsistencyToken: resp.ConsistencyToken,
+						}, resp)
 					}
 				})
 			})
@@ -4135,7 +4146,11 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 							Subject:  makeSubjectRef("subject-789"),
 						}, CheckForUpdate, httpEndpoint("POST /api/kessel/v1beta2/checkforupdate")))
 						resp := Extract(t, res, expectSuccess(func() *pb.CheckForUpdateResponse { return &pb.CheckForUpdateResponse{} }))
-						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Allowed)
+						require.NotEmpty(t, resp.ConsistencyToken.GetToken())
+						assertProtoEqual(t, &pb.CheckForUpdateResponse{
+							Allowed:          pb.Allowed_ALLOWED_TRUE,
+							ConsistencyToken: resp.ConsistencyToken,
+						}, resp)
 					}
 				})
 			})
@@ -4156,7 +4171,11 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 							Object:   makeResourceRef("resource-abc", tc.resourceType, tc.reporterType),
 						}, CheckSelf, httpEndpoint("POST /api/kessel/v1beta2/checkself")))
 						resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfResponse { return &pb.CheckSelfResponse{} }))
-						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Allowed)
+						require.NotEmpty(t, resp.ConsistencyToken.GetToken())
+						assertProtoEqual(t, &pb.CheckSelfResponse{
+							Allowed:          pb.Allowed_ALLOWED_TRUE,
+							ConsistencyToken: resp.ConsistencyToken,
+						}, resp)
 					}
 				})
 			})
@@ -4171,17 +4190,22 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
 					authz := data.NewSimpleRelationsRepository()
 					authz.Grant("subject-a", "view", "hbi", "host", "resource-1")
+					items := []*pb.CheckBulkRequestItem{
+						{Object: makeResourceRef("resource-1", tc.resourceType, tc.reporterType), Subject: makeSubjectRef("subject-a"), Relation: "view"},
+						{Object: makeResourceRef("resource-2", tc.resourceType, tc.reporterType), Subject: makeSubjectRef("subject-b"), Relation: "edit"},
+					}
 					return makeAuthzConfig(t, authz, "user-123"), func(t *testing.T, tr *Transport) {
-						res := tr.Invoke(context.Background(), withBody(&pb.CheckBulkRequest{
-							Items: []*pb.CheckBulkRequestItem{
-								{Object: makeResourceRef("resource-1", tc.resourceType, tc.reporterType), Subject: makeSubjectRef("subject-a"), Relation: "view"},
-								{Object: makeResourceRef("resource-2", tc.resourceType, tc.reporterType), Subject: makeSubjectRef("subject-b"), Relation: "edit"},
-							},
-						}, CheckBulk, httpEndpoint("POST /api/kessel/v1beta2/checkbulk")))
+						res := tr.Invoke(context.Background(), withBody(&pb.CheckBulkRequest{Items: items},
+							CheckBulk, httpEndpoint("POST /api/kessel/v1beta2/checkbulk")))
 						resp := Extract(t, res, expectSuccess(func() *pb.CheckBulkResponse { return &pb.CheckBulkResponse{} }))
-						require.Len(t, resp.Pairs, 2)
-						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
-						assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
+						require.NotEmpty(t, resp.ConsistencyToken.GetToken())
+						assertProtoEqual(t, &pb.CheckBulkResponse{
+							Pairs: []*pb.CheckBulkResponsePair{
+								{Request: items[0], Response: &pb.CheckBulkResponsePair_Item{Item: &pb.CheckBulkResponseItem{Allowed: pb.Allowed_ALLOWED_TRUE}}},
+								{Request: items[1], Response: &pb.CheckBulkResponsePair_Item{Item: &pb.CheckBulkResponseItem{Allowed: pb.Allowed_ALLOWED_FALSE}}},
+							},
+							ConsistencyToken: resp.ConsistencyToken,
+						}, resp)
 					}
 				})
 			})
@@ -4196,17 +4220,22 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
 					authz := data.NewSimpleRelationsRepository()
 					authz.Grant("subject-a", "update", "hbi", "host", "resource-1")
+					items := []*pb.CheckBulkRequestItem{
+						{Object: makeResourceRef("resource-1", tc.resourceType, tc.reporterType), Subject: makeSubjectRef("subject-a"), Relation: "update"},
+						{Object: makeResourceRef("resource-2", tc.resourceType, tc.reporterType), Subject: makeSubjectRef("subject-b"), Relation: "update"},
+					}
 					return makeAuthzConfig(t, authz, "user-123"), func(t *testing.T, tr *Transport) {
-						res := tr.Invoke(context.Background(), withBody(&pb.CheckForUpdateBulkRequest{
-							Items: []*pb.CheckBulkRequestItem{
-								{Object: makeResourceRef("resource-1", tc.resourceType, tc.reporterType), Subject: makeSubjectRef("subject-a"), Relation: "update"},
-								{Object: makeResourceRef("resource-2", tc.resourceType, tc.reporterType), Subject: makeSubjectRef("subject-b"), Relation: "update"},
-							},
-						}, CheckForUpdateBulk, httpEndpoint("POST /api/kessel/v1beta2/checkforupdatebulk")))
+						res := tr.Invoke(context.Background(), withBody(&pb.CheckForUpdateBulkRequest{Items: items},
+							CheckForUpdateBulk, httpEndpoint("POST /api/kessel/v1beta2/checkforupdatebulk")))
 						resp := Extract(t, res, expectSuccess(func() *pb.CheckForUpdateBulkResponse { return &pb.CheckForUpdateBulkResponse{} }))
-						require.Len(t, resp.Pairs, 2)
-						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
-						assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
+						require.NotEmpty(t, resp.ConsistencyToken.GetToken())
+						assertProtoEqual(t, &pb.CheckForUpdateBulkResponse{
+							Pairs: []*pb.CheckForUpdateBulkResponsePair{
+								{Request: items[0], Response: &pb.CheckForUpdateBulkResponsePair_Item{Item: &pb.CheckForUpdateBulkResponseItem{Allowed: pb.Allowed_ALLOWED_TRUE}}},
+								{Request: items[1], Response: &pb.CheckForUpdateBulkResponsePair_Item{Item: &pb.CheckForUpdateBulkResponseItem{Allowed: pb.Allowed_ALLOWED_FALSE}}},
+							},
+							ConsistencyToken: resp.ConsistencyToken,
+						}, resp)
 					}
 				})
 			})
@@ -4221,17 +4250,22 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
 					authz := data.NewSimpleRelationsRepository()
 					authz.Grant("user-123", "view", "hbi", "host", "resource-1")
+					items := []*pb.CheckSelfBulkRequestItem{
+						{Object: makeResourceRef("resource-1", tc.resourceType, tc.reporterType), Relation: "view"},
+						{Object: makeResourceRef("resource-2", tc.resourceType, tc.reporterType), Relation: "edit"},
+					}
 					return makeAuthzConfig(t, authz, "user-123"), func(t *testing.T, tr *Transport) {
-						res := tr.Invoke(context.Background(), withBody(&pb.CheckSelfBulkRequest{
-							Items: []*pb.CheckSelfBulkRequestItem{
-								{Object: makeResourceRef("resource-1", tc.resourceType, tc.reporterType), Relation: "view"},
-								{Object: makeResourceRef("resource-2", tc.resourceType, tc.reporterType), Relation: "edit"},
-							},
-						}, CheckSelfBulk, httpEndpoint("POST /api/kessel/v1beta2/checkselfbulk")))
+						res := tr.Invoke(context.Background(), withBody(&pb.CheckSelfBulkRequest{Items: items},
+							CheckSelfBulk, httpEndpoint("POST /api/kessel/v1beta2/checkselfbulk")))
 						resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfBulkResponse { return &pb.CheckSelfBulkResponse{} }))
-						require.Len(t, resp.Pairs, 2)
-						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
-						assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
+						require.NotEmpty(t, resp.ConsistencyToken.GetToken())
+						assertProtoEqual(t, &pb.CheckSelfBulkResponse{
+							Pairs: []*pb.CheckSelfBulkResponsePair{
+								{Request: items[0], Response: &pb.CheckSelfBulkResponsePair_Item{Item: &pb.CheckSelfBulkResponseItem{Allowed: pb.Allowed_ALLOWED_TRUE}}},
+								{Request: items[1], Response: &pb.CheckSelfBulkResponsePair_Item{Item: &pb.CheckSelfBulkResponseItem{Allowed: pb.Allowed_ALLOWED_FALSE}}},
+							},
+							ConsistencyToken: resp.ConsistencyToken,
+						}, resp)
 					}
 				})
 			})
@@ -4259,20 +4293,28 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				var resourceIDs []string
+				var objects []*pb.ResourceReference
 				for {
 					resp, err := stream.Recv()
 					if err == io.EOF {
 						break
 					}
 					require.NoError(t, err)
-					assert.Equal(t, "host", resp.Object.ResourceType)
-					assert.Equal(t, "hbi", resp.Object.Reporter.Type)
-					resourceIDs = append(resourceIDs, resp.Object.ResourceId)
+					objects = append(objects, resp.Object)
 				}
 
-				slices.Sort(resourceIDs)
-				assert.Equal(t, []string{"host-1", "host-2"}, resourceIDs)
+				slices.SortFunc(objects, func(a, b *pb.ResourceReference) int {
+					if a.ResourceId < b.ResourceId {
+						return -1
+					}
+					if a.ResourceId > b.ResourceId {
+						return 1
+					}
+					return 0
+				})
+				require.Len(t, objects, 2)
+				assertProtoEqual(t, makeResourceRef("host-1", "host", "hbi"), objects[0])
+				assertProtoEqual(t, makeResourceRef("host-2", "host", "hbi"), objects[1])
 			})
 		}
 	})
@@ -4303,20 +4345,28 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				var subjectIDs []string
+				var subjects []*pb.SubjectReference
 				for {
 					resp, err := stream.Recv()
 					if err == io.EOF {
 						break
 					}
 					require.NoError(t, err)
-					assert.Equal(t, "principal", resp.Subject.Resource.ResourceType)
-					assert.Equal(t, "rbac", resp.Subject.Resource.Reporter.Type)
-					subjectIDs = append(subjectIDs, resp.Subject.Resource.ResourceId)
+					subjects = append(subjects, resp.Subject)
 				}
 
-				slices.Sort(subjectIDs)
-				assert.Equal(t, []string{"user-1", "user-2"}, subjectIDs)
+				slices.SortFunc(subjects, func(a, b *pb.SubjectReference) int {
+					if a.Resource.ResourceId < b.Resource.ResourceId {
+						return -1
+					}
+					if a.Resource.ResourceId > b.Resource.ResourceId {
+						return 1
+					}
+					return 0
+				})
+				require.Len(t, subjects, 2)
+				assertProtoEqual(t, makeSubjectRef("user-1"), subjects[0])
+				assertProtoEqual(t, makeSubjectRef("user-2"), subjects[1])
 			})
 		}
 	})

--- a/internal/service/resources/kesselinventoryservice_test.go
+++ b/internal/service/resources/kesselinventoryservice_test.go
@@ -3961,13 +3961,13 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 					}
 
 					return TestServerConfig{
-						Usecase:       uc,
-						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-					}, func(t *testing.T, tr *Transport) {
-						ctx := context.Background()
-						res := tr.Invoke(ctx, withBody(protoReq, ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
-						Assert(t, res, requireSuccess())
-					}
+							Usecase:       uc,
+							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+						}, func(t *testing.T, tr *Transport) {
+							ctx := context.Background()
+							res := tr.Invoke(ctx, withBody(protoReq, ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
+							Assert(t, res, requireSuccess())
+						}
 				})
 			})
 		}
@@ -4031,16 +4031,16 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 					}
 
 					return TestServerConfig{
-						Usecase:       uc,
-						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-					}, func(t *testing.T, tr *Transport) {
-						ctx := context.Background()
-						res1 := tr.Invoke(ctx, withBody(createReq, ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
-						Assert(t, res1, requireSuccess())
+							Usecase:       uc,
+							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+						}, func(t *testing.T, tr *Transport) {
+							ctx := context.Background()
+							res1 := tr.Invoke(ctx, withBody(createReq, ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
+							Assert(t, res1, requireSuccess())
 
-						res2 := tr.Invoke(ctx, withBody(updateReq, ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
-						Assert(t, res2, requireSuccess())
-					}
+							res2 := tr.Invoke(ctx, withBody(updateReq, ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
+							Assert(t, res2, requireSuccess())
+						}
 				})
 			})
 		}
@@ -4098,16 +4098,16 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 					}
 
 					return TestServerConfig{
-						Usecase:       uc,
-						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-					}, func(t *testing.T, tr *Transport) {
-						ctx := context.Background()
-						res1 := tr.Invoke(ctx, withBody(reportReq, ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
-						Assert(t, res1, requireSuccess())
+							Usecase:       uc,
+							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+						}, func(t *testing.T, tr *Transport) {
+							ctx := context.Background()
+							res1 := tr.Invoke(ctx, withBody(reportReq, ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
+							Assert(t, res1, requireSuccess())
 
-						res2 := tr.Invoke(ctx, withBody(deleteReq, DeleteResource, httpEndpoint("DELETE /api/kessel/v1beta2/resources")))
-						Assert(t, res2, requireSuccess())
-					}
+							res2 := tr.Invoke(ctx, withBody(deleteReq, DeleteResource, httpEndpoint("DELETE /api/kessel/v1beta2/resources")))
+							Assert(t, res2, requireSuccess())
+						}
 				})
 			})
 		}
@@ -4152,14 +4152,14 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 					}
 
 					return TestServerConfig{
-						Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-					}, func(t *testing.T, tr *Transport) {
-						ctx := context.Background()
-						res := tr.Invoke(ctx, withBody(protoReq, Check, httpEndpoint("POST /api/kessel/v1beta2/check")))
-						resp := Extract(t, res, expectSuccess(func() *pb.CheckResponse { return &pb.CheckResponse{} }))
-						assert.Equal(t, tc.expectedAllowed, resp.Allowed)
-					}
+							Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
+							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+						}, func(t *testing.T, tr *Transport) {
+							ctx := context.Background()
+							res := tr.Invoke(ctx, withBody(protoReq, Check, httpEndpoint("POST /api/kessel/v1beta2/check")))
+							resp := Extract(t, res, expectSuccess(func() *pb.CheckResponse { return &pb.CheckResponse{} }))
+							assert.Equal(t, tc.expectedAllowed, resp.Allowed)
+						}
 				})
 			})
 		}
@@ -4204,14 +4204,14 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 					}
 
 					return TestServerConfig{
-						Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-					}, func(t *testing.T, tr *Transport) {
-						ctx := context.Background()
-						res := tr.Invoke(ctx, withBody(protoReq, CheckForUpdate, httpEndpoint("POST /api/kessel/v1beta2/checkforupdate")))
-						resp := Extract(t, res, expectSuccess(func() *pb.CheckForUpdateResponse { return &pb.CheckForUpdateResponse{} }))
-						assert.Equal(t, tc.expectedAllowed, resp.Allowed)
-					}
+							Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
+							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+						}, func(t *testing.T, tr *Transport) {
+							ctx := context.Background()
+							res := tr.Invoke(ctx, withBody(protoReq, CheckForUpdate, httpEndpoint("POST /api/kessel/v1beta2/checkforupdate")))
+							resp := Extract(t, res, expectSuccess(func() *pb.CheckForUpdateResponse { return &pb.CheckForUpdateResponse{} }))
+							assert.Equal(t, tc.expectedAllowed, resp.Allowed)
+						}
 				})
 			})
 		}
@@ -4249,14 +4249,14 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 					}
 
 					return TestServerConfig{
-						Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-					}, func(t *testing.T, tr *Transport) {
-						ctx := context.Background()
-						res := tr.Invoke(ctx, withBody(protoReq, CheckSelf, httpEndpoint("POST /api/kessel/v1beta2/checkself")))
-						resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfResponse { return &pb.CheckSelfResponse{} }))
-						assert.Equal(t, tc.expectedAllowed, resp.Allowed)
-					}
+							Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
+							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+						}, func(t *testing.T, tr *Transport) {
+							ctx := context.Background()
+							res := tr.Invoke(ctx, withBody(protoReq, CheckSelf, httpEndpoint("POST /api/kessel/v1beta2/checkself")))
+							resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfResponse { return &pb.CheckSelfResponse{} }))
+							assert.Equal(t, tc.expectedAllowed, resp.Allowed)
+						}
 				})
 			})
 		}
@@ -4319,16 +4319,16 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 					}
 
 					return TestServerConfig{
-						Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-					}, func(t *testing.T, tr *Transport) {
-						ctx := context.Background()
-						res := tr.Invoke(ctx, withBody(protoReq, CheckBulk, httpEndpoint("POST /api/kessel/v1beta2/checkbulk")))
-						resp := Extract(t, res, expectSuccess(func() *pb.CheckBulkResponse { return &pb.CheckBulkResponse{} }))
-						require.Len(t, resp.Pairs, 2)
-						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
-						assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
-					}
+							Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
+							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+						}, func(t *testing.T, tr *Transport) {
+							ctx := context.Background()
+							res := tr.Invoke(ctx, withBody(protoReq, CheckBulk, httpEndpoint("POST /api/kessel/v1beta2/checkbulk")))
+							resp := Extract(t, res, expectSuccess(func() *pb.CheckBulkResponse { return &pb.CheckBulkResponse{} }))
+							require.Len(t, resp.Pairs, 2)
+							assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
+							assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
+						}
 				})
 			})
 		}
@@ -4391,16 +4391,16 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 					}
 
 					return TestServerConfig{
-						Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-					}, func(t *testing.T, tr *Transport) {
-						ctx := context.Background()
-						res := tr.Invoke(ctx, withBody(protoReq, CheckForUpdateBulk, httpEndpoint("POST /api/kessel/v1beta2/checkforupdatebulk")))
-						resp := Extract(t, res, expectSuccess(func() *pb.CheckForUpdateBulkResponse { return &pb.CheckForUpdateBulkResponse{} }))
-						require.Len(t, resp.Pairs, 2)
-						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
-						assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
-					}
+							Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
+							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+						}, func(t *testing.T, tr *Transport) {
+							ctx := context.Background()
+							res := tr.Invoke(ctx, withBody(protoReq, CheckForUpdateBulk, httpEndpoint("POST /api/kessel/v1beta2/checkforupdatebulk")))
+							resp := Extract(t, res, expectSuccess(func() *pb.CheckForUpdateBulkResponse { return &pb.CheckForUpdateBulkResponse{} }))
+							require.Len(t, resp.Pairs, 2)
+							assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
+							assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
+						}
 				})
 			})
 		}
@@ -4449,16 +4449,16 @@ func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
 					}
 
 					return TestServerConfig{
-						Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
-						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
-					}, func(t *testing.T, tr *Transport) {
-						ctx := context.Background()
-						res := tr.Invoke(ctx, withBody(protoReq, CheckSelfBulk, httpEndpoint("POST /api/kessel/v1beta2/checkselfbulk")))
-						resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfBulkResponse { return &pb.CheckSelfBulkResponse{} }))
-						require.Len(t, resp.Pairs, 2)
-						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
-						assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
-					}
+							Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
+							Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+						}, func(t *testing.T, tr *Transport) {
+							ctx := context.Background()
+							res := tr.Invoke(ctx, withBody(protoReq, CheckSelfBulk, httpEndpoint("POST /api/kessel/v1beta2/checkselfbulk")))
+							resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfBulkResponse { return &pb.CheckSelfBulkResponse{} }))
+							require.Len(t, resp.Pairs, 2)
+							assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
+							assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
+						}
 				})
 			})
 		}

--- a/internal/service/resources/kesselinventoryservice_test.go
+++ b/internal/service/resources/kesselinventoryservice_test.go
@@ -3917,3 +3917,679 @@ func newFakeSchemaRepository(t *testing.T) model.SchemaRepository {
 
 	return schemaRepository
 }
+
+func TestInventoryService_CaseInsensitiveTypes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Report", func(t *testing.T) {
+		cases := []struct {
+			name               string
+			resourceType       string
+			reporterType       string
+			reporterInstanceId string
+		}{
+			{"lowercase types", "host", "hbi", "instance-001"},
+			{"uppercase resource type", "HOST", "hbi", "instance-001"},
+			{"uppercase reporter type", "host", "HBI", "instance-001"},
+			{"all uppercase", "HOST", "HBI", "INSTANCE-001"},
+			{"mixed case instance id", "host", "hbi", "Instance-001"},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
+					claims := &authnapi.Claims{
+						SubjectId: authnapi.SubjectId("reporter-service"),
+						AuthType:  authnapi.AuthTypeXRhIdentity,
+					}
+					uc := newTestUsecase(t, testUsecaseConfig{})
+					protoReq := &pb.ReportResourceRequest{
+						Type:               tc.resourceType,
+						ReporterType:       tc.reporterType,
+						ReporterInstanceId: tc.reporterInstanceId,
+						Representations: &pb.ResourceRepresentations{
+							Metadata: &pb.RepresentationMetadata{
+								LocalResourceId: "my-host-123",
+								ApiHref:         "https://api.example.com/hosts/my-host-123",
+							},
+							Common: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"hostname": structpb.NewStringValue("example-host"),
+								},
+							},
+						},
+					}
+
+					return TestServerConfig{
+						Usecase:       uc,
+						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+					}, func(t *testing.T, tr *Transport) {
+						ctx := context.Background()
+						res := tr.Invoke(ctx, withBody(protoReq, ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
+						Assert(t, res, requireSuccess())
+					}
+				})
+			})
+		}
+	})
+
+	t.Run("ReportUpdate", func(t *testing.T) {
+		cases := []struct {
+			name           string
+			createType     string
+			createReporter string
+			createInstance string
+			updateType     string
+			updateReporter string
+			updateInstance string
+		}{
+			{"create uppercase, update lowercase", "HOST", "HBI", "INSTANCE-001", "host", "hbi", "instance-001"},
+			{"create lowercase, update uppercase", "host", "hbi", "instance-001", "HOST", "HBI", "INSTANCE-001"},
+			{"create mixed, update lowercase", "Host", "Hbi", "Instance-001", "host", "hbi", "instance-001"},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
+					claims := &authnapi.Claims{
+						SubjectId: authnapi.SubjectId("reporter-service"),
+						AuthType:  authnapi.AuthTypeXRhIdentity,
+					}
+					uc := newTestUsecase(t, testUsecaseConfig{})
+
+					createReq := &pb.ReportResourceRequest{
+						Type:               tc.createType,
+						ReporterType:       tc.createReporter,
+						ReporterInstanceId: tc.createInstance,
+						Representations: &pb.ResourceRepresentations{
+							Metadata: &pb.RepresentationMetadata{
+								LocalResourceId: "my-host-123",
+								ApiHref:         "https://api.example.com/hosts/my-host-123",
+							},
+							Common: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"hostname": structpb.NewStringValue("original-host"),
+								},
+							},
+						},
+					}
+					updateReq := &pb.ReportResourceRequest{
+						Type:               tc.updateType,
+						ReporterType:       tc.updateReporter,
+						ReporterInstanceId: tc.updateInstance,
+						Representations: &pb.ResourceRepresentations{
+							Metadata: &pb.RepresentationMetadata{
+								LocalResourceId: "my-host-123",
+								ApiHref:         "https://api.example.com/hosts/my-host-123",
+							},
+							Common: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"hostname": structpb.NewStringValue("updated-host"),
+								},
+							},
+						},
+					}
+
+					return TestServerConfig{
+						Usecase:       uc,
+						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+					}, func(t *testing.T, tr *Transport) {
+						ctx := context.Background()
+						res1 := tr.Invoke(ctx, withBody(createReq, ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
+						Assert(t, res1, requireSuccess())
+
+						res2 := tr.Invoke(ctx, withBody(updateReq, ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
+						Assert(t, res2, requireSuccess())
+					}
+				})
+			})
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		cases := []struct {
+			name           string
+			reportType     string
+			reportReporter string
+			reportInstance string
+			deleteType     string
+			deleteReporter string
+			deleteInstance string
+		}{
+			{"report uppercase, delete lowercase", "HOST", "HBI", "INSTANCE-001", "host", "hbi", "instance-001"},
+			{"report lowercase, delete uppercase", "host", "hbi", "instance-001", "HOST", "HBI", "INSTANCE-001"},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
+					claims := &authnapi.Claims{
+						SubjectId: authnapi.SubjectId("reporter-service"),
+						AuthType:  authnapi.AuthTypeXRhIdentity,
+					}
+					uc := newTestUsecase(t, testUsecaseConfig{})
+
+					reportReq := &pb.ReportResourceRequest{
+						Type:               tc.reportType,
+						ReporterType:       tc.reportReporter,
+						ReporterInstanceId: tc.reportInstance,
+						Representations: &pb.ResourceRepresentations{
+							Metadata: &pb.RepresentationMetadata{
+								LocalResourceId: "my-host-123",
+								ApiHref:         "https://api.example.com/hosts/my-host-123",
+							},
+							Common: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"hostname": structpb.NewStringValue("example-host"),
+								},
+							},
+						},
+					}
+					deleteInstance := tc.deleteInstance
+					deleteReq := &pb.DeleteResourceRequest{
+						Reference: &pb.ResourceReference{
+							ResourceType: tc.deleteType,
+							ResourceId:   "my-host-123",
+							Reporter: &pb.ReporterReference{
+								Type:       tc.deleteReporter,
+								InstanceId: &deleteInstance,
+							},
+						},
+					}
+
+					return TestServerConfig{
+						Usecase:       uc,
+						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+					}, func(t *testing.T, tr *Transport) {
+						ctx := context.Background()
+						res1 := tr.Invoke(ctx, withBody(reportReq, ReportResource, httpEndpoint("POST /api/kessel/v1beta2/resources")))
+						Assert(t, res1, requireSuccess())
+
+						res2 := tr.Invoke(ctx, withBody(deleteReq, DeleteResource, httpEndpoint("DELETE /api/kessel/v1beta2/resources")))
+						Assert(t, res2, requireSuccess())
+					}
+				})
+			})
+		}
+	})
+
+	t.Run("Check", func(t *testing.T) {
+		cases := []struct {
+			name            string
+			resourceType    string
+			reporterType    string
+			expectedAllowed pb.Allowed
+		}{
+			{"lowercase types", "host", "hbi", pb.Allowed_ALLOWED_TRUE},
+			{"uppercase types", "HOST", "HBI", pb.Allowed_ALLOWED_TRUE},
+			{"mixed case", "Host", "Hbi", pb.Allowed_ALLOWED_TRUE},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
+					claims := &authnapi.Claims{
+						SubjectId: authnapi.SubjectId("user-123"),
+						AuthType:  authnapi.AuthTypeXRhIdentity,
+					}
+					simpleAuthz := data.NewSimpleRelationsRepository()
+					simpleAuthz.Grant("subject-456", "view", "hbi", "host", "resource-abc")
+
+					protoReq := &pb.CheckRequest{
+						Relation: "view",
+						Object: &pb.ResourceReference{
+							ResourceId:   "resource-abc",
+							ResourceType: tc.resourceType,
+							Reporter:     &pb.ReporterReference{Type: tc.reporterType},
+						},
+						Subject: &pb.SubjectReference{
+							Resource: &pb.ResourceReference{
+								ResourceId:   "subject-456",
+								ResourceType: "principal",
+								Reporter:     &pb.ReporterReference{Type: "rbac"},
+							},
+						},
+					}
+
+					return TestServerConfig{
+						Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
+						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+					}, func(t *testing.T, tr *Transport) {
+						ctx := context.Background()
+						res := tr.Invoke(ctx, withBody(protoReq, Check, httpEndpoint("POST /api/kessel/v1beta2/check")))
+						resp := Extract(t, res, expectSuccess(func() *pb.CheckResponse { return &pb.CheckResponse{} }))
+						assert.Equal(t, tc.expectedAllowed, resp.Allowed)
+					}
+				})
+			})
+		}
+	})
+
+	t.Run("CheckForUpdate", func(t *testing.T) {
+		cases := []struct {
+			name            string
+			resourceType    string
+			reporterType    string
+			expectedAllowed pb.Allowed
+		}{
+			{"lowercase types", "host", "hbi", pb.Allowed_ALLOWED_TRUE},
+			{"uppercase types", "HOST", "HBI", pb.Allowed_ALLOWED_TRUE},
+			{"mixed case", "Host", "Hbi", pb.Allowed_ALLOWED_TRUE},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
+					claims := &authnapi.Claims{
+						SubjectId: authnapi.SubjectId("user-123"),
+						AuthType:  authnapi.AuthTypeXRhIdentity,
+					}
+					simpleAuthz := data.NewSimpleRelationsRepository()
+					simpleAuthz.Grant("subject-789", "edit", "hbi", "host", "resource-xyz")
+
+					protoReq := &pb.CheckForUpdateRequest{
+						Relation: "edit",
+						Object: &pb.ResourceReference{
+							ResourceId:   "resource-xyz",
+							ResourceType: tc.resourceType,
+							Reporter:     &pb.ReporterReference{Type: tc.reporterType},
+						},
+						Subject: &pb.SubjectReference{
+							Resource: &pb.ResourceReference{
+								ResourceId:   "subject-789",
+								ResourceType: "principal",
+								Reporter:     &pb.ReporterReference{Type: "rbac"},
+							},
+						},
+					}
+
+					return TestServerConfig{
+						Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
+						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+					}, func(t *testing.T, tr *Transport) {
+						ctx := context.Background()
+						res := tr.Invoke(ctx, withBody(protoReq, CheckForUpdate, httpEndpoint("POST /api/kessel/v1beta2/checkforupdate")))
+						resp := Extract(t, res, expectSuccess(func() *pb.CheckForUpdateResponse { return &pb.CheckForUpdateResponse{} }))
+						assert.Equal(t, tc.expectedAllowed, resp.Allowed)
+					}
+				})
+			})
+		}
+	})
+
+	t.Run("CheckSelf", func(t *testing.T) {
+		cases := []struct {
+			name            string
+			resourceType    string
+			reporterType    string
+			expectedAllowed pb.Allowed
+		}{
+			{"lowercase types", "host", "hbi", pb.Allowed_ALLOWED_TRUE},
+			{"uppercase types", "HOST", "HBI", pb.Allowed_ALLOWED_TRUE},
+			{"mixed case", "Host", "Hbi", pb.Allowed_ALLOWED_TRUE},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
+					claims := &authnapi.Claims{
+						SubjectId: authnapi.SubjectId("user-123"),
+						AuthType:  authnapi.AuthTypeXRhIdentity,
+					}
+					simpleAuthz := data.NewSimpleRelationsRepository()
+					simpleAuthz.Grant("user-123", "view", "hbi", "host", "resource-abc")
+
+					protoReq := &pb.CheckSelfRequest{
+						Relation: "view",
+						Object: &pb.ResourceReference{
+							ResourceId:   "resource-abc",
+							ResourceType: tc.resourceType,
+							Reporter:     &pb.ReporterReference{Type: tc.reporterType},
+						},
+					}
+
+					return TestServerConfig{
+						Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
+						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+					}, func(t *testing.T, tr *Transport) {
+						ctx := context.Background()
+						res := tr.Invoke(ctx, withBody(protoReq, CheckSelf, httpEndpoint("POST /api/kessel/v1beta2/checkself")))
+						resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfResponse { return &pb.CheckSelfResponse{} }))
+						assert.Equal(t, tc.expectedAllowed, resp.Allowed)
+					}
+				})
+			})
+		}
+	})
+
+	t.Run("CheckBulk", func(t *testing.T) {
+		cases := []struct {
+			name         string
+			resourceType string
+			reporterType string
+		}{
+			{"lowercase types", "host", "hbi"},
+			{"uppercase types", "HOST", "HBI"},
+			{"mixed case", "Host", "Hbi"},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
+					claims := &authnapi.Claims{
+						SubjectId: authnapi.SubjectId("user-123"),
+						AuthType:  authnapi.AuthTypeXRhIdentity,
+					}
+					simpleAuthz := data.NewSimpleRelationsRepository()
+					simpleAuthz.Grant("subject-a", "view", "hbi", "host", "resource-1")
+
+					protoReq := &pb.CheckBulkRequest{
+						Items: []*pb.CheckBulkRequestItem{
+							{
+								Object: &pb.ResourceReference{
+									ResourceId:   "resource-1",
+									ResourceType: tc.resourceType,
+									Reporter:     &pb.ReporterReference{Type: tc.reporterType},
+								},
+								Subject: &pb.SubjectReference{
+									Resource: &pb.ResourceReference{
+										ResourceId:   "subject-a",
+										ResourceType: "principal",
+										Reporter:     &pb.ReporterReference{Type: "rbac"},
+									},
+								},
+								Relation: "view",
+							},
+							{
+								Object: &pb.ResourceReference{
+									ResourceId:   "resource-2",
+									ResourceType: tc.resourceType,
+									Reporter:     &pb.ReporterReference{Type: tc.reporterType},
+								},
+								Subject: &pb.SubjectReference{
+									Resource: &pb.ResourceReference{
+										ResourceId:   "subject-b",
+										ResourceType: "principal",
+										Reporter:     &pb.ReporterReference{Type: "rbac"},
+									},
+								},
+								Relation: "edit",
+							},
+						},
+					}
+
+					return TestServerConfig{
+						Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
+						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+					}, func(t *testing.T, tr *Transport) {
+						ctx := context.Background()
+						res := tr.Invoke(ctx, withBody(protoReq, CheckBulk, httpEndpoint("POST /api/kessel/v1beta2/checkbulk")))
+						resp := Extract(t, res, expectSuccess(func() *pb.CheckBulkResponse { return &pb.CheckBulkResponse{} }))
+						require.Len(t, resp.Pairs, 2)
+						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
+						assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
+					}
+				})
+			})
+		}
+	})
+
+	t.Run("CheckForUpdateBulk", func(t *testing.T) {
+		cases := []struct {
+			name         string
+			resourceType string
+			reporterType string
+		}{
+			{"lowercase types", "host", "hbi"},
+			{"uppercase types", "HOST", "HBI"},
+			{"mixed case", "Host", "Hbi"},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
+					claims := &authnapi.Claims{
+						SubjectId: authnapi.SubjectId("user-123"),
+						AuthType:  authnapi.AuthTypeXRhIdentity,
+					}
+					simpleAuthz := data.NewSimpleRelationsRepository()
+					simpleAuthz.Grant("subject-a", "update", "hbi", "host", "resource-1")
+
+					protoReq := &pb.CheckForUpdateBulkRequest{
+						Items: []*pb.CheckBulkRequestItem{
+							{
+								Object: &pb.ResourceReference{
+									ResourceId:   "resource-1",
+									ResourceType: tc.resourceType,
+									Reporter:     &pb.ReporterReference{Type: tc.reporterType},
+								},
+								Subject: &pb.SubjectReference{
+									Resource: &pb.ResourceReference{
+										ResourceId:   "subject-a",
+										ResourceType: "principal",
+										Reporter:     &pb.ReporterReference{Type: "rbac"},
+									},
+								},
+								Relation: "update",
+							},
+							{
+								Object: &pb.ResourceReference{
+									ResourceId:   "resource-2",
+									ResourceType: tc.resourceType,
+									Reporter:     &pb.ReporterReference{Type: tc.reporterType},
+								},
+								Subject: &pb.SubjectReference{
+									Resource: &pb.ResourceReference{
+										ResourceId:   "subject-b",
+										ResourceType: "principal",
+										Reporter:     &pb.ReporterReference{Type: "rbac"},
+									},
+								},
+								Relation: "update",
+							},
+						},
+					}
+
+					return TestServerConfig{
+						Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
+						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+					}, func(t *testing.T, tr *Transport) {
+						ctx := context.Background()
+						res := tr.Invoke(ctx, withBody(protoReq, CheckForUpdateBulk, httpEndpoint("POST /api/kessel/v1beta2/checkforupdatebulk")))
+						resp := Extract(t, res, expectSuccess(func() *pb.CheckForUpdateBulkResponse { return &pb.CheckForUpdateBulkResponse{} }))
+						require.Len(t, resp.Pairs, 2)
+						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
+						assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
+					}
+				})
+			})
+		}
+	})
+
+	t.Run("CheckSelfBulk", func(t *testing.T) {
+		cases := []struct {
+			name         string
+			resourceType string
+			reporterType string
+		}{
+			{"lowercase types", "host", "hbi"},
+			{"uppercase types", "HOST", "HBI"},
+			{"mixed case", "Host", "Hbi"},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				runServerTest(t, func(t *testing.T) (TestServerConfig, func(t *testing.T, tr *Transport)) {
+					claims := &authnapi.Claims{
+						SubjectId: authnapi.SubjectId("user-123"),
+						AuthType:  authnapi.AuthTypeXRhIdentity,
+					}
+					simpleAuthz := data.NewSimpleRelationsRepository()
+					simpleAuthz.Grant("user-123", "view", "hbi", "host", "resource-1")
+
+					protoReq := &pb.CheckSelfBulkRequest{
+						Items: []*pb.CheckSelfBulkRequestItem{
+							{
+								Object: &pb.ResourceReference{
+									ResourceId:   "resource-1",
+									ResourceType: tc.resourceType,
+									Reporter:     &pb.ReporterReference{Type: tc.reporterType},
+								},
+								Relation: "view",
+							},
+							{
+								Object: &pb.ResourceReference{
+									ResourceId:   "resource-2",
+									ResourceType: tc.resourceType,
+									Reporter:     &pb.ReporterReference{Type: tc.reporterType},
+								},
+								Relation: "edit",
+							},
+						},
+					}
+
+					return TestServerConfig{
+						Usecase:       newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz}),
+						Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+					}, func(t *testing.T, tr *Transport) {
+						ctx := context.Background()
+						res := tr.Invoke(ctx, withBody(protoReq, CheckSelfBulk, httpEndpoint("POST /api/kessel/v1beta2/checkselfbulk")))
+						resp := Extract(t, res, expectSuccess(func() *pb.CheckSelfBulkResponse { return &pb.CheckSelfBulkResponse{} }))
+						require.Len(t, resp.Pairs, 2)
+						assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.Pairs[0].GetItem().Allowed)
+						assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.Pairs[1].GetItem().Allowed)
+					}
+				})
+			})
+		}
+	})
+
+	t.Run("StreamedListObjects", func(t *testing.T) {
+		cases := []struct {
+			name         string
+			resourceType string
+			reporterType string
+			expectedIDs  []string
+		}{
+			{"lowercase types", "host", "hbi", []string{"host-1", "host-2"}},
+			{"uppercase types", "HOST", "HBI", []string{"host-1", "host-2"}},
+			{"mixed case", "Host", "Hbi", []string{"host-1", "host-2"}},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				claims := &authnapi.Claims{
+					SubjectId: authnapi.SubjectId("user-abc"),
+					AuthType:  authnapi.AuthTypeXRhIdentity,
+				}
+				simpleAuthz := data.NewSimpleRelationsRepository()
+				simpleAuthz.Grant("subject-xyz", "view", "hbi", "host", "host-1")
+				simpleAuthz.Grant("subject-xyz", "view", "hbi", "host", "host-2")
+
+				uc := newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz})
+				client := newTestServer(t, TestServerConfig{
+					Usecase:       uc,
+					Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+				})
+
+				reporterType := tc.reporterType
+				req := &pb.StreamedListObjectsRequest{
+					ObjectType: &pb.RepresentationType{
+						ReporterType: &reporterType,
+						ResourceType: tc.resourceType,
+					},
+					Relation: "view",
+					Subject: &pb.SubjectReference{
+						Resource: &pb.ResourceReference{
+							ResourceId:   "subject-xyz",
+							ResourceType: "principal",
+							Reporter:     &pb.ReporterReference{Type: "rbac"},
+						},
+					},
+				}
+
+				stream, err := client.StreamedListObjects(context.Background(), req)
+				require.NoError(t, err)
+
+				var resourceIDs []string
+				for {
+					resp, err := stream.Recv()
+					if err == io.EOF {
+						break
+					}
+					require.NoError(t, err)
+					resourceIDs = append(resourceIDs, resp.Object.ResourceId)
+				}
+
+				slices.Sort(resourceIDs)
+				wantSorted := slices.Clone(tc.expectedIDs)
+				slices.Sort(wantSorted)
+				assert.Equal(t, wantSorted, resourceIDs)
+			})
+		}
+	})
+
+	t.Run("StreamedListSubjects", func(t *testing.T) {
+		cases := []struct {
+			name         string
+			resourceType string
+			reporterType string
+			expectedIDs  []string
+		}{
+			{"lowercase types", "host", "hbi", []string{"user-1", "user-2"}},
+			{"uppercase types", "HOST", "HBI", []string{"user-1", "user-2"}},
+			{"mixed case", "Host", "Hbi", []string{"user-1", "user-2"}},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				claims := &authnapi.Claims{
+					SubjectId: authnapi.SubjectId("user-abc"),
+					AuthType:  authnapi.AuthTypeXRhIdentity,
+				}
+				simpleAuthz := data.NewSimpleRelationsRepository()
+				simpleAuthz.Grant("user-1", "view", "hbi", "host", "host-1")
+				simpleAuthz.Grant("user-2", "view", "hbi", "host", "host-1")
+
+				uc := newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz})
+				client := newTestServer(t, TestServerConfig{
+					Usecase:       uc,
+					Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+				})
+
+				reporterType := tc.reporterType
+				subjectReporterType := "rbac"
+				req := &pb.StreamedListSubjectsRequest{
+					Resource: &pb.ResourceReference{
+						ResourceType: tc.resourceType,
+						ResourceId:   "host-1",
+						Reporter:     &pb.ReporterReference{Type: reporterType},
+					},
+					Relation: "view",
+					SubjectType: &pb.RepresentationType{
+						ResourceType: "principal",
+						ReporterType: &subjectReporterType,
+					},
+				}
+
+				stream, err := client.StreamedListSubjects(context.Background(), req)
+				require.NoError(t, err)
+
+				var subjectIDs []string
+				for {
+					resp, err := stream.Recv()
+					if err == io.EOF {
+						break
+					}
+					require.NoError(t, err)
+					subjectIDs = append(subjectIDs, resp.Subject.Resource.ResourceId)
+				}
+
+				slices.Sort(subjectIDs)
+				wantSorted := slices.Clone(tc.expectedIDs)
+				slices.Sort(wantSorted)
+				assert.Equal(t, wantSorted, subjectIDs)
+			})
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Add safety tests to document current normalization behavior before refactoring. This PR implements the Cursor plan for normalization consolidation safety tests.

Jira: https://redhat.atlassian.net/browse/RHCLOUD-45005

## Test Plan

**Cursor Plan:** `normalization_consolidation_safety_tests_1acf155a.plan.md` (attached to Jira)

This plan focuses on minimum tests needed to safely:
1. Promote raw primitives to tiny types in signatures
2. Move normalization from outer layers into domain constructors

## Changes

### 1. Schema Repository Tests (`internal/data/schema_inmemory_test.go`)
- ✅ Convert `TestInMemorySchemaRepository_GetResource` to table-driven
- ✅ Add mixed-case lookup tests:
  - Uppercase normalization (`K8S_CLUSTER` → `k8s_cluster`)
  - Mixed-case normalization (`K8s_Cluster` → `k8s_cluster`)
  - Slash normalization (`rhel/host` → `rhel_host`)
  - Combined uppercase + slash (`RHEL/Host` → `rhel_host`)

### 2. Service Layer Tests (`internal/service/resources/kesselinventoryservice_test.go`)
- ✅ Add `TestInventoryService_CaseInsensitiveTypes`
- ✅ Test `ReportResource` with various case combinations:
  - Uppercase resource type
  - Uppercase reporter type
  - All uppercase
  - Mixed case instance IDs

## What This Protects Against

- **Normalization differs after move**: Catches if schema lookups or command construction produce different values
- **Constructor rejects valid values**: Prevents runtime errors at new signature boundaries
- **Serialize output changes**: Prevents data corruption or lookup mismatches
- **Double-normalization**: Detects if outer layers still normalize after constructor does

## Test Strategy

- All tests extend existing tests, converting to table-driven where needed
- Tests document **current behavior** (will all PASS now)
- Provides safety net for future refactoring when normalization moves to model layer

## Next Steps

After this PR merges:
1. Move `NormalizeResourceType` logic into `ResourceType` constructor
2. Move `normalizeReporterType` into `ReporterType` constructor
3. Remove normalization from data/service layers
4. These tests will catch any regressions

## Related

- Epic: RHCLOUD-44628 - Merging Inventory API and Relations API
- Story: RHCLOUD-45005 - Add/move logic to model (value types & normalization)
- Test plan attached to Jira ticket

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded and refactored tests to verify case-insensitive handling and normalization of resource and reporter identifiers across write, delete, auth checks, and streaming endpoints; added table-driven parallel scenarios and validation of empty/whitespace inputs.
  * Improved streaming test coverage to assert normalized types and expected IDs in streamed responses.
* **Style**
  * Minor whitespace/formatting cleanup in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->