### PR TITLE
RHCLOUD-45005: Use ContinuationToken tiny type for pagination

### DIFF
--- a/internal/biz/model/common.go
+++ b/internal/biz/model/common.go
@@ -99,6 +99,25 @@ func DeserializeConsistencyToken(value string) ConsistencyToken {
 	return Deserialize[ConsistencyToken](value)
 }
 
+// ContinuationToken is an opaque pagination cursor from clients or authz backends.
+type ContinuationToken string
+
+func NewContinuationToken(token string) (ContinuationToken, error) {
+	return ContinuationToken(token), nil
+}
+
+func (ct ContinuationToken) String() string {
+	return string(ct)
+}
+
+func (ct ContinuationToken) Serialize() string {
+	return SerializeString(ct)
+}
+
+func DeserializeContinuationToken(value string) ContinuationToken {
+	return Deserialize[ContinuationToken](value)
+}
+
 func DeserializeGeneration(value uint) Generation {
 	return DeserializeUint[Generation](value)
 }
@@ -243,6 +262,17 @@ func (rt ResourceType) String() string {
 func (rt ResourceType) Serialize() string {
 	str := SerializeString(rt)
 	return strings.ToLower(str)
+}
+
+// SchemaRepositoryKey returns the canonical key used for schema repository storage and lookups
+// (lowercase; forward slashes replaced with underscores). This matches historical path and cache normalization.
+func (rt ResourceType) SchemaRepositoryKey() string {
+	s := strings.TrimSpace(rt.String())
+	if s == "" {
+		return ""
+	}
+	s = strings.ReplaceAll(s, "/", "_")
+	return strings.ToLower(s)
 }
 
 type ReporterType string

--- a/internal/biz/model/common.go
+++ b/internal/biz/model/common.go
@@ -264,17 +264,6 @@ func (rt ResourceType) Serialize() string {
 	return strings.ToLower(str)
 }
 
-// SchemaRepositoryKey returns the canonical key used for schema repository storage and lookups
-// (lowercase; forward slashes replaced with underscores). This matches historical path and cache normalization.
-func (rt ResourceType) SchemaRepositoryKey() string {
-	s := strings.TrimSpace(rt.String())
-	if s == "" {
-		return ""
-	}
-	s = strings.ReplaceAll(s, "/", "_")
-	return strings.ToLower(s)
-}
-
 type ReporterType string
 
 func NewReporterType(reporterType string) (ReporterType, error) {

--- a/internal/biz/model/lookup_objects_item.go
+++ b/internal/biz/model/lookup_objects_item.go
@@ -3,12 +3,12 @@ package model
 // LookupObjectsItem represents a single object from a lookup stream.
 type LookupObjectsItem struct {
 	object            ResourceReference
-	continuationToken string
+	continuationToken ContinuationToken
 }
 
-func NewLookupObjectsItem(object ResourceReference, continuationToken string) LookupObjectsItem {
+func NewLookupObjectsItem(object ResourceReference, continuationToken ContinuationToken) LookupObjectsItem {
 	return LookupObjectsItem{object: object, continuationToken: continuationToken}
 }
 
-func (i LookupObjectsItem) Object() ResourceReference { return i.object }
-func (i LookupObjectsItem) ContinuationToken() string { return i.continuationToken }
+func (i LookupObjectsItem) Object() ResourceReference            { return i.object }
+func (i LookupObjectsItem) ContinuationToken() ContinuationToken { return i.continuationToken }

--- a/internal/biz/model/lookup_subjects_item.go
+++ b/internal/biz/model/lookup_subjects_item.go
@@ -3,12 +3,12 @@ package model
 // LookupSubjectsItem represents a single subject from a lookup stream.
 type LookupSubjectsItem struct {
 	subject           SubjectReference
-	continuationToken string
+	continuationToken ContinuationToken
 }
 
-func NewLookupSubjectsItem(subject SubjectReference, continuationToken string) LookupSubjectsItem {
+func NewLookupSubjectsItem(subject SubjectReference, continuationToken ContinuationToken) LookupSubjectsItem {
 	return LookupSubjectsItem{subject: subject, continuationToken: continuationToken}
 }
 
-func (i LookupSubjectsItem) Subject() SubjectReference { return i.subject }
-func (i LookupSubjectsItem) ContinuationToken() string { return i.continuationToken }
+func (i LookupSubjectsItem) Subject() SubjectReference            { return i.subject }
+func (i LookupSubjectsItem) ContinuationToken() ContinuationToken { return i.continuationToken }

--- a/internal/biz/model/pagination.go
+++ b/internal/biz/model/pagination.go
@@ -7,5 +7,18 @@ type Pagination struct {
 	// Limit is the maximum number of results to return (always > 0 when Pagination is non-nil).
 	Limit uint32
 	// Continuation is the token to continue from a previous query. nil if not specified.
-	Continuation *string
+	Continuation *ContinuationToken
+}
+
+// NewPagination builds pagination parameters for streaming queries.
+func NewPagination(limit uint32, continuation *ContinuationToken) *Pagination {
+	return &Pagination{Limit: limit, Continuation: continuation}
+}
+
+// ContinuationToken returns the continuation cursor, or nil when absent.
+func (p *Pagination) ContinuationToken() *ContinuationToken {
+	if p == nil {
+		return nil
+	}
+	return p.Continuation
 }

--- a/internal/biz/model/read_tuples_item.go
+++ b/internal/biz/model/read_tuples_item.go
@@ -5,11 +5,11 @@ type ReadTuplesItem struct {
 	object            ResourceReference
 	relation          Relation
 	subject           SubjectReference
-	continuationToken string
+	continuationToken ContinuationToken
 	consistencyToken  ConsistencyToken
 }
 
-func NewReadTuplesItem(object ResourceReference, relation Relation, subject SubjectReference, continuationToken string, consistencyToken ConsistencyToken) ReadTuplesItem {
+func NewReadTuplesItem(object ResourceReference, relation Relation, subject SubjectReference, continuationToken ContinuationToken, consistencyToken ConsistencyToken) ReadTuplesItem {
 	return ReadTuplesItem{
 		object:            object,
 		relation:          relation,
@@ -19,8 +19,8 @@ func NewReadTuplesItem(object ResourceReference, relation Relation, subject Subj
 	}
 }
 
-func (i ReadTuplesItem) Object() ResourceReference          { return i.object }
-func (i ReadTuplesItem) Relation() Relation                 { return i.relation }
-func (i ReadTuplesItem) Subject() SubjectReference          { return i.subject }
-func (i ReadTuplesItem) ContinuationToken() string          { return i.continuationToken }
-func (i ReadTuplesItem) ConsistencyToken() ConsistencyToken { return i.consistencyToken }
+func (i ReadTuplesItem) Object() ResourceReference            { return i.object }
+func (i ReadTuplesItem) Relation() Relation                   { return i.relation }
+func (i ReadTuplesItem) Subject() SubjectReference            { return i.subject }
+func (i ReadTuplesItem) ContinuationToken() ContinuationToken { return i.continuationToken }
+func (i ReadTuplesItem) ConsistencyToken() ConsistencyToken   { return i.consistencyToken }

--- a/internal/data/grpc_relations_repository.go
+++ b/internal/data/grpc_relations_repository.go
@@ -445,7 +445,8 @@ func paginationToV1Beta1(pagination *model.Pagination) *kesselapi.RequestPaginat
 		Limit: pagination.Limit,
 	}
 	if pagination.Continuation != nil {
-		result.ContinuationToken = pagination.Continuation
+		s := pagination.Continuation.String()
+		result.ContinuationToken = &s
 	}
 	return result
 }
@@ -566,7 +567,7 @@ func (s *lookupObjectsStream) Recv() (model.LookupObjectsItem, error) {
 		model.DeserializeLocalResourceId(resp.GetResource().GetId()),
 		&reporter,
 	)
-	return model.NewLookupObjectsItem(object, resp.GetPagination().GetContinuationToken()), nil
+	return model.NewLookupObjectsItem(object, model.DeserializeContinuationToken(resp.GetPagination().GetContinuationToken())), nil
 }
 
 type lookupSubjectsStream struct {
@@ -597,7 +598,7 @@ func (s *lookupSubjectsStream) Recv() (model.LookupSubjectsItem, error) {
 		subjectRef = model.NewSubjectReferenceWithoutRelation(subResource)
 	}
 
-	return model.NewLookupSubjectsItem(subjectRef, resp.GetPagination().GetContinuationToken()), nil
+	return model.NewLookupSubjectsItem(subjectRef, model.DeserializeContinuationToken(resp.GetPagination().GetContinuationToken())), nil
 }
 
 type emptyLookupObjectsStream struct{}
@@ -655,7 +656,7 @@ func (s *readTuplesStream) Recv() (model.ReadTuplesItem, error) {
 		object,
 		model.DeserializeRelation(tuple.GetRelation()),
 		subjectRef,
-		resp.GetPagination().GetContinuationToken(),
+		model.DeserializeContinuationToken(resp.GetPagination().GetContinuationToken()),
 		consistencyToken,
 	), nil
 }

--- a/internal/data/grpc_relations_repository_test.go
+++ b/internal/data/grpc_relations_repository_test.go
@@ -137,7 +137,7 @@ func TestPaginationToV1Beta1_Nil(t *testing.T) {
 }
 
 func TestPaginationToV1Beta1_WithContinuation(t *testing.T) {
-	token := "continuation-abc"
+	token := model.DeserializeContinuationToken("continuation-abc")
 	result := paginationToV1Beta1(&model.Pagination{Limit: 100, Continuation: &token})
 	require.NotNil(t, result)
 	assert.Equal(t, uint32(100), result.Limit)
@@ -400,7 +400,7 @@ func TestLookupObjectsStream_Recv(t *testing.T) {
 	assert.Equal(t, "host", item.Object().ResourceType().String())
 	require.NotNil(t, item.Object().Reporter())
 	assert.Equal(t, "hbi", item.Object().Reporter().ReporterType().String())
-	assert.Equal(t, "page-1", item.ContinuationToken())
+	assert.Equal(t, "page-1", item.ContinuationToken().String())
 
 	_, err = stream.Recv()
 	assert.ErrorIs(t, err, io.EOF)
@@ -447,7 +447,7 @@ func TestLookupSubjectsStream_WithoutRelation(t *testing.T) {
 	assert.Equal(t, "user-1", item.Subject().Resource().ResourceId().String())
 	assert.Equal(t, "principal", item.Subject().Resource().ResourceType().String())
 	assert.False(t, item.Subject().HasRelation())
-	assert.Equal(t, "tok", item.ContinuationToken())
+	assert.Equal(t, "tok", item.ContinuationToken().String())
 }
 
 func TestLookupSubjectsStream_WithRelation(t *testing.T) {
@@ -526,7 +526,7 @@ func TestReadTuplesStream_BasicTuple(t *testing.T) {
 	assert.Equal(t, model.DeserializeRelation("member"), item.Relation())
 	assert.Equal(t, "user-1", item.Subject().Resource().ResourceId().String())
 	assert.False(t, item.Subject().HasRelation())
-	assert.Equal(t, "page-tok", item.ContinuationToken())
+	assert.Equal(t, "page-tok", item.ContinuationToken().String())
 	assert.Equal(t, model.DeserializeConsistencyToken("ct-1"), item.ConsistencyToken())
 }
 

--- a/internal/data/relations_simple.go
+++ b/internal/data/relations_simple.go
@@ -360,7 +360,7 @@ func (s *SimpleRelationsRepository) LookupObjects(_ context.Context,
 					model.DeserializeResourceType(key.ResourceType),
 					model.DeserializeLocalResourceId(key.ResourceID),
 					&reporter,
-				), "",
+				), model.DeserializeContinuationToken(""),
 			))
 		}
 	}
