### PR TITLE
RHCLOUD-47158: add RBAC to full-kessel compose and integration test to validate compose stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ scripts/kubeconfig-global-hub
 
 development/configs/monitoring/ephemeral-prometheus.yml
 development/full-kessel/configs/schema.zed
+development/full-kessel/configs/rbac-role-definitions/

--- a/Makefile
+++ b/Makefile
@@ -231,8 +231,8 @@ kessel-up:
 kessel-up-monitoring:
 	./scripts/start-full-kessel.sh --profile monitoring
 
-.PHONY: kessel-test
-kessel-test:
+.PHONY: kessel-compose-integration-test
+kessel-compose-integration-test:
 	./scripts/kessel-integration-test.sh
 
 .PHONY: kessel-down

--- a/Makefile
+++ b/Makefile
@@ -231,6 +231,10 @@ kessel-up:
 kessel-up-monitoring:
 	./scripts/start-full-kessel.sh --profile monitoring
 
+.PHONY: kessel-test
+kessel-test:
+	./scripts/kessel-integration-test.sh
+
 .PHONY: kessel-down
 kessel-down:
 	./scripts/stop-full-kessel.sh

--- a/development/full-kessel/.env
+++ b/development/full-kessel/.env
@@ -10,6 +10,12 @@ SCHEMA_ZED_URL=https://raw.githubusercontent.com/RedHatInsights/rbac-config/refs
 # Override with a local file path instead of downloading (leave empty to use URL)
 SCHEMA_ZED_FILE=
 
+### RBAC role definitions (stage configmap)
+# Default: download stage configmap from rbac-config repo and extract role JSON files
+RBAC_CONFIG_URL=https://raw.githubusercontent.com/RedHatInsights/rbac-config/refs/heads/master/_private/configmaps/stage/rbac-config.yml
+# Override with a local file path instead of downloading (leave empty to use URL)
+RBAC_CONFIG_FILE=
+
 ### Credentials (shared defaults matching existing dev configs)
 POSTGRES_PASSWORD=yPsw5e6ab4bvAGe5H
 SPICEDB_GRPC_PRESHARED_KEY=foobar

--- a/development/full-kessel/.env
+++ b/development/full-kessel/.env
@@ -2,6 +2,7 @@
 INVENTORY_API_IMAGE=quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api:latest
 RELATIONS_API_IMAGE=quay.io/redhat-services-prod/project-kessel-tenant/kessel-relations/relations-api:latest
 INVENTORY_CONSUMER_IMAGE=quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer:latest
+RBAC_IMAGE=quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac:latest
 
 ### SpiceDB schema
 # Default: download from stage rbac-config repo

--- a/development/full-kessel/configs/prometheus.yml
+++ b/development/full-kessel/configs/prometheus.yml
@@ -17,3 +17,7 @@ scrape_configs:
    static_configs:
     - targets:
        - kafka-connect:8083
+ - job_name: kessel-rbac
+   static_configs:
+    - targets:
+       - rbac-server:8080

--- a/development/full-kessel/configs/rbac-consumer-acg.json
+++ b/development/full-kessel/configs/rbac-consumer-acg.json
@@ -1,0 +1,4 @@
+{
+  "metricsPort": 9006,
+  "metricsPath": "/metrics"
+}

--- a/development/full-kessel/configs/rbac-debezium-connector.json
+++ b/development/full-kessel/configs/rbac-debezium-connector.json
@@ -1,0 +1,22 @@
+{
+  "name": "rbac-outbox-connector",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "database.server.name": "rbac",
+    "database.dbname": "postgres",
+    "database.hostname": "rbac-database",
+    "database.port": "5432",
+    "database.user": "postgres",
+    "database.password": "postgres",
+    "topic.prefix": "rbac",
+    "table.include.list": "public.management_outbox",
+    "transforms": "outbox",
+    "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
+    "transforms.outbox.table.field.payload": "payload",
+    "transforms.outbox.table.field.event.type": "type",
+    "plugin.name": "pgoutput",
+    "slot.name": "rbac_outbox_debezium",
+    "snapshot.mode": "no_data",
+    "poll.interval.ms": 250
+  }
+}

--- a/development/full-kessel/docker-compose.yaml
+++ b/development/full-kessel/docker-compose.yaml
@@ -181,7 +181,7 @@ services:
         condition: service_healthy
     command: [
       "/bin/sh", "-c",
-      "curl -sf -d @/debezium-connector.json -H 'Content-Type: application/json' -X POST http://kafka-connect:8083/connectors || curl -sf -X GET http://kafka-connect:8083/connectors/debezium-connector && curl -sf -d @/rbac-debezium-connector.json -H 'Content-Type: application/json' -X POST http://kafka-connect:8083/connectors || curl -sf -X GET http://kafka-connect:8083/connectors/rbac-outbox-connector"
+      "(curl -sf -d @/debezium-connector.json -H 'Content-Type: application/json' -X POST http://kafka-connect:8083/connectors || curl -sf -X GET http://kafka-connect:8083/connectors/debezium-connector) && (curl -sf -d @/rbac-debezium-connector.json -H 'Content-Type: application/json' -X POST http://kafka-connect:8083/connectors || curl -sf -X GET http://kafka-connect:8083/connectors/rbac-outbox-connector)"
     ]
     volumes:
       - ../configs/debezium-connector.json:/debezium-connector.json:ro,z
@@ -428,7 +428,7 @@ services:
       rbac-scheduler:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -q http://localhost:8080/metrics"]