@@ -404,7 +404,7 @@ func (s *SimpleRelationsRepository) LookupSubjects(_ context.Context,
 				&reporter,
 			)
 			results = append(results, model.NewLookupSubjectsItem(
-				model.NewSubjectReferenceWithoutRelation(subResource), "",
+				model.NewSubjectReferenceWithoutRelation(subResource), model.DeserializeContinuationToken(""),
 			))
 		}
 	}
@@ -505,7 +505,7 @@ func (s *SimpleRelationsRepository) ReadTuples(_ context.Context, filter model.T
 				object,
 				model.DeserializeRelation(key.Relation),
 				model.NewSubjectReferenceWithoutRelation(subResource),
-				"",
+				model.DeserializeContinuationToken(""),
 				model.MinimizeLatencyToken,
 			))
 		}

--- a/internal/service/resources/kesselinventoryservice.go
+++ b/internal/service/resources/kesselinventoryservice.go
@@ -302,12 +302,12 @@ func paginationFromProto(p *pb.RequestPagination) *model.Pagination {
 	if p == nil {
 		return nil
 	}
-	out := &model.Pagination{Limit: p.Limit}
+	pagination := &model.Pagination{Limit: p.Limit}
 	if p.ContinuationToken != nil {
 		ct, _ := model.NewContinuationToken(*p.ContinuationToken)
-		out.Continuation = &ct
+		pagination.Continuation = &ct
 	}
-	return out
+	return pagination
 }
 
 // checkBulkResultItemToProtoFields derives the proto Allowed enum and, if the result carries an

--- a/internal/service/resources/kesselinventoryservice.go
+++ b/internal/service/resources/kesselinventoryservice.go
@@ -302,10 +302,12 @@ func paginationFromProto(p *pb.RequestPagination) *model.Pagination {
 	if p == nil {
 		return nil
 	}
-	return &model.Pagination{
-		Limit:        p.Limit,
-		Continuation: p.ContinuationToken,
+	out := &model.Pagination{Limit: p.Limit}
+	if p.ContinuationToken != nil {
+		ct, _ := model.NewContinuationToken(*p.ContinuationToken)
+		out.Continuation = &ct
 	}
+	return out
 }
 
 // checkBulkResultItemToProtoFields derives the proto Allowed enum and, if the result carries an
@@ -574,7 +576,7 @@ func ToLookupObjectsResponse(item model.LookupObjectsItem) *pb.StreamedListObjec
 			ResourceType: obj.ResourceType().String(),
 		},
 		Pagination: &pb.ResponsePagination{
-			ContinuationToken: item.ContinuationToken(),
+			ContinuationToken: item.ContinuationToken().String(),
 		},
 	}
 	if obj.HasReporter() {
@@ -646,7 +648,7 @@ func ToLookupSubjectsResponse(item model.LookupSubjectsItem) *pb.StreamedListSub
 	return &pb.StreamedListSubjectsResponse{
 		Subject: subRef,
 		Pagination: &pb.ResponsePagination{
-			ContinuationToken: item.ContinuationToken(),
+			ContinuationToken: item.ContinuationToken().String(),
 		},
 	}
 }