+      test: ["CMD-SHELL", "curl -f -sS http://localhost:8080/metrics || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 15
@@ -441,7 +441,7 @@ services:
     profiles: ["rbac"]
     command: [
       "sh", "-c",
-      "echo 'Resetting rbac-consumer-group offset to latest...' && bin/kafka-consumer-groups.sh --bootstrap-server kafka:9093 --group rbac-consumer-group --reset-offsets --to-latest --topic outbox.event.relations-replication-event --execute 2>&1 || true && echo 'Offset reset complete.'"
+      "echo 'Resetting rbac-consumer-group offset to latest...' && bin/kafka-consumer-groups.sh --bootstrap-server kafka:9093 --group rbac-consumer-group --reset-offsets --to-latest --topic outbox.event.relations-replication-event --execute 2>&1 && echo 'Offset reset complete.'"
     ]
     depends_on:
       kafka:

--- a/development/full-kessel/docker-compose.yaml
+++ b/development/full-kessel/docker-compose.yaml
@@ -324,6 +324,8 @@ services:
       - DATABASE_PORT=5432
       - PGSSLMODE=disable
       - ACCESS_CACHE_CONNECT_SIGNALS=False
+    volumes:
+      - ./configs/rbac-role-definitions:/opt/rbac/rbac/management/role/definitions:ro,z
     restart: "on-failure"
     depends_on:
       rbac-database:
@@ -419,7 +421,12 @@ services:
       - SYSTEM_DEFAULT_TENANT_ROLE_UUID=d8e9d8c6-1edf-41b8-951d-805e9e701f49
       - SYSTEM_ADMIN_ROOT_WORKSPACE_ROLE_UUID=411ef1a0-75a8-4765-8e9f-377297e8ee28
       - SYSTEM_ADMIN_TENANT_ROLE_UUID=a62b9113-593d-471b-96aa-971d6e748a9b
+      - ROOT_SCOPE_PERMISSIONS=advisor:*:*,patch:*:*,staleness:*:*
+      - TENANT_SCOPE_PERMISSIONS=rbac:*:*,subscriptions:*:*
+      - DEFAULT_SCOPE_PERMISSIONS=rbac:role_binding:*,subscriptions:reports:*,subscriptions:manifests:*,subscriptions:cloud_access:*
       - ROLE_CREATE_ALLOW_LIST=catalog,catalog_local_test,cost-management,remediations,inventory,drift,policies,advisor,approval,vulnerability,compliance,automation-analytics,notifications,patch,integrations,ros,staleness
+    volumes:
+      - ./configs/rbac-role-definitions:/opt/rbac/rbac/management/role/definitions:ro,z
     depends_on:
       rbac-migrate:
         condition: service_completed_successfully
@@ -433,21 +440,6 @@ services:
       timeout: 5s
       retries: 15
     restart: "always"
-    networks:
-      - kessel
-
-  rbac-consumer-offset-reset:
-    image: quay.io/strimzi/kafka:latest-kafka-3.8.0
-    profiles: ["rbac"]
-    command: [
-      "sh", "-c",
-      "echo 'Resetting rbac-consumer-group offset to latest...' && bin/kafka-consumer-groups.sh --bootstrap-server kafka:9093 --group rbac-consumer-group --reset-offsets --to-latest --topic outbox.event.relations-replication-event --execute 2>&1 && echo 'Offset reset complete.'"
-    ]
-    depends_on:
-      kafka:
-        condition: service_healthy
-      rbac-server:
-        condition: service_healthy
     networks:
       - kessel
 
@@ -475,8 +467,6 @@ services:
     volumes:
       - ./configs/rbac-consumer-acg.json:/acg-config.json:ro,z
     depends_on:
-      rbac-consumer-offset-reset:
-        condition: service_completed_successfully
       kafka:
         condition: service_healthy
       rbac-server:

--- a/development/full-kessel/docker-compose.yaml
+++ b/development/full-kessel/docker-compose.yaml
@@ -79,6 +79,9 @@ services:
       bin/kafka-topics.sh --bootstrap-server kafka:9093 --create --if-not-exists --topic host-inventory.hbi.hosts --replication-factor 1 --partitions 6
       bin/kafka-topics.sh --bootstrap-server kafka:9093 --create --if-not-exists --topic outbox.event.hbi.hosts --replication-factor 1 --partitions 1
 
+      # RBAC outbox topic (Debezium CDC from RBAC → Relations API)
+      bin/kafka-topics.sh --bootstrap-server kafka:9093 --create --if-not-exists --topic outbox.event.relations-replication-event --replication-factor 1 --partitions 1
+
       echo -e 'Successfully created the following topics:'
       bin/kafka-topics.sh --bootstrap-server kafka:9093 --list
       "
@@ -178,10 +181,11 @@ services:
         condition: service_healthy
     command: [
       "/bin/sh", "-c",
-      "curl -sf -d @/debezium-connector.json -H 'Content-Type: application/json' -X POST http://kafka-connect:8083/connectors || curl -sf -X GET http://kafka-connect:8083/connectors/debezium-connector"
+      "curl -sf -d @/debezium-connector.json -H 'Content-Type: application/json' -X POST http://kafka-connect:8083/connectors || curl -sf -X GET http://kafka-connect:8083/connectors/debezium-connector && curl -sf -d @/rbac-debezium-connector.json -H 'Content-Type: application/json' -X POST http://kafka-connect:8083/connectors || curl -sf -X GET http://kafka-connect:8083/connectors/rbac-outbox-connector"
     ]
     volumes:
       - ../configs/debezium-connector.json:/debezium-connector.json:ro,z
+      - ./configs/rbac-debezium-connector.json:/rbac-debezium-connector.json:ro,z
     restart: on-failure:10
     networks:
       - kessel
@@ -278,6 +282,7 @@ services:
 
   rbac-database:
     image: postgres:16
+    command: -c wal_level=logical
     profiles: ["rbac"]
     ports:
       - "15432:5432"
@@ -340,6 +345,9 @@ services:
       - DATABASE_PASSWORD=postgres
       - PGSSLMODE=disable
       - REDIS_HOST=redis
+      - DEVELOPMENT=True
+      - RELATION_API_SERVER=relations-api:9000
+      - REPLICATION_TO_RELATION_ENABLED=True
     depends_on:
       redis:
         condition: service_healthy
@@ -391,6 +399,7 @@ services:
       - DATABASE_PORT=5432
       - PGSSLMODE=disable
       - REDIS_HOST=redis
+      - DEVELOPMENT=True
       - DJANGO_DEBUG=True
       - DJANGO_LOG_HANDLERS=console
       - API_PATH_PREFIX=/api/rbac
@@ -423,6 +432,55 @@ services:
       interval: 10s
       timeout: 5s
       retries: 15
+    restart: "always"
+    networks:
+      - kessel
+
+  rbac-consumer-offset-reset:
+    image: quay.io/strimzi/kafka:latest-kafka-3.8.0
+    profiles: ["rbac"]
+    command: [
+      "sh", "-c",
+      "echo 'Resetting rbac-consumer-group offset to latest...' && bin/kafka-consumer-groups.sh --bootstrap-server kafka:9093 --group rbac-consumer-group --reset-offsets --to-latest --topic outbox.event.relations-replication-event --execute 2>&1 || true && echo 'Offset reset complete.'"
+    ]
+    depends_on:
+      kafka:
+        condition: service_healthy
+      rbac-server:
+        condition: service_healthy
+    networks:
+      - kessel
+
+  rbac-kafka-consumer:
+    image: "${RBAC_IMAGE}"
+    profiles: ["rbac"]
+    working_dir: /opt/rbac/rbac
+    entrypoint: ["python", "/opt/rbac/rbac/manage.py", "launch-rbac-kafka-consumer"]
+    environment:
+      - DJANGO_SETTINGS_MODULE=rbac.settings
+      - DATABASE_HOST=rbac-database
+      - DATABASE_PORT=5432
+      - DATABASE_NAME=postgres
+      - DATABASE_USER=postgres
+      - DATABASE_PASSWORD=postgres
+      - PGSSLMODE=disable
+      - REDIS_HOST=redis
+      - DEVELOPMENT=True
+      - KAFKA_ENABLED=True
+      - RBAC_KAFKA_CONSUMER_TOPIC=outbox.event.relations-replication-event
+      - RBAC_KAFKA_CUSTOM_CONSUMER_BROKER=kafka:9093
+      - RELATION_API_SERVER=relations-api:9000
+      - REPLICATION_TO_RELATION_ENABLED=True
+      - ACG_CONFIG=/acg-config.json
+    volumes:
+      - ./configs/rbac-consumer-acg.json:/acg-config.json:ro,z
+    depends_on:
+      rbac-consumer-offset-reset:
+        condition: service_completed_successfully
+      kafka:
+        condition: service_healthy
+      rbac-server:
+        condition: service_healthy
     restart: "always"
     networks:
       - kessel

--- a/development/full-kessel/docker-compose.yaml
+++ b/development/full-kessel/docker-compose.yaml
@@ -274,6 +274,159 @@ services:
     networks:
       - kessel
 
+  ### ---------- RBAC Stack (profile: rbac) ----------
+
+  rbac-database:
+    image: postgres:16
+    profiles: ["rbac"]
+    ports:
+      - "15432:5432"
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 15
+    networks:
+      - kessel
+
+  redis:
+    image: redis:5.0.4
+    profiles: ["rbac"]
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    networks:
+      - kessel
+
+  rbac-migrate:
+    image: "${RBAC_IMAGE}"
+    profiles: ["rbac"]
+    entrypoint: ["bash", "/opt/rbac/deploy/init-container-setup.sh"]
+    environment:
+      - MIGRATE_AND_SEED_ON_INIT=True
+      - DATABASE_NAME=postgres
+      - DATABASE_USER=postgres
+      - DATABASE_PASSWORD=postgres
+      - DATABASE_HOST=rbac-database
+      - DATABASE_PORT=5432
+      - PGSSLMODE=disable
+      - ACCESS_CACHE_CONNECT_SIGNALS=False
+    restart: "on-failure"
+    depends_on:
+      rbac-database:
+        condition: service_healthy
+    networks:
+      - kessel
+
+  rbac-worker:
+    image: "${RBAC_IMAGE}"
+    profiles: ["rbac"]
+    working_dir: /opt/rbac/rbac
+    entrypoint: ["celery", "--broker=redis://redis:6379/0", "-A", "rbac.celery", "worker", "--loglevel=INFO"]
+    environment:
+      - DJANGO_SETTINGS_MODULE=rbac.settings
+      - DATABASE_HOST=rbac-database
+      - DATABASE_PORT=5432
+      - DATABASE_NAME=postgres
+      - DATABASE_USER=postgres
+      - DATABASE_PASSWORD=postgres
+      - PGSSLMODE=disable
+      - REDIS_HOST=redis
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "celery --broker=redis://redis:6379/0 -A rbac.celery status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: "always"
+    networks:
+      - kessel
+
+  rbac-scheduler:
+    image: "${RBAC_IMAGE}"
+    profiles: ["rbac"]
+    working_dir: /opt/rbac/rbac
+    entrypoint: ["celery", "--broker=redis://redis:6379/0", "-A", "rbac.celery", "beat", "--loglevel=INFO"]
+    environment:
+      - DJANGO_SETTINGS_MODULE=rbac.settings
+      - DATABASE_HOST=rbac-database
+      - DATABASE_PORT=5432
+      - DATABASE_NAME=postgres
+      - DATABASE_USER=postgres
+      - DATABASE_PASSWORD=postgres
+      - PGSSLMODE=disable
+      - REDIS_HOST=redis
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "celery --broker=redis://redis:6379/0 -A rbac.celery status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: "always"
+    networks:
+      - kessel
+
+  rbac-server:
+    image: "${RBAC_IMAGE}"
+    profiles: ["rbac"]
+    ports:
+      - "9080:8080"
+    environment:
+      - DATABASE_NAME=postgres
+      - DATABASE_USER=postgres
+      - DATABASE_PASSWORD=postgres
+      - DATABASE_HOST=rbac-database
+      - DATABASE_PORT=5432
+      - PGSSLMODE=disable
+      - REDIS_HOST=redis
+      - DJANGO_DEBUG=True
+      - DJANGO_LOG_HANDLERS=console
+      - API_PATH_PREFIX=/api/rbac
+      - V2_APIS_ENABLED=True
+      - V2_READ_ONLY_API_MODE=False
+      - V2_BOOTSTRAP_TENANT=True
+      - RELATION_API_SERVER=relations-api:9000
+      - INVENTORY_API_SERVER=inventory-api:9081
+      - INVENTORY_API_LOCAL=True
+      - REPLICATION_TO_RELATION_ENABLED=True
+      - KAFKA_ENABLED=false
+      - BYPASS_BOP_VERIFICATION=True
+      - PRINCIPAL_USER_DOMAIN=redhat
+      - WORKSPACE_HIERARCHY_DEPTH_LIMIT=5
+      - WORKSPACE_ORG_CREATION_LIMIT=20000000
+      - SYSTEM_DEFAULT_ROOT_WORKSPACE_ROLE_UUID=23592f00-71f7-482d-be2c-e82eeb704406
+      - SYSTEM_DEFAULT_TENANT_ROLE_UUID=d8e9d8c6-1edf-41b8-951d-805e9e701f49
+      - SYSTEM_ADMIN_ROOT_WORKSPACE_ROLE_UUID=411ef1a0-75a8-4765-8e9f-377297e8ee28
+      - SYSTEM_ADMIN_TENANT_ROLE_UUID=a62b9113-593d-471b-96aa-971d6e748a9b
+      - ROLE_CREATE_ALLOW_LIST=catalog,catalog_local_test,cost-management,remediations,inventory,drift,policies,advisor,approval,vulnerability,compliance,automation-analytics,notifications,patch,integrations,ros,staleness
+    depends_on:
+      rbac-migrate:
+        condition: service_completed_successfully
+      rbac-worker:
+        condition: service_healthy
+      rbac-scheduler:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -q http://localhost:8080/metrics"]
+      interval: 10s
+      timeout: 5s
+      retries: 15
+    restart: "always"
+    networks:
+      - kessel
+
   ### ---------- Monitoring Stack (profile: monitoring) ----------
 
   prometheus:

--- a/docs/dev-guides/docker-compose-options.md
+++ b/docs/dev-guides/docker-compose-options.md
@@ -5,6 +5,7 @@
 | Make Target | What It Starts | Use Case |
 |---|---|---|
 | `make kessel-up` | Full Kessel suite (all services, pre-built images) | Most common -- test the full stack |
+| `make kessel-test` | Runs integration tests against running stack | Verify all services integrate correctly |
 | `make kessel-up-monitoring` | Full Kessel + Prometheus/Grafana/Alertmanager | Metrics and dashboard development |
 | `make inventory-up` | Inventory API only (built from source) | Developing Inventory API code |
 | `make inventory-up-relations-ready` | Inventory API (built from source, x-rh-identity auth) | Testing with external Relations API |
@@ -14,7 +15,7 @@
 | `make inventory-up-split-relations-ready` | Infra only (relations-compatible ports) | Debugging with local binary + Relations |
 | `make monitoring-only` | Prometheus/Grafana/Alertmanager for ephemeral | Monitoring an ephemeral namespace |
 
-All setups are stopped with `make inventory-down` except Full Kessel which uses `make kessel-down`.
+All setups are stopped with `make inventory-down` except Full Kessel which uses `make kessel-down`. To run the end-to-end integration test against the full Kessel stack, use `make kessel-test`.
 
 > NOTE: Setups that include Kafka infrastructure can take about a minute before the full Kafka stack is ready.
 
@@ -22,7 +23,7 @@ All setups are stopped with `make inventory-down` except Full Kessel which uses 
 
 ## Full Kessel Stack (Recommended)
 
-Deploy the entire Kessel suite locally with a single command: Inventory API, Relations API + SpiceDB, Inventory Consumer, Kafka, and Kafka Connect. Uses pre-built images so no other repos need to be cloned.
+Deploy the entire Kessel suite locally with a single command: Inventory API, Relations API + SpiceDB, Inventory Consumer, RBAC, Kafka, and Kafka Connect. Uses pre-built images so no other repos need to be cloned.
 
 ```shell
 make kessel-up
@@ -43,6 +44,9 @@ This starts all services using the compose file at `development/full-kessel/dock
 | 9092 | Kafka |
 | 5432 | Relations DB (postgres) |
 | 5433 | Inventory DB (postgres) |
+| 9080 | RBAC Server (HTTP, rbac profile) |
+| 15432 | RBAC DB (postgres, rbac profile) |
+| 6379 | Redis (rbac profile) |
 | 9050 | Prometheus (monitoring profile) |
 | 9093 | Alertmanager (monitoring profile) |
 | 3000 | Grafana (monitoring profile) |
@@ -55,6 +59,7 @@ Edit `development/full-kessel/.env` to use custom images for development:
 INVENTORY_API_IMAGE=localhost/kessel-inventory:dev
 RELATIONS_API_IMAGE=quay.io/redhat-services-prod/project-kessel-tenant/kessel-relations/relations-api:latest
 INVENTORY_CONSUMER_IMAGE=quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer:latest
+RBAC_IMAGE=quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac:latest
 ```
 
 ### Using a Custom SpiceDB Schema
@@ -79,9 +84,34 @@ To include Prometheus, Grafana, and Alertmanager:
 make kessel-up-monitoring
 ```
 
-Grafana is pre-loaded with a local Prometheus datasource and the current dashboards from the [dashboards folder](../../dashboards/). Prometheus is configured to scrape all Kessel services (Inventory API, Relations API, Consumer, and Kafka Connect).
+Grafana is pre-loaded with a local Prometheus datasource and the current dashboards from the [dashboards folder](../../dashboards/). Prometheus is configured to scrape all Kessel services (Inventory API, Relations API, Consumer, RBAC, and Kafka Connect).
 
 See [Monitoring Info](#monitoring-info) for URLs and login details.
+
+### RBAC Integration
+
+The full Kessel stack includes [insights-rbac](https://github.com/RedHatInsights/insights-rbac) for role-based access control testing. RBAC connects to both Relations API (gRPC) and Inventory API (gRPC) automatically. The V2 APIs are enabled by default.
+
+RBAC is available at `http://localhost:9080/api/rbac/v1/`. Metrics are served at `http://localhost:9080/metrics`.
+
+### Integration Test
+
+Run end-to-end integration tests that exercise the full service flow: RBAC tenant bootstrap, simulated HBI host events via Kafka, Inventory Consumer processing, Relations API tuple verification, and resource deletion.
+
+```shell
+make kessel-test
+```
+
+Requires `kcat`, `grpcurl`, and `jq` to be installed locally. The script will print install instructions if any are missing.
+
+The test flow:
+1. Verifies all services are healthy
+2. Bootstraps a tenant via RBAC V2 API (creates workspace hierarchy in Relations API)
+3. Publishes a simulated HBI host event to Kafka using the real workspace ID
+4. Verifies the Inventory Consumer processes the event and the resource appears in Inventory API
+5. Confirms the resource-to-workspace authorization tuple exists in Relations API
+6. Validates RBAC V2 roles and workspaces for the tenant
+7. Deletes the resource and verifies tuple cleanup
 
 ### Teardown
 

--- a/docs/dev-guides/docker-compose-options.md
+++ b/docs/dev-guides/docker-compose-options.md
@@ -5,7 +5,7 @@
 | Make Target | What It Starts | Use Case |
 |---|---|---|
 | `make kessel-up` | Full Kessel suite (all services, pre-built images) | Most common -- test the full stack |
-| `make kessel-test` | Runs integration tests against running stack | Verify all services integrate correctly |
+| `make kessel-compose-integration-test` | Runs integration tests against running stack | Verify all services integrate correctly |
 | `make kessel-up-monitoring` | Full Kessel + Prometheus/Grafana/Alertmanager | Metrics and dashboard development |
 | `make inventory-up` | Inventory API only (built from source) | Developing Inventory API code |
 | `make inventory-up-relations-ready` | Inventory API (built from source, x-rh-identity auth) | Testing with external Relations API |
@@ -15,7 +15,7 @@
 | `make inventory-up-split-relations-ready` | Infra only (relations-compatible ports) | Debugging with local binary + Relations |
 | `make monitoring-only` | Prometheus/Grafana/Alertmanager for ephemeral | Monitoring an ephemeral namespace |
 
-All setups are stopped with `make inventory-down` except Full Kessel which uses `make kessel-down`. To run the end-to-end integration test against the full Kessel stack, use `make kessel-test`.
+All setups are stopped with `make inventory-down` except Full Kessel which uses `make kessel-down`. To run the end-to-end integration test against the full Kessel stack, use `make kessel-compose-integration-test`.
 
 > NOTE: Setups that include Kafka infrastructure can take about a minute before the full Kafka stack is ready.
 
@@ -92,14 +92,14 @@ See [Monitoring Info](#monitoring-info) for URLs and login details.
 
 The full Kessel stack includes [insights-rbac](https://github.com/RedHatInsights/insights-rbac) for role-based access control testing. RBAC connects to both Relations API (gRPC) and Inventory API (gRPC) automatically. The V2 APIs are enabled by default.
 
-RBAC is available at `http://localhost:9080/api/rbac/v1/`. Metrics are served at `http://localhost:9080/metrics`.
+RBAC is available at `http://localhost:9080/api/rbac/v2/`. Metrics are served at `http://localhost:9080/metrics`.
 
 ### Integration Test
 
 Run end-to-end integration tests that exercise the full service flow: RBAC tenant bootstrap, simulated HBI host events via Kafka, Inventory Consumer processing, Relations API tuple verification, and resource deletion.
 
 ```shell
-make kessel-test
+make kessel-compose-integration-test
 ```
 
 Requires `kcat`, `grpcurl`, and `jq` to be installed locally. The script will print install instructions if any are missing.

--- a/scripts/kessel-integration-test.sh
+++ b/scripts/kessel-integration-test.sh
@@ -39,7 +39,7 @@ X_RH_IDENTITY=$(echo -n "{\"identity\":{\"account_number\":\"12345\",\"org_id\":
 # Test host UUIDs — unique per run to avoid tombstone conflicts on re-run.
 # DeleteResource soft-deletes (tombstone=true), and re-reporting a tombstoned
 # resource is an update that doesn't re-create the Relations API tuple.
-RUN_ID=$(uuidgen | tr -d '-' | head -c 12)
+RUN_ID=$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-' | head -c 12)
 HOST_ID="e2e10000-0000-0000-0000-${RUN_ID}"
 INSIGHTS_ID="e2e20000-0000-0000-0000-${RUN_ID}"
 SUB_MGR_ID="e2e30000-0000-0000-0000-${RUN_ID}"

--- a/scripts/kessel-integration-test.sh
+++ b/scripts/kessel-integration-test.sh
@@ -36,10 +36,13 @@ KAFKA_CONNECT="localhost:8083"
 ORG_ID="test-org-kessel-e2e"
 X_RH_IDENTITY=$(echo -n "{\"identity\":{\"account_number\":\"12345\",\"org_id\":\"${ORG_ID}\",\"type\":\"User\",\"user\":{\"user_id\":\"test-user-1\",\"email\":\"test@example.com\",\"username\":\"testuser\",\"is_org_admin\":true}}}" | base64 | tr -d '\n')
 
-# Test host UUIDs (deterministic for idempotent runs, valid UUID format)
-HOST_ID="e2e10000-0000-0000-0000-000000000001"
-INSIGHTS_ID="e2e20000-0000-0000-0000-000000000001"
-SUB_MGR_ID="e2e30000-0000-0000-0000-000000000001"
+# Test host UUIDs — unique per run to avoid tombstone conflicts on re-run.
+# DeleteResource soft-deletes (tombstone=true), and re-reporting a tombstoned
+# resource is an update that doesn't re-create the Relations API tuple.
+RUN_ID=$(uuidgen | tr -d '-' | head -c 12)
+HOST_ID="e2e10000-0000-0000-0000-${RUN_ID}"
+INSIGHTS_ID="e2e20000-0000-0000-0000-${RUN_ID}"
+SUB_MGR_ID="e2e30000-0000-0000-0000-${RUN_ID}"
 
 # ─── Step 0: Prerequisites ───────────────────────────────────────────────────
 
@@ -252,10 +255,10 @@ fi
 
 log_step "Step 6: Verify Resource-to-Workspace Tuple in Relations API"
 
-log_info "Polling Relations API for host tuples (up to 30s)..."
+log_info "Polling Relations API for host tuples (up to 60s)..."
 
 HOST_TUPLE_FOUND=false
-for ((i=1; i<=10; i++)); do
+for ((i=1; i<=20; i++)); do
   HOST_TUPLES_RESPONSE=$(grpcurl -plaintext -d '{"filter":{"resourceNamespace":"hbi","resourceType":"host"}}' \
     "${RELATIONS_GRPC}" kessel.relations.v1beta1.KesselTupleService/ReadTuples 2>&1) || true
 
@@ -284,7 +287,7 @@ if [[ "$HOST_TUPLE_FOUND" == "true" ]]; then
     echo "  Tuples: $(echo "$HOST_TUPLES_RESPONSE" | jq -s -c '.[] | select(.tuple) | {resource: .tuple.resource.id, relation: .tuple.relation, subject: .tuple.subject.subject.id}')"
   fi
 else
-  fail "No host tuples found in Relations API after 30s"
+  fail "No host tuples found in Relations API after 60s"
   echo "  The resource may have been stored without creating authorization tuples."
   echo "  Check that authz.impl=kessel in the inventory-api config."
 fi
@@ -293,22 +296,28 @@ fi
 
 log_step "Step 7: RBAC Access Check"
 
-# V2 roles requires rbac_roles_read on the tenant resource, but the local
-# compose seed only attaches permission children to the default workspace
-# platform role, not the tenant platform role. Use V1 for roles.
-ROLES_RESPONSE=$(curl -sf \
-  -H "x-rh-identity: ${X_RH_IDENTITY}" \
-  "http://${RBAC_HTTP}/api/rbac/v1/roles/?scope=org_id" 2>&1) || {
-  fail "RBAC V1 roles request failed"
-}
+log_info "Polling RBAC V2 roles (up to 60s for CDC replication)..."
 
-if [[ -n "${ROLES_RESPONSE:-}" ]]; then
-  ROLE_COUNT=$(echo "$ROLES_RESPONSE" | jq '.meta.count // 0')
-  if [[ "$ROLE_COUNT" -gt 0 ]]; then
-    pass "RBAC has ${ROLE_COUNT} roles for tenant"
-  else
-    fail "No roles found in RBAC for this tenant"
+ROLES_FOUND=false
+for ((i=1; i<=20; i++)); do
+  ROLES_RESPONSE=$(curl -sf \
+    -H "x-rh-identity: ${X_RH_IDENTITY}" \
+    "http://${RBAC_HTTP}/api/rbac/v2/roles/" 2>&1) || true
+
+  if [[ -n "${ROLES_RESPONSE:-}" ]]; then
+    ROLE_COUNT=$(echo "$ROLES_RESPONSE" | jq '.data | length')
+    if [[ "$ROLE_COUNT" -gt 0 ]]; then
+      ROLES_FOUND=true
+      break
+    fi
   fi
+  sleep 3
+done
+
+if [[ "$ROLES_FOUND" == "true" ]]; then
+  pass "RBAC V2 has ${ROLE_COUNT} roles for tenant"
+else
+  fail "No roles found via RBAC V2 after 60s"
 fi
 
 # Verify workspaces list includes both root and default (V2)

--- a/scripts/kessel-integration-test.sh
+++ b/scripts/kessel-integration-test.sh
@@ -26,21 +26,20 @@ fail() {
 }
 
 # Ports (match full-kessel docker-compose)
-INVENTORY_HTTP="localhost:8081"
 INVENTORY_GRPC="localhost:9081"
-RELATIONS_HTTP="localhost:8000"
+RELATIONS_GRPC="localhost:9000"
 RBAC_HTTP="localhost:9080"
 KAFKA_BOOTSTRAP="localhost:9092"
 KAFKA_CONNECT="localhost:8083"
 
 # Test identity
 ORG_ID="test-org-kessel-e2e"
-X_RH_IDENTITY=$(echo -n "{\"identity\":{\"account_number\":\"12345\",\"org_id\":\"${ORG_ID}\",\"type\":\"User\",\"user\":{\"user_id\":\"test-user-1\",\"email\":\"test@example.com\",\"username\":\"testuser\"}}}" | base64 -w0)
+X_RH_IDENTITY=$(echo -n "{\"identity\":{\"account_number\":\"12345\",\"org_id\":\"${ORG_ID}\",\"type\":\"User\",\"user\":{\"user_id\":\"test-user-1\",\"email\":\"test@example.com\",\"username\":\"testuser\",\"is_org_admin\":true}}}" | base64 -w0)
 
-# Test host UUIDs (deterministic for idempotent runs)
-HOST_ID="e2e-10000000-0000-0000-0000-000000000001"
-INSIGHTS_ID="e2e-20000000-0000-0000-0000-000000000001"
-SUB_MGR_ID="e2e-30000000-0000-0000-0000-000000000001"
+# Test host UUIDs (deterministic for idempotent runs, valid UUID format)
+HOST_ID="e2e10000-0000-0000-0000-000000000001"
+INSIGHTS_ID="e2e20000-0000-0000-0000-000000000001"
+SUB_MGR_ID="e2e30000-0000-0000-0000-000000000001"
 
 # ─── Step 0: Prerequisites ───────────────────────────────────────────────────
 
@@ -68,7 +67,7 @@ pass "All prerequisites installed"
 
 log_step "Step 1: Service Health Checks"
 
-wait_for_service() {
+wait_for_http_service() {
   local name="$1" url="$2" retries="${3:-30}" interval="${4:-5}"
   for ((i=1; i<=retries; i++)); do
     if curl -sf "$url" -o /dev/null 2>/dev/null; then
@@ -84,11 +83,27 @@ wait_for_service() {
   return 1
 }
 
+wait_for_grpc_service() {
+  local name="$1" address="$2" service="$3" retries="${4:-30}" interval="${5:-5}"
+  for ((i=1; i<=retries; i++)); do
+    if grpcurl -plaintext "$address" "$service" &>/dev/null; then
+      pass "$name is ready"
+      return 0
+    fi
+    if [[ $i -eq 1 ]]; then
+      log_info "Waiting for $name..."
+    fi
+    sleep "$interval"
+  done
+  fail "$name did not become ready after $((retries * interval))s"
+  return 1
+}
+
 HEALTH_OK=true
-wait_for_service "Inventory API"  "http://${INVENTORY_HTTP}/api/kessel/v1/readyz" || HEALTH_OK=false
-wait_for_service "Relations API"  "http://${RELATIONS_HTTP}/readyz" || HEALTH_OK=false
-wait_for_service "RBAC"           "http://${RBAC_HTTP}/metrics" || HEALTH_OK=false
-wait_for_service "Kafka Connect"  "http://${KAFKA_CONNECT}/connectors" || HEALTH_OK=false
+wait_for_grpc_service "Inventory API" "${INVENTORY_GRPC}" "kessel.inventory.v1.KesselInventoryHealthService/GetReadyz" || HEALTH_OK=false
+wait_for_grpc_service "Relations API" "${RELATIONS_GRPC}" "kessel.relations.v1.KesselRelationsHealthService/GetReadyz" || HEALTH_OK=false
+wait_for_http_service "RBAC"          "http://${RBAC_HTTP}/metrics" || HEALTH_OK=false
+wait_for_http_service "Kafka Connect" "http://${KAFKA_CONNECT}/connectors" || HEALTH_OK=false
 
 if [[ "$HEALTH_OK" != "true" ]]; then
   log_error "Not all services are healthy. Is the stack running? (make kessel-up)"
@@ -135,30 +150,39 @@ fi
 
 log_step "Step 3: Verify Workspace Hierarchy in Relations API"
 
-TUPLES_RESPONSE=$(curl -sf \
-  "http://${RELATIONS_HTTP}/v1beta1/tuples?filter.resourceNamespace=rbac&filter.resourceType=workspace" 2>&1) || {
-  fail "Failed to query workspace tuples from Relations API"
-  exit 1
-}
+log_info "Polling Relations API for workspace tuples (up to 60s)..."
 
-TUPLE_COUNT=$(echo "$TUPLES_RESPONSE" | jq '[.tuples // [] | length] | add // 0')
+WS_TUPLES_FOUND=false
+for ((i=1; i<=20; i++)); do
+  TUPLES_RESPONSE=$(grpcurl -plaintext -d '{"filter":{"resourceNamespace":"rbac","resourceType":"workspace"}}' \
+    "${RELATIONS_GRPC}" kessel.relations.v1beta1.KesselTupleService/ReadTuples 2>&1) || true
 
-if [[ "$TUPLE_COUNT" -gt 0 ]]; then
-  pass "Found ${TUPLE_COUNT} workspace tuples in Relations API"
-else
-  fail "No workspace tuples found — RBAC bootstrap may not have replicated to Relations API"
-  echo "  This can happen if Relations API was slow to start. Wait a few seconds and re-run."
-fi
-
-# Verify the default workspace has a parent tuple (default → root)
-if [[ -n "$DEFAULT_WORKSPACE_ID" ]]; then
-  DEFAULT_WS_TUPLE=$(echo "$TUPLES_RESPONSE" | jq --arg wsid "$DEFAULT_WORKSPACE_ID" \
-    '[.tuples[]? | select(.resource.id == $wsid)] | length')
-  if [[ "$DEFAULT_WS_TUPLE" -gt 0 ]]; then
-    pass "Default workspace has parent relationship in hierarchy"
-  else
-    log_warn "Default workspace parent tuple not found (may take a moment to replicate)"
+  if [[ -n "${TUPLES_RESPONSE:-}" ]]; then
+    TUPLE_COUNT=$(echo "$TUPLES_RESPONSE" | jq -s '[.[] | select(.tuple)] | length')
+    if [[ "$TUPLE_COUNT" -gt 0 ]]; then
+      WS_TUPLES_FOUND=true
+      break
+    fi
   fi
+  sleep 3
+done
+
+if [[ "$WS_TUPLES_FOUND" == "true" ]]; then
+  pass "Found ${TUPLE_COUNT} workspace tuples in Relations API"
+
+  # Verify the default workspace has a parent tuple (default → root)
+  if [[ -n "$DEFAULT_WORKSPACE_ID" ]]; then
+    DEFAULT_WS_TUPLE=$(echo "$TUPLES_RESPONSE" | jq -s --arg wsid "$DEFAULT_WORKSPACE_ID" \
+      '[.[] | select(.tuple.resource.id == $wsid)] | length')
+    if [[ "$DEFAULT_WS_TUPLE" -gt 0 ]]; then
+      pass "Default workspace has parent relationship in hierarchy"
+    else
+      log_warn "Default workspace parent tuple not found (may take a moment to replicate)"
+    fi
+  fi
+else
+  fail "No workspace tuples found in Relations API after 60s"
+  echo "  Check that RBAC CDC pipeline is running (rbac-kafka-consumer, kafka-connect connectors)"
 fi
 
 # ─── Step 4: Publish Simulated HBI Host Event via kcat ───────────────────────
@@ -228,59 +252,66 @@ fi
 
 log_step "Step 6: Verify Resource-to-Workspace Tuple in Relations API"
 
-# Give Relations API a moment to process the tuple creation
-sleep 3
+log_info "Polling Relations API for host tuples (up to 30s)..."
 
-HOST_TUPLES_RESPONSE=$(curl -sf \
-  "http://${RELATIONS_HTTP}/v1beta1/tuples?filter.resourceType=host" 2>&1) || {
-  fail "Failed to query host tuples from Relations API"
-}
+HOST_TUPLE_FOUND=false
+for ((i=1; i<=10; i++)); do
+  HOST_TUPLES_RESPONSE=$(grpcurl -plaintext -d '{"filter":{"resourceNamespace":"hbi","resourceType":"host"}}' \
+    "${RELATIONS_GRPC}" kessel.relations.v1beta1.KesselTupleService/ReadTuples 2>&1) || true
 
-if [[ -n "${HOST_TUPLES_RESPONSE:-}" ]]; then
-  HOST_TUPLE_COUNT=$(echo "$HOST_TUPLES_RESPONSE" | jq '[.tuples // [] | length] | add // 0')
-
-  if [[ "$HOST_TUPLE_COUNT" -gt 0 ]]; then
-    pass "Found ${HOST_TUPLE_COUNT} host tuple(s) in Relations API"
-
-    # Verify the tuple links our host to the correct workspace
-    MATCHING_TUPLE=$(echo "$HOST_TUPLES_RESPONSE" | jq --arg wsid "$DEFAULT_WORKSPACE_ID" \
-      '[.tuples[]? | select(.subject.subject.id == $wsid)] | length')
-
-    if [[ "$MATCHING_TUPLE" -gt 0 ]]; then
-      pass "Host resource is linked to workspace ${DEFAULT_WORKSPACE_ID}"
-    else
-      fail "Host tuple exists but not linked to expected workspace"
-      echo "  Expected workspace: ${DEFAULT_WORKSPACE_ID}"
-      echo "  Tuples: $(echo "$HOST_TUPLES_RESPONSE" | jq -c '.tuples[]? | {resource: .resource.id, relation: .relation, subject: .subject.subject.id}')"
+  if [[ -n "${HOST_TUPLES_RESPONSE:-}" ]]; then
+    HOST_TUPLE_COUNT=$(echo "$HOST_TUPLES_RESPONSE" | jq -s '[.[] | select(.tuple)] | length')
+    if [[ "$HOST_TUPLE_COUNT" -gt 0 ]]; then
+      HOST_TUPLE_FOUND=true
+      break
     fi
-  else
-    fail "No host tuples found in Relations API"
-    echo "  The resource may have been stored without creating authorization tuples."
-    echo "  Check that authz.impl=kessel in the inventory-api config."
   fi
+  sleep 3
+done
+
+if [[ "$HOST_TUPLE_FOUND" == "true" ]]; then
+  pass "Found ${HOST_TUPLE_COUNT} host tuple(s) in Relations API"
+
+  # Verify the tuple links our host to the correct workspace
+  MATCHING_TUPLE=$(echo "$HOST_TUPLES_RESPONSE" | jq -s --arg wsid "$DEFAULT_WORKSPACE_ID" \
+    '[.[] | select(.tuple.subject.subject.id == $wsid)] | length')
+
+  if [[ "$MATCHING_TUPLE" -gt 0 ]]; then
+    pass "Host resource is linked to workspace ${DEFAULT_WORKSPACE_ID}"
+  else
+    fail "Host tuple exists but not linked to expected workspace"
+    echo "  Expected workspace: ${DEFAULT_WORKSPACE_ID}"
+    echo "  Tuples: $(echo "$HOST_TUPLES_RESPONSE" | jq -s -c '.[] | select(.tuple) | {resource: .tuple.resource.id, relation: .tuple.relation, subject: .tuple.subject.subject.id}')"
+  fi
+else
+  fail "No host tuples found in Relations API after 30s"
+  echo "  The resource may have been stored without creating authorization tuples."
+  echo "  Check that authz.impl=kessel in the inventory-api config."
 fi
 
-# ─── Step 7: RBAC V2 Access Check ───────────────────────────────────────────
+# ─── Step 7: RBAC Access Check ──────────────────────────────────────────────
 
-log_step "Step 7: RBAC V2 Access Check"
+log_step "Step 7: RBAC Access Check"
 
-# Verify roles exist for this tenant
+# V2 roles requires rbac_roles_read on the tenant resource, but the local
+# compose seed only attaches permission children to the default workspace
+# platform role, not the tenant platform role. Use V1 for roles.
 ROLES_RESPONSE=$(curl -sf \
   -H "x-rh-identity: ${X_RH_IDENTITY}" \
-  "http://${RBAC_HTTP}/api/rbac/v2/roles/" 2>&1) || {
-  fail "RBAC V2 roles request failed"
+  "http://${RBAC_HTTP}/api/rbac/v1/roles/?scope=org_id" 2>&1) || {
+  fail "RBAC V1 roles request failed"
 }
 
 if [[ -n "${ROLES_RESPONSE:-}" ]]; then
   ROLE_COUNT=$(echo "$ROLES_RESPONSE" | jq '.meta.count // 0')
   if [[ "$ROLE_COUNT" -gt 0 ]]; then
-    pass "RBAC has ${ROLE_COUNT} roles for tenant org_id=${ORG_ID}"
+    pass "RBAC has ${ROLE_COUNT} roles for tenant"
   else
     fail "No roles found in RBAC for this tenant"
   fi
 fi
 
-# Verify workspaces list includes both root and default
+# Verify workspaces list includes both root and default (V2)
 WORKSPACES_RESPONSE=$(curl -sf \
   -H "x-rh-identity: ${X_RH_IDENTITY}" \
   "http://${RBAC_HTTP}/api/rbac/v2/workspaces/" 2>&1) || {
@@ -290,7 +321,7 @@ WORKSPACES_RESPONSE=$(curl -sf \
 if [[ -n "${WORKSPACES_RESPONSE:-}" ]]; then
   WS_COUNT=$(echo "$WORKSPACES_RESPONSE" | jq '.meta.count // 0')
   if [[ "$WS_COUNT" -ge 2 ]]; then
-    pass "RBAC lists ${WS_COUNT} workspaces (root + default + any user-created)"
+    pass "RBAC V2 lists ${WS_COUNT} workspaces (root + default + any user-created)"
   else
     fail "Expected at least 2 workspaces (root + default), got ${WS_COUNT}"
   fi
@@ -318,21 +349,31 @@ DELETE_RESULT=$(grpcurl -plaintext -d "{
   echo "  grpcurl output: ${DELETE_RESULT}"
 }
 
-# Wait for tuple cleanup
-sleep 3
+# Wait for tuple cleanup via CDC pipeline
+log_info "Waiting for tuple cleanup (up to 30s)..."
 
-HOST_TUPLES_AFTER=$(curl -sf \
-  "http://${RELATIONS_HTTP}/v1beta1/tuples?filter.resourceType=host" 2>&1) || true
+TUPLE_CLEANED=false
+for ((i=1; i<=10; i++)); do
+  sleep 3
+  HOST_TUPLES_AFTER=$(grpcurl -plaintext -d '{"filter":{"resourceNamespace":"hbi","resourceType":"host"}}' \
+    "${RELATIONS_GRPC}" kessel.relations.v1beta1.KesselTupleService/ReadTuples 2>&1) || true
 
-if [[ -n "${HOST_TUPLES_AFTER:-}" ]]; then
-  REMAINING=$(echo "$HOST_TUPLES_AFTER" | jq --arg wsid "$DEFAULT_WORKSPACE_ID" \
-    '[.tuples[]? | select(.subject.subject.id == $wsid)] | length')
+  REMAINING=0
+  if [[ -n "${HOST_TUPLES_AFTER:-}" ]]; then
+    REMAINING=$(echo "$HOST_TUPLES_AFTER" | jq -s --arg wsid "$DEFAULT_WORKSPACE_ID" \
+      '[.[] | select(.tuple.subject.subject.id == $wsid)] | length')
+  fi
 
   if [[ "$REMAINING" -eq 0 ]]; then
-    pass "Host-to-workspace tuple removed from Relations API after deletion"
-  else
-    fail "Host-to-workspace tuple still present after deletion (count: ${REMAINING})"
+    TUPLE_CLEANED=true
+    break
   fi
+done
+
+if [[ "$TUPLE_CLEANED" == "true" ]]; then
+  pass "Host-to-workspace tuple removed from Relations API after deletion"
+else
+  fail "Host-to-workspace tuple still present after deletion (count: ${REMAINING})"
 fi
 
 # ─── Step 9: Summary ─────────────────────────────────────────────────────────

--- a/scripts/kessel-integration-test.sh
+++ b/scripts/kessel-integration-test.sh
@@ -34,7 +34,7 @@ KAFKA_CONNECT="localhost:8083"
 
 # Test identity
 ORG_ID="test-org-kessel-e2e"
-X_RH_IDENTITY=$(echo -n "{\"identity\":{\"account_number\":\"12345\",\"org_id\":\"${ORG_ID}\",\"type\":\"User\",\"user\":{\"user_id\":\"test-user-1\",\"email\":\"test@example.com\",\"username\":\"testuser\",\"is_org_admin\":true}}}" | base64 -w0)
+X_RH_IDENTITY=$(echo -n "{\"identity\":{\"account_number\":\"12345\",\"org_id\":\"${ORG_ID}\",\"type\":\"User\",\"user\":{\"user_id\":\"test-user-1\",\"email\":\"test@example.com\",\"username\":\"testuser\",\"is_org_admin\":true}}}" | base64 | tr -d '\n')
 
 # Test host UUIDs (deterministic for idempotent runs, valid UUID format)
 HOST_ID="e2e10000-0000-0000-0000-000000000001"
@@ -171,11 +171,11 @@ if [[ "$WS_TUPLES_FOUND" == "true" ]]; then
   pass "Found ${TUPLE_COUNT} workspace tuples in Relations API"
 
   # Verify the default workspace has a parent tuple (default → root)
-  if [[ -n "$DEFAULT_WORKSPACE_ID" ]]; then
-    DEFAULT_WS_TUPLE=$(echo "$TUPLES_RESPONSE" | jq -s --arg wsid "$DEFAULT_WORKSPACE_ID" \
-      '[.[] | select(.tuple.resource.id == $wsid)] | length')
+  if [[ -n "$DEFAULT_WORKSPACE_ID" && -n "$ROOT_WORKSPACE_ID" ]]; then
+    DEFAULT_WS_TUPLE=$(echo "$TUPLES_RESPONSE" | jq -s --arg wsid "$DEFAULT_WORKSPACE_ID" --arg root "$ROOT_WORKSPACE_ID" \
+      '[.[] | select(.tuple.resource.id == $wsid and .tuple.subject.subject.id == $root)] | length')
     if [[ "$DEFAULT_WS_TUPLE" -gt 0 ]]; then
-      pass "Default workspace has parent relationship in hierarchy"
+      pass "Default workspace has parent relationship to root workspace"
     else
       log_warn "Default workspace parent tuple not found (may take a moment to replicate)"
     fi

--- a/scripts/kessel-integration-test.sh
+++ b/scripts/kessel-integration-test.sh
@@ -1,0 +1,353 @@
+#!/bin/bash
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_step() { echo -e "\n${CYAN}=== $1 ===${NC}"; }
+
+pass() {
+  echo -e "  ${GREEN}✓ PASS:${NC} $1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+  echo -e "  ${RED}✗ FAIL:${NC} $1"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# Ports (match full-kessel docker-compose)
+INVENTORY_HTTP="localhost:8081"
+INVENTORY_GRPC="localhost:9081"
+RELATIONS_HTTP="localhost:8000"
+RBAC_HTTP="localhost:9080"
+KAFKA_BOOTSTRAP="localhost:9092"
+KAFKA_CONNECT="localhost:8083"
+
+# Test identity
+ORG_ID="test-org-kessel-e2e"
+X_RH_IDENTITY=$(echo -n "{\"identity\":{\"account_number\":\"12345\",\"org_id\":\"${ORG_ID}\",\"type\":\"User\",\"user\":{\"user_id\":\"test-user-1\",\"email\":\"test@example.com\",\"username\":\"testuser\"}}}" | base64 -w0)
+
+# Test host UUIDs (deterministic for idempotent runs)
+HOST_ID="e2e-10000000-0000-0000-0000-000000000001"
+INSIGHTS_ID="e2e-20000000-0000-0000-0000-000000000001"
+SUB_MGR_ID="e2e-30000000-0000-0000-0000-000000000001"
+
+# ─── Step 0: Prerequisites ───────────────────────────────────────────────────
+
+log_step "Step 0: Prerequisites Check"
+
+MISSING=""
+for cmd in kcat grpcurl jq curl; do
+  if ! command -v "$cmd" &>/dev/null; then
+    MISSING="${MISSING} ${cmd}"
+  fi
+done
+
+if [[ -n "$MISSING" ]]; then
+  log_error "Missing required tools:${MISSING}"
+  echo "  Install with:"
+  echo "    kcat:    dnf install kcat  /  brew install kcat"
+  echo "    grpcurl: go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest"
+  echo "    jq:      dnf install jq    /  brew install jq"
+  echo "    curl:    dnf install curl  /  brew install curl"
+  exit 1
+fi
+pass "All prerequisites installed"
+
+# ─── Step 1: Service Health Checks ───────────────────────────────────────────
+
+log_step "Step 1: Service Health Checks"
+
+wait_for_service() {
+  local name="$1" url="$2" retries="${3:-30}" interval="${4:-5}"
+  for ((i=1; i<=retries; i++)); do
+    if curl -sf "$url" -o /dev/null 2>/dev/null; then
+      pass "$name is ready"
+      return 0
+    fi
+    if [[ $i -eq 1 ]]; then
+      log_info "Waiting for $name..."
+    fi
+    sleep "$interval"
+  done
+  fail "$name did not become ready after $((retries * interval))s"
+  return 1
+}
+
+HEALTH_OK=true
+wait_for_service "Inventory API"  "http://${INVENTORY_HTTP}/api/kessel/v1/readyz" || HEALTH_OK=false
+wait_for_service "Relations API"  "http://${RELATIONS_HTTP}/readyz" || HEALTH_OK=false
+wait_for_service "RBAC"           "http://${RBAC_HTTP}/metrics" || HEALTH_OK=false
+wait_for_service "Kafka Connect"  "http://${KAFKA_CONNECT}/connectors" || HEALTH_OK=false
+
+if [[ "$HEALTH_OK" != "true" ]]; then
+  log_error "Not all services are healthy. Is the stack running? (make kessel-up)"
+  exit 1
+fi
+
+# ─── Step 2: Bootstrap Tenant via RBAC V2 ────────────────────────────────────
+
+log_step "Step 2: Bootstrap Tenant via RBAC V2"
+
+log_info "Triggering tenant bootstrap for org_id=${ORG_ID}"
+
+WORKSPACE_RESPONSE=$(curl -sf \
+  -H "x-rh-identity: ${X_RH_IDENTITY}" \
+  "http://${RBAC_HTTP}/api/rbac/v2/workspaces/?type=default" 2>&1) || {
+  fail "RBAC V2 workspaces request failed"
+  echo "  Response: ${WORKSPACE_RESPONSE}"
+  exit 1
+}
+
+DEFAULT_WORKSPACE_ID=$(echo "$WORKSPACE_RESPONSE" | jq -r '.data[0].id // empty')
+
+if [[ -z "$DEFAULT_WORKSPACE_ID" ]]; then
+  fail "Could not extract default workspace ID from RBAC response"
+  echo "  Response: ${WORKSPACE_RESPONSE}"
+  exit 1
+fi
+
+pass "Tenant bootstrapped — default workspace: ${DEFAULT_WORKSPACE_ID}"
+
+# Also fetch root workspace for reference
+ROOT_RESPONSE=$(curl -sf \
+  -H "x-rh-identity: ${X_RH_IDENTITY}" \
+  "http://${RBAC_HTTP}/api/rbac/v2/workspaces/?type=root" 2>&1) || true
+
+ROOT_WORKSPACE_ID=$(echo "$ROOT_RESPONSE" | jq -r '.data[0].id // empty')
+if [[ -n "$ROOT_WORKSPACE_ID" ]]; then
+  pass "Root workspace: ${ROOT_WORKSPACE_ID}"
+else
+  log_warn "Could not retrieve root workspace (non-fatal)"
+fi
+
+# ─── Step 3: Verify Workspace Hierarchy in Relations API ─────────────────────
+
+log_step "Step 3: Verify Workspace Hierarchy in Relations API"
+
+TUPLES_RESPONSE=$(curl -sf \
+  "http://${RELATIONS_HTTP}/v1beta1/tuples?filter.resourceNamespace=rbac&filter.resourceType=workspace" 2>&1) || {
+  fail "Failed to query workspace tuples from Relations API"
+  exit 1
+}
+
+TUPLE_COUNT=$(echo "$TUPLES_RESPONSE" | jq '[.tuples // [] | length] | add // 0')
+
+if [[ "$TUPLE_COUNT" -gt 0 ]]; then
+  pass "Found ${TUPLE_COUNT} workspace tuples in Relations API"
+else
+  fail "No workspace tuples found — RBAC bootstrap may not have replicated to Relations API"
+  echo "  This can happen if Relations API was slow to start. Wait a few seconds and re-run."
+fi
+
+# Verify the default workspace has a parent tuple (default → root)
+if [[ -n "$DEFAULT_WORKSPACE_ID" ]]; then
+  DEFAULT_WS_TUPLE=$(echo "$TUPLES_RESPONSE" | jq --arg wsid "$DEFAULT_WORKSPACE_ID" \
+    '[.tuples[]? | select(.resource.id == $wsid)] | length')
+  if [[ "$DEFAULT_WS_TUPLE" -gt 0 ]]; then
+    pass "Default workspace has parent relationship in hierarchy"
+  else
+    log_warn "Default workspace parent tuple not found (may take a moment to replicate)"
+  fi
+fi
+
+# ─── Step 4: Publish Simulated HBI Host Event via kcat ───────────────────────
+
+log_step "Step 4: Publish Simulated HBI Host Event via kcat"
+
+HBI_MESSAGE=$(cat <<EOF
+{"schema":{},"payload":{"id":"${HOST_ID}","ansible_host":"e2e-test-host","insights_id":"${INSIGHTS_ID}","subscription_manager_id":"${SUB_MGR_ID}","satellite_id":null,"groups":[{"id":"${DEFAULT_WORKSPACE_ID}"}]}}
+EOF
+)
+
+log_info "Publishing HBI host event to outbox.event.hbi.hosts"
+log_info "  host_id=${HOST_ID}, workspace_id=${DEFAULT_WORKSPACE_ID}"
+
+echo "${HBI_MESSAGE}" | kcat -P -b "${KAFKA_BOOTSTRAP}" \
+  -H "operation=ReportResource" -H "version=v1beta2" \
+  -t outbox.event.hbi.hosts -K "|" 2>&1 || {
+  fail "Failed to publish HBI event to Kafka"
+  exit 1
+}
+
+pass "HBI host event published to Kafka"
+
+# ─── Step 5: Wait for Consumer Processing ────────────────────────────────────
+
+log_step "Step 5: Wait for Consumer Processing"
+
+log_info "Polling Inventory API for the reported resource (up to 30s)..."
+
+RESOURCE_FOUND=false
+for ((i=1; i<=10; i++)); do
+  REPORT_RESULT=$(grpcurl -plaintext -d "{
+    \"type\": \"host\",
+    \"reporterType\": \"hbi\",
+    \"reporterInstanceId\": \"redhat\",
+    \"representations\": {
+      \"metadata\": {
+        \"localResourceId\": \"${HOST_ID}\",
+        \"apiHref\": \"https://apihref.com/\",
+        \"consoleHref\": \"https://www.console.com/\",
+        \"reporterVersion\": \"1.0\"
+      },
+      \"common\": {
+        \"workspace_id\": \"${DEFAULT_WORKSPACE_ID}\"
+      },
+      \"reporter\": {
+        \"insights_id\": \"${INSIGHTS_ID}\",
+        \"subscription_manager_id\": \"${SUB_MGR_ID}\",
+        \"ansible_host\": \"e2e-test-host\"
+      }
+    }
+  }" "${INVENTORY_GRPC}" kessel.inventory.v1beta2.KesselInventoryService/ReportResource 2>&1) && {
+    RESOURCE_FOUND=true
+    break
+  }
+  sleep 3
+done
+
+if [[ "$RESOURCE_FOUND" == "true" ]]; then
+  pass "Resource confirmed in Inventory API (host_id=${HOST_ID})"
+else
+  fail "Resource not found in Inventory API after 30s"
+  echo "  Last grpcurl output: ${REPORT_RESULT}"
+fi
+
+# ─── Step 6: Verify Resource-to-Workspace Tuple in Relations API ─────────────
+
+log_step "Step 6: Verify Resource-to-Workspace Tuple in Relations API"
+
+# Give Relations API a moment to process the tuple creation
+sleep 3
+
+HOST_TUPLES_RESPONSE=$(curl -sf \
+  "http://${RELATIONS_HTTP}/v1beta1/tuples?filter.resourceType=host" 2>&1) || {
+  fail "Failed to query host tuples from Relations API"
+}
+
+if [[ -n "${HOST_TUPLES_RESPONSE:-}" ]]; then
+  HOST_TUPLE_COUNT=$(echo "$HOST_TUPLES_RESPONSE" | jq '[.tuples // [] | length] | add // 0')
+
+  if [[ "$HOST_TUPLE_COUNT" -gt 0 ]]; then
+    pass "Found ${HOST_TUPLE_COUNT} host tuple(s) in Relations API"
+
+    # Verify the tuple links our host to the correct workspace
+    MATCHING_TUPLE=$(echo "$HOST_TUPLES_RESPONSE" | jq --arg wsid "$DEFAULT_WORKSPACE_ID" \
+      '[.tuples[]? | select(.subject.subject.id == $wsid)] | length')
+
+    if [[ "$MATCHING_TUPLE" -gt 0 ]]; then
+      pass "Host resource is linked to workspace ${DEFAULT_WORKSPACE_ID}"
+    else
+      fail "Host tuple exists but not linked to expected workspace"
+      echo "  Expected workspace: ${DEFAULT_WORKSPACE_ID}"
+      echo "  Tuples: $(echo "$HOST_TUPLES_RESPONSE" | jq -c '.tuples[]? | {resource: .resource.id, relation: .relation, subject: .subject.subject.id}')"
+    fi
+  else
+    fail "No host tuples found in Relations API"
+    echo "  The resource may have been stored without creating authorization tuples."
+    echo "  Check that authz.impl=kessel in the inventory-api config."
+  fi
+fi
+
+# ─── Step 7: RBAC V2 Access Check ───────────────────────────────────────────
+
+log_step "Step 7: RBAC V2 Access Check"
+
+# Verify roles exist for this tenant
+ROLES_RESPONSE=$(curl -sf \
+  -H "x-rh-identity: ${X_RH_IDENTITY}" \
+  "http://${RBAC_HTTP}/api/rbac/v2/roles/" 2>&1) || {
+  fail "RBAC V2 roles request failed"
+}
+
+if [[ -n "${ROLES_RESPONSE:-}" ]]; then
+  ROLE_COUNT=$(echo "$ROLES_RESPONSE" | jq '.meta.count // 0')
+  if [[ "$ROLE_COUNT" -gt 0 ]]; then
+    pass "RBAC has ${ROLE_COUNT} roles for tenant org_id=${ORG_ID}"
+  else
+    fail "No roles found in RBAC for this tenant"
+  fi
+fi
+
+# Verify workspaces list includes both root and default
+WORKSPACES_RESPONSE=$(curl -sf \
+  -H "x-rh-identity: ${X_RH_IDENTITY}" \
+  "http://${RBAC_HTTP}/api/rbac/v2/workspaces/" 2>&1) || {
+  fail "RBAC V2 workspaces list request failed"
+}
+
+if [[ -n "${WORKSPACES_RESPONSE:-}" ]]; then
+  WS_COUNT=$(echo "$WORKSPACES_RESPONSE" | jq '.meta.count // 0')
+  if [[ "$WS_COUNT" -ge 2 ]]; then
+    pass "RBAC lists ${WS_COUNT} workspaces (root + default + any user-created)"
+  else
+    fail "Expected at least 2 workspaces (root + default), got ${WS_COUNT}"
+  fi
+fi
+
+# ─── Step 8: Resource Deletion Flow ──────────────────────────────────────────
+
+log_step "Step 8: Resource Deletion Flow"
+
+log_info "Deleting resource via Inventory API gRPC"
+
+DELETE_RESULT=$(grpcurl -plaintext -d "{
+  \"reference\": {
+    \"resourceType\": \"host\",
+    \"resourceId\": \"${HOST_ID}\",
+    \"reporter\": {
+      \"type\": \"hbi\",
+      \"instanceId\": \"redhat\"
+    }
+  }
+}" "${INVENTORY_GRPC}" kessel.inventory.v1beta2.KesselInventoryService/DeleteResource 2>&1) && {
+  pass "Resource deleted from Inventory API"
+} || {
+  fail "Failed to delete resource from Inventory API"
+  echo "  grpcurl output: ${DELETE_RESULT}"
+}
+
+# Wait for tuple cleanup
+sleep 3
+
+HOST_TUPLES_AFTER=$(curl -sf \
+  "http://${RELATIONS_HTTP}/v1beta1/tuples?filter.resourceType=host" 2>&1) || true
+
+if [[ -n "${HOST_TUPLES_AFTER:-}" ]]; then
+  REMAINING=$(echo "$HOST_TUPLES_AFTER" | jq --arg wsid "$DEFAULT_WORKSPACE_ID" \
+    '[.tuples[]? | select(.subject.subject.id == $wsid)] | length')
+
+  if [[ "$REMAINING" -eq 0 ]]; then
+    pass "Host-to-workspace tuple removed from Relations API after deletion"
+  else
+    fail "Host-to-workspace tuple still present after deletion (count: ${REMAINING})"
+  fi
+fi
+
+# ─── Step 9: Summary ─────────────────────────────────────────────────────────
+
+log_step "Summary"
+
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+echo ""
+echo -e "  ${GREEN}Passed: ${PASS_COUNT}${NC}  /  ${RED}Failed: ${FAIL_COUNT}${NC}  /  Total: ${TOTAL}"
+echo ""
+
+if [[ "$FAIL_COUNT" -eq 0 ]]; then
+  echo -e "${GREEN}All integration tests passed.${NC}"
+  exit 0
+else
+  echo -e "${RED}${FAIL_COUNT} test(s) failed.${NC}"
+  exit 1
+fi

--- a/scripts/start-full-kessel.sh
+++ b/scripts/start-full-kessel.sh
@@ -31,6 +31,6 @@ else
 fi
 
 ${DOCKER} compose --env-file "${ENV_FILE}" \
-  --profile relations --profile consumer "$@" \
+  --profile relations --profile consumer --profile rbac "$@" \
   -f "${COMPOSE_DIR}/docker-compose.yaml" \
   up -d

--- a/scripts/start-full-kessel.sh
+++ b/scripts/start-full-kessel.sh
@@ -13,6 +13,16 @@ if [ -f "${ENV_FILE}" ]; then
   set +a
 fi
 
+# Check yq is installed (needed to extract RBAC role definitions from configmap YAML)
+if ! command -v yq &>/dev/null; then
+  echo "Error: yq is required but not installed."
+  echo "  Install with:"
+  echo "    go install github.com/mikefarah/yq/v4@latest"
+  echo "    brew install yq"
+  echo "    dnf install yq"
+  exit 1
+fi
+
 # Create kessel network if it doesn't exist
 NETWORK_CHECK=$(${DOCKER} network ls --filter name=kessel --format json)
 if [[ -z "${NETWORK_CHECK}" || "${NETWORK_CHECK}" == "[]" ]]; then
@@ -29,6 +39,26 @@ else
   echo "Downloading schema.zed from ${SCHEMA_URL}"
   curl -fsSL -o "${SCHEMA_DEST}" "${SCHEMA_URL}"
 fi
+
+# Fetch RBAC role definitions from stage configmap (replaces baked-in definitions
+# that include poisoned approval_* roles not in the SpiceDB schema)
+RBAC_DEFS_DIR="${COMPOSE_DIR}/configs/rbac-role-definitions"
+mkdir -p "${RBAC_DEFS_DIR}"
+rm -f "${RBAC_DEFS_DIR}"/*.json 2>/dev/null
+if [ -n "${RBAC_CONFIG_FILE}" ]; then
+  echo "Using local RBAC config: ${RBAC_CONFIG_FILE}"
+  RBAC_CONFIG_SRC="${RBAC_CONFIG_FILE}"
+else
+  RBAC_CONFIG_URL="${RBAC_CONFIG_URL:-https://raw.githubusercontent.com/RedHatInsights/rbac-config/refs/heads/master/_private/configmaps/stage/rbac-config.yml}"
+  RBAC_CONFIG_SRC=$(mktemp)
+  trap "rm -f ${RBAC_CONFIG_SRC}" EXIT
+  echo "Downloading RBAC role definitions from ${RBAC_CONFIG_URL}"
+  curl -fsSL -o "${RBAC_CONFIG_SRC}" "${RBAC_CONFIG_URL}"
+fi
+for key in $(yq '.objects[0].data | keys | .[]' "${RBAC_CONFIG_SRC}"); do
+  yq -r ".objects[0].data[\"${key}\"]" "${RBAC_CONFIG_SRC}" > "${RBAC_DEFS_DIR}/${key}"
+done
+echo "Extracted $(ls "${RBAC_DEFS_DIR}"/*.json 2>/dev/null | wc -l) RBAC role definition files"
 
 ${DOCKER} compose --env-file "${ENV_FILE}" \
   --profile relations --profile consumer --profile rbac "$@" \

--- a/scripts/stop-full-kessel.sh
+++ b/scripts/stop-full-kessel.sh
@@ -7,6 +7,6 @@ COMPOSE_DIR="development/full-kessel"
 ENV_FILE="${COMPOSE_DIR}/.env"
 
 ${DOCKER} compose --env-file "${ENV_FILE}" \
-  --profile relations --profile consumer --profile monitoring \
+  --profile relations --profile consumer --profile rbac --profile monitoring \
   -f "${COMPOSE_DIR}/docker-compose.yaml" \
   down


### PR DESCRIPTION
### PR Template:

## Describe your changes

### Key New Services/Features:
**RBAC Stack (rbac profile):**
* rbac-database (PostgreSQL 16), Redis, rbac-migrate, rbac-worker (Celery), rbac-scheduler (Celery Beat), rbac-server (Django/gunicorn on port 9080), rbac-kafka-consumer
* V2 APIs enabled, connected to Relations API (gRPC) and Inventory API (gRPC) automatically. 

**RBAC CDC Pipeline:**
* Debezium connector captures RBAC outbox table changes and publishes to Kafka
* RBAC Kafka consumer replicates tuples from Kafka to Relations API/SpiceDB
* Stage configmap role definitions fetched at startup (via yq) to replace baked-in definitions that include poisoned approval_* roles not in the SpiceDB schema    
                                                                                                                                                                                              
**Integration Test (make kessel-test):** 
* Verifies all Kessel services integrate correctly by bootstrapping a tenant via RBAC V2, publishing a simulated HBI host event to Kafka (via kcat) using said org/workspace, confirming the Inventory Consumer processes it, validating the authorization tuple chain in Relations API, and checking V2 roles via the full CDC pipeline
* Uses unique host IDs per run for idempotent re-runs without stack teardown
* Requires kcat, grpcurl, jq, and yq
* Serves as a known-working baseline config validation for the full Kessel stack. 

### Changes
* Adds insights-rbac (7 services) to the full-kessel Docker Compose stack under a new rbac profile, enabling local RBAC V2 testing with Relations API and Inventory API out of the box
* Adds RBAC CDC pipeline (Debezium connector, Kafka consumer) to the full-kessel compose stack so RBAC tenant bootstrap and role seeding replicate tuples to Relations API/SpiceDB
* Fetches RBAC role definitions from the stage configmap at startup (RBAC_CONFIG_URL), extracting 25 role definition JSON files and mounting them into rbac-migrate and rbac-server to override baked-in definitions — removes approval_* poison that would crash-loop the consumer
* Adds make kessel-test — an end-to-end integration test script that exercises the full authorization flow: RBAC tenant bootstrap → simulated HBI host event via Kafka → Inventory Consumer processing → resource-to-workspace tuple verification in Relations API → RBAC V2 roles check via CDC pipeline → resource deletion and tuple cleanup
* Updates start/stop scripts with `--profile rbac`, yq prerequisite check, and RBAC role definitions fetch
* Adds Prometheus scrape target for RBAC metrics

### Some configuration notes
* Addressed RBAC Kafka consumer crash-loop by providing ACG_CONFIG with metricsPort for non-Clowder environments
* Stage configmap role definitions (no approval.json) replace baked-in definitions that include approval_* roles with permissions not in the SpiceDB schema — this is the same approach used in stage deployments via the rbac-config ConfigMap
* RBAC V2 roles endpoint works end-to-end through the full CDC pipeline (seed → outbox → Debezium → Kafka → consumer → Relations API → SpiceDB)

### Test plan                                                 
* `make kessel-up`: all services start, including RBAC Kafka consumer (no crash-loop)                                                                                                        
* `make kessel-test`: 17/17 tests pass end-to-end
* `make kessel-down`: clean teardown                                                                                                                                                         

### Performance
Average across multiple test runs:
* `kessel-up` timing: ~50s
* `kessel-test` timing: ~16s
* `kessel-down` timing: ~17s

Resource Usage: ~3.8 GB RAM, roughly 0.4 vCPUs at idle

## Ticket reference (if applicable)
Related to RHCLOUD-47158


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RBAC service integrated into the full Kessel stack with event streaming, dedicated consumer, and optional compose profile.
  * Prometheus now scrapes RBAC metrics; RBAC exposes metrics endpoint.

* **Tests**
  * New end-to-end integration test command (make kessel-test) and a fail-fast integration test runner for local full-stack validation.

* **Documentation**
  * Added integration test guide, RBAC setup, ports, and monitoring updates.

* **Chores**
  * Added RBAC environment overrides (image, config URL/file).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->