--- a/internal/service/resources/pagination_test.go
+++ b/internal/service/resources/pagination_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+	"github.com/project-kessel/inventory-api/internal/biz/model"
 	svc "github.com/project-kessel/inventory-api/internal/service/resources"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -78,7 +79,7 @@ func TestToLookupObjectsCommand_WithContinuationOnly(t *testing.T) {
 	require.NotNil(t, result.Pagination)
 	assert.Equal(t, uint32(0), result.Pagination.Limit, "Pure converter passes through limit=0")
 	assert.NotNil(t, result.Pagination.Continuation)
-	assert.Equal(t, "continuation-token-123", *result.Pagination.Continuation)
+	assert.Equal(t, model.DeserializeContinuationToken("continuation-token-123"), *result.Pagination.Continuation)
 }
 
 func TestToLookupObjectsCommand_WithBothLimitAndContinuation(t *testing.T) {
@@ -113,7 +114,7 @@ func TestToLookupObjectsCommand_WithBothLimitAndContinuation(t *testing.T) {
 	require.NotNil(t, result.Pagination)
 	assert.Equal(t, uint32(100), result.Pagination.Limit)
 	assert.NotNil(t, result.Pagination.Continuation)
-	assert.Equal(t, "continuation-token-456", *result.Pagination.Continuation)
+	assert.Equal(t, model.DeserializeContinuationToken("continuation-token-456"), *result.Pagination.Continuation)
 }
 
 func TestToLookupObjectsCommand_WithEmptyContinuationToken(t *testing.T) {
@@ -148,7 +149,7 @@ func TestToLookupObjectsCommand_WithEmptyContinuationToken(t *testing.T) {
 	require.NotNil(t, result.Pagination)
 	assert.Equal(t, uint32(50), result.Pagination.Limit)
 	assert.NotNil(t, result.Pagination.Continuation, "Pure converter passes through empty string")
-	assert.Equal(t, "", *result.Pagination.Continuation)
+	assert.Equal(t, model.DeserializeContinuationToken(""), *result.Pagination.Continuation)
 }
 
 func TestToLookupSubjectsCommand_WithLimitOnly(t *testing.T) {
@@ -212,7 +213,7 @@ func TestToLookupSubjectsCommand_WithContinuationOnly(t *testing.T) {
 	require.NotNil(t, result.Pagination)
 	assert.Equal(t, uint32(0), result.Pagination.Limit, "Pure converter passes through limit=0")
 	assert.NotNil(t, result.Pagination.Continuation)
-	assert.Equal(t, "subjects-token-789", *result.Pagination.Continuation)
+	assert.Equal(t, model.DeserializeContinuationToken("subjects-token-789"), *result.Pagination.Continuation)
 }
 
 func TestToLookupSubjectsCommand_WithBothLimitAndContinuation(t *testing.T) {
@@ -243,7 +244,7 @@ func TestToLookupSubjectsCommand_WithBothLimitAndContinuation(t *testing.T) {
 	require.NotNil(t, result.Pagination)
 	assert.Equal(t, uint32(200), result.Pagination.Limit)
 	assert.NotNil(t, result.Pagination.Continuation)
-	assert.Equal(t, "subjects-token-999", *result.Pagination.Continuation)
+	assert.Equal(t, model.DeserializeContinuationToken("subjects-token-999"), *result.Pagination.Continuation)
 }
 
 func TestPaginationFromProto_NilInput(t *testing.T) {

--- a/internal/service/tuples/tuples.go
+++ b/internal/service/tuples/tuples.go
@@ -247,9 +247,14 @@ func paginationFromProto(p *pb.RequestPagination) *model.Pagination {
 	if p == nil {
 		return nil
 	}
+	var continuation *model.ContinuationToken
+	if p.ContinuationToken != nil {
+		ct := model.DeserializeContinuationToken(*p.ContinuationToken)
+		continuation = &ct
+	}
 	return &model.Pagination{
 		Limit:        p.Limit,
-		Continuation: p.ContinuationToken,
+		Continuation: continuation,
 	}
 }
 
@@ -332,7 +337,8 @@ func readTuplesItemToProto(item model.ReadTuplesItem) *pb.ReadTuplesResponse {
 	}
 
 	if item.ContinuationToken() != "" {
-		resp.Pagination = &pb.ResponsePagination{ContinuationToken: item.ContinuationToken()}
+		ct := item.ContinuationToken().String()
+		resp.Pagination = &pb.ResponsePagination{ContinuationToken: ct}
 	}
 
 	if item.ConsistencyToken() != "" {

--- a/internal/service/tuples/tuples_test.go
+++ b/internal/service/tuples/tuples_test.go
@@ -147,7 +147,8 @@ func TestToReadTuplesCommand(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, cmd.Pagination)
 		assert.Equal(t, uint32(10), cmd.Pagination.Limit)
-		assert.Equal(t, &token, cmd.Pagination.Continuation)
+		expectedCT := model.DeserializeContinuationToken(token)
+		assert.Equal(t, &expectedCT, cmd.Pagination.Continuation)
 	})
 
 	t.Run("with consistency", func(t *testing.T) {
@@ -335,7 +336,7 @@ func TestPaginationFromProto(t *testing.T) {
 		require.NotNil(t, result)
 		assert.Equal(t, uint32(25), result.Limit)
 		require.NotNil(t, result.Continuation)
-		assert.Equal(t, token, *result.Continuation)
+		assert.Equal(t, model.DeserializeContinuationToken(token), *result.Continuation)
 	})
 
 	t.Run("without continuation token", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Define `ContinuationToken` type in `model/common.go` with constructor, `String()`, `Serialize()`, and `DeserializeContinuationToken`
- Replace `string` with `ContinuationToken` in `Pagination`, `ReadTuplesItem`, `LookupObjectsItem`, `LookupSubjectsItem`
- Use `DeserializeContinuationToken` when reconstructing from gRPC responses; `.String()` at proto response boundaries

## Stack
2/4 in the tiny-types series. Depends on #1329 (merge that first).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/...` — all 36 packages pass


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced pagination token handling with improved internal type safety and serialization support across lookup and read operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->