### PR TITLE
RHCLOUD-45005: Normalize ResourceType/ReporterType/ReporterInstanceId at construction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ See `common.go` for the full pattern and generic helpers.
 
 **Struct value objects**: Use unexported fields, a `New*` constructor, and minimal getters. Each struct type gets its own file for a flat view of the domain (e.g., `relationship.go`, `fencing_check.go`). Tightly coupled types may share a file.
 
+- **Use meaningful variable names** for domain types -- `resourceType`, `reporterType`, `reporterInstanceId`, not cryptic abbreviations like `rt`, `rpt`, `ri`.
 - **All domain types must use unexported fields** initialized through constructor functions (`New*`).
 - **Constructors must validate invariants** (non-empty IDs, required fields, etc.) and return `(T, error)` when validation can fail. Do not silently discard constructor errors.
 - **Add getters only when they are actually used** by callers outside the package. Do not add speculative getters.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,15 @@ This is the Kessel Inventory API, a Go-based microservice that provides resource
 ### Domain Model Conventions (`internal/biz/model`)
 Prefer **value objects** (private fields, constructors, getters) over plain data containers (exported fields).
 
-**Tiny types**: Use Go defined types on primitives (`type LockId string`, `type Version uint`, `type ResourceId uuid.UUID`) -- not structs with a single field. Tiny types make interfaces self-documenting, prevent argument transposition, and provide a home for domain-specific methods. Each tiny type gets a `New*` constructor (with invariant validation), a `Serialize()` method (using the generic helpers `SerializeString`, `SerializeUint`, `SerializeUUID`, `SerializeBool` from `common.go`), and a `String()` method where appropriate. A corresponding `Deserialize*` function bypasses validation for reconstruction from trusted sources. See `common.go` for the full pattern and generic helpers.
+**Tiny types** (e.g., `LockId`, `Version`, `ResourceId`, `ResourceType`, `ReporterType`) make interfaces self-documenting, prevent argument transposition, and provide a home for domain-specific methods like validation and normalization. Always create tiny type values through their `New*` constructor -- never via direct type conversion (e.g., `ReporterType("HBI")`). Direct conversion bypasses validation and normalization (such as lowercasing). Use `NewReporterType("HBI")` instead, which returns the validated, normalized value.
+
+Each tiny type gets:
+- A `New*` constructor that validates invariants and normalizes the value
+- A `Serialize()` method (using the generic helpers `SerializeString`, `SerializeUint`, `SerializeUUID`, `SerializeBool` from `common.go`)
+- A `String()` method where appropriate
+- A corresponding `Deserialize*` function that reconstructs the domain type from stored/wire representations (e.g., database rows, protobuf fields) — analogous to how Jackson deserializes JSON into Java objects. The stored value is assumed to be already validated and normalized.
+
+See `common.go` for the full pattern and generic helpers.
 
 **Struct value objects**: Use unexported fields, a `New*` constructor, and minimal getters. Each struct type gets its own file for a flat view of the domain (e.g., `relationship.go`, `fencing_check.go`). Tightly coupled types may share a file.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ See `common.go` for the full pattern and generic helpers.
 
 **Struct value objects**: Use unexported fields, a `New*` constructor, and minimal getters. Each struct type gets its own file for a flat view of the domain (e.g., `relationship.go`, `fencing_check.go`). Tightly coupled types may share a file.
 
-- **Use meaningful variable names** for domain types -- `resourceType`, `reporterType`, `reporterInstanceId`, not cryptic abbreviations like `rt`, `rpt`, `ri`.
+- **Use meaningful variable names** -- `resourceType`, `reporterType`, `reporterInstanceId`, not cryptic abbreviations like `rt`, `rpt`, `ri`.
 - **All domain types must use unexported fields** initialized through constructor functions (`New*`).
 - **Constructors must validate invariants** (non-empty IDs, required fields, etc.) and return `(T, error)` when validation can fail. Do not silently discard constructor errors.
 - **Add getters only when they are actually used** by callers outside the package. Do not add speculative getters.

--- a/cmd/schema/schema.go
+++ b/cmd/schema/schema.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/project-kessel/inventory-api/cmd/common"
 	bizmodel "github.com/project-kessel/inventory-api/internal/biz/model"
-	"github.com/project-kessel/inventory-api/internal/data"
 )
 
 var schemaDir = "data/schema/resources"
@@ -46,7 +45,7 @@ func normalizeYAMLResourceType(yamlContent []byte) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid resource type in YAML: %w", err)
 		}
-		yamlData["type"] = data.NormalizeResourceType(rt).String()
+		yamlData["type"] = rt.String()
 	}
 
 	// Convert back to YAML format
@@ -91,7 +90,7 @@ func preloadSchemas() error {
 		if err != nil {
 			continue
 		}
-		resourceType := data.NormalizeResourceType(rt).String()
+		resourceType := rt.String()
 		resourcePath := filepath.Join(schemaDir, resource.Name())
 
 		// Load common resource data schema
@@ -122,7 +121,7 @@ func preloadSchemas() error {
 				if err != nil {
 					continue
 				}
-				reporterType := data.NormalizeReporterType(rpt).String()
+				reporterType := rpt.String()
 				reporterPath := filepath.Join(reportersPath, reporter.Name())
 
 				// Encode reporter's config.yaml

--- a/internal/biz/model/common.go
+++ b/internal/biz/model/common.go
@@ -252,6 +252,7 @@ func NewResourceType(resourceType string) (ResourceType, error) {
 	if resourceType == "" {
 		return ResourceType(""), fmt.Errorf("%w: ResourceType", ErrEmpty)
 	}
+	resourceType = strings.ToLower(strings.ReplaceAll(resourceType, "/", "_"))
 	return ResourceType(resourceType), nil
 }
 
@@ -259,10 +260,7 @@ func (rt ResourceType) String() string {
 	return string(rt)
 }
 
-func (rt ResourceType) Serialize() string {
-	str := SerializeString(rt)
-	return strings.ToLower(str)
-}
+func (rt ResourceType) Serialize() string { return SerializeString(rt) }
 
 type ReporterType string
 
@@ -271,17 +269,14 @@ func NewReporterType(reporterType string) (ReporterType, error) {
 	if reporterType == "" {
 		return ReporterType(""), fmt.Errorf("%w: ReporterType", ErrEmpty)
 	}
-	return ReporterType(reporterType), nil
+	return ReporterType(strings.ToLower(reporterType)), nil
 }
 
 func (rt ReporterType) String() string {
 	return string(rt)
 }
 
-func (rt ReporterType) Serialize() string {
-	str := SerializeString(rt)
-	return strings.ToLower(str)
-}
+func (rt ReporterType) Serialize() string { return SerializeString(rt) }
 
 type ReporterInstanceId string
 
@@ -290,17 +285,14 @@ func NewReporterInstanceId(reporterInstanceId string) (ReporterInstanceId, error
 	if reporterInstanceId == "" {
 		return ReporterInstanceId(""), fmt.Errorf("%w: ReporterInstanceId", ErrEmpty)
 	}
-	return ReporterInstanceId(reporterInstanceId), nil
+	return ReporterInstanceId(strings.ToLower(reporterInstanceId)), nil
 }
 
 func (ri ReporterInstanceId) String() string {
 	return string(ri)
 }
 
-func (ri ReporterInstanceId) Serialize() string {
-	str := SerializeString(ri)
-	return strings.ToLower(str)
-}
+func (ri ReporterInstanceId) Serialize() string { return SerializeString(ri) }
 
 type ConsistencyToken string
 

--- a/internal/biz/model/resource.go
+++ b/internal/biz/model/resource.go
@@ -2,7 +2,7 @@ package model
 
 import (
 	"fmt"
-	"strings"
+
 	"time"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -312,14 +312,14 @@ func (r *Resource) findReporterResourceToUpdateByKey(key ReporterResourceKey) (*
 		reporter := &r.reporterResources[i]
 		storedKey := reporter.Key()
 
-		if strings.EqualFold(storedKey.LocalResourceId().Serialize(), key.LocalResourceId().Serialize()) &&
-			strings.EqualFold(storedKey.ResourceType().Serialize(), key.ResourceType().Serialize()) &&
-			strings.EqualFold(storedKey.ReporterType().Serialize(), key.ReporterType().Serialize()) {
+		if storedKey.LocalResourceId().Serialize() == key.LocalResourceId().Serialize() &&
+			storedKey.ResourceType().Serialize() == key.ResourceType().Serialize() &&
+			storedKey.ReporterType().Serialize() == key.ReporterType().Serialize() {
 
 			searchReporterInstanceId := key.ReporterInstanceId().Serialize()
 			storedReporterInstanceId := storedKey.ReporterInstanceId().Serialize()
 
-			if searchReporterInstanceId == "" || strings.EqualFold(storedReporterInstanceId, searchReporterInstanceId) {
+			if searchReporterInstanceId == "" || storedReporterInstanceId == searchReporterInstanceId {
 				return reporter, nil
 			}
 		}

--- a/internal/biz/model/resource.go
+++ b/internal/biz/model/resource.go
@@ -2,7 +2,7 @@ package model
 
 import (
 	"fmt"
-
+	"strings"
 	"time"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -312,14 +312,14 @@ func (r *Resource) findReporterResourceToUpdateByKey(key ReporterResourceKey) (*
 		reporter := &r.reporterResources[i]
 		storedKey := reporter.Key()
 
-		if storedKey.LocalResourceId().Serialize() == key.LocalResourceId().Serialize() &&
-			storedKey.ResourceType().Serialize() == key.ResourceType().Serialize() &&
-			storedKey.ReporterType().Serialize() == key.ReporterType().Serialize() {
+		if strings.EqualFold(storedKey.LocalResourceId().Serialize(), key.LocalResourceId().Serialize()) &&
+			strings.EqualFold(storedKey.ResourceType().Serialize(), key.ResourceType().Serialize()) &&
+			strings.EqualFold(storedKey.ReporterType().Serialize(), key.ReporterType().Serialize()) {
 
 			searchReporterInstanceId := key.ReporterInstanceId().Serialize()
 			storedReporterInstanceId := storedKey.ReporterInstanceId().Serialize()
 
-			if searchReporterInstanceId == "" || storedReporterInstanceId == searchReporterInstanceId {
+			if searchReporterInstanceId == "" || strings.EqualFold(storedReporterInstanceId, searchReporterInstanceId) {
 				return reporter, nil
 			}
 		}

--- a/internal/biz/model/schema_service_test.go
+++ b/internal/biz/model/schema_service_test.go
@@ -70,15 +70,15 @@ func TestCalculateTuples(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sc := model.NewSchemaService(data.NewInMemorySchemaRepository(), log.NewHelper(log.DefaultLogger))
-			rt, err := model.NewResourceType("host")
+			resourceType, err := model.NewResourceType("host")
 			require.NoError(t, err)
-			rpt, err := model.NewReporterType("HBI")
+			reporterType, err := model.NewReporterType("HBI")
 			require.NoError(t, err)
-			ri, err := model.NewReporterInstanceId("test-instance")
+			reporterInstanceId, err := model.NewReporterInstanceId("test-instance")
 			require.NoError(t, err)
 			key, err := model.NewReporterResourceKey(
 				model.LocalResourceId("test-resource"),
-				rt, rpt, ri,
+				resourceType, reporterType, reporterInstanceId,
 			)
 			require.NoError(t, err)
 
@@ -152,15 +152,15 @@ func TestCalculateTuples(t *testing.T) {
 func TestGetWorkspaceVersions(t *testing.T) {
 	sc := model.NewSchemaService(data.NewInMemorySchemaRepository(), log.NewHelper(log.DefaultLogger))
 
-	rt, err := model.NewResourceType("host")
+	resourceType, err := model.NewResourceType("host")
 	require.NoError(t, err)
-	rpt, err := model.NewReporterType("HBI")
+	reporterType, err := model.NewReporterType("HBI")
 	require.NoError(t, err)
-	ri, err := model.NewReporterInstanceId("test-instance")
+	reporterInstanceId, err := model.NewReporterInstanceId("test-instance")
 	require.NoError(t, err)
 	key, err := model.NewReporterResourceKey(
 		model.LocalResourceId("test-resource"),
-		rt, rpt, ri,
+		resourceType, reporterType, reporterInstanceId,
 	)
 	require.NoError(t, err)
 
@@ -186,15 +186,15 @@ func TestGetWorkspaceVersions(t *testing.T) {
 }
 
 func TestCreateWorkspaceTuple(t *testing.T) {
-	rt, err := model.NewResourceType("host")
+	resourceType, err := model.NewResourceType("host")
 	require.NoError(t, err)
-	rpt, err := model.NewReporterType("HBI")
+	reporterType, err := model.NewReporterType("HBI")
 	require.NoError(t, err)
-	ri, err := model.NewReporterInstanceId("test-instance")
+	reporterInstanceId, err := model.NewReporterInstanceId("test-instance")
 	require.NoError(t, err)
 	key, err := model.NewReporterResourceKey(
 		model.LocalResourceId("test-resource"),
-		rt, rpt, ri,
+		resourceType, reporterType, reporterInstanceId,
 	)
 	require.NoError(t, err)
 
@@ -255,15 +255,15 @@ func TestCreateWorkspaceTuple(t *testing.T) {
 func TestDetermineTupleOperations(t *testing.T) {
 	sc := model.NewSchemaService(data.NewInMemorySchemaRepository(), log.NewHelper(log.DefaultLogger))
 
-	rt, err := model.NewResourceType("host")
+	resourceType, err := model.NewResourceType("host")
 	require.NoError(t, err)
-	rpt, err := model.NewReporterType("HBI")
+	reporterType, err := model.NewReporterType("HBI")
 	require.NoError(t, err)
-	ri, err := model.NewReporterInstanceId("test-instance")
+	reporterInstanceId, err := model.NewReporterInstanceId("test-instance")
 	require.NoError(t, err)
 	key, err := model.NewReporterResourceKey(
 		model.LocalResourceId("test-resource"),
-		rt, rpt, ri,
+		resourceType, reporterType, reporterInstanceId,
 	)
 	require.NoError(t, err)
 
@@ -343,15 +343,15 @@ func TestCalculateTuples_OperationTypeScenarios(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sc := model.NewSchemaService(data.NewInMemorySchemaRepository(), log.NewHelper(log.DefaultLogger))
 
-			rt, err := model.NewResourceType("host")
+			resourceType, err := model.NewResourceType("host")
 			require.NoError(t, err)
-			rpt, err := model.NewReporterType("HBI")
+			reporterType, err := model.NewReporterType("HBI")
 			require.NoError(t, err)
-			ri, err := model.NewReporterInstanceId("test-instance")
+			reporterInstanceId, err := model.NewReporterInstanceId("test-instance")
 			require.NoError(t, err)
 			key, err := model.NewReporterResourceKey(
 				model.LocalResourceId("test-resource"),
-				rt, rpt, ri,
+				resourceType, reporterType, reporterInstanceId,
 			)
 			require.NoError(t, err)
 

--- a/internal/biz/model/schema_service_test.go
+++ b/internal/biz/model/schema_service_test.go
@@ -70,11 +70,15 @@ func TestCalculateTuples(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sc := model.NewSchemaService(data.NewInMemorySchemaRepository(), log.NewHelper(log.DefaultLogger))
+			rt, err := model.NewResourceType("host")
+			require.NoError(t, err)
+			rpt, err := model.NewReporterType("HBI")
+			require.NoError(t, err)
+			ri, err := model.NewReporterInstanceId("test-instance")
+			require.NoError(t, err)
 			key, err := model.NewReporterResourceKey(
 				model.LocalResourceId("test-resource"),
-				model.ResourceType("host"),
-				model.ReporterType("hbi"),
-				model.ReporterInstanceId("test-instance"),
+				rt, rpt, ri,
 			)
 			require.NoError(t, err)
 
@@ -148,11 +152,15 @@ func TestCalculateTuples(t *testing.T) {
 func TestGetWorkspaceVersions(t *testing.T) {
 	sc := model.NewSchemaService(data.NewInMemorySchemaRepository(), log.NewHelper(log.DefaultLogger))
 
+	rt, err := model.NewResourceType("host")
+	require.NoError(t, err)
+	rpt, err := model.NewReporterType("HBI")
+	require.NoError(t, err)
+	ri, err := model.NewReporterInstanceId("test-instance")
+	require.NoError(t, err)
 	key, err := model.NewReporterResourceKey(
 		model.LocalResourceId("test-resource"),
-		model.ResourceType("host"),
-		model.ReporterType("hbi"),
-		model.ReporterInstanceId("test-instance"),
+		rt, rpt, ri,
 	)
 	require.NoError(t, err)
 
@@ -178,11 +186,15 @@ func TestGetWorkspaceVersions(t *testing.T) {
 }
 
 func TestCreateWorkspaceTuple(t *testing.T) {
+	rt, err := model.NewResourceType("host")
+	require.NoError(t, err)
+	rpt, err := model.NewReporterType("HBI")
+	require.NoError(t, err)
+	ri, err := model.NewReporterInstanceId("test-instance")
+	require.NoError(t, err)
 	key, err := model.NewReporterResourceKey(
 		model.LocalResourceId("test-resource"),
-		model.ResourceType("host"),
-		model.ReporterType("hbi"),
-		model.ReporterInstanceId("test-instance"),
+		rt, rpt, ri,
 	)
 	require.NoError(t, err)
 
@@ -243,11 +255,15 @@ func TestCreateWorkspaceTuple(t *testing.T) {
 func TestDetermineTupleOperations(t *testing.T) {
 	sc := model.NewSchemaService(data.NewInMemorySchemaRepository(), log.NewHelper(log.DefaultLogger))
 
+	rt, err := model.NewResourceType("host")
+	require.NoError(t, err)
+	rpt, err := model.NewReporterType("HBI")
+	require.NoError(t, err)
+	ri, err := model.NewReporterInstanceId("test-instance")
+	require.NoError(t, err)
 	key, err := model.NewReporterResourceKey(
 		model.LocalResourceId("test-resource"),
-		model.ResourceType("host"),
-		model.ReporterType("hbi"),
-		model.ReporterInstanceId("test-instance"),
+		rt, rpt, ri,
 	)
 	require.NoError(t, err)
 
@@ -327,11 +343,15 @@ func TestCalculateTuples_OperationTypeScenarios(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sc := model.NewSchemaService(data.NewInMemorySchemaRepository(), log.NewHelper(log.DefaultLogger))
 
+			rt, err := model.NewResourceType("host")
+			require.NoError(t, err)
+			rpt, err := model.NewReporterType("HBI")
+			require.NoError(t, err)
+			ri, err := model.NewReporterInstanceId("test-instance")
+			require.NoError(t, err)
 			key, err := model.NewReporterResourceKey(
 				model.LocalResourceId("test-resource"),
-				model.ResourceType("host"),
-				model.ReporterType("hbi"),
-				model.ReporterInstanceId("test-instance"),
+				rt, rpt, ri,
 			)
 			require.NoError(t, err)
 

--- a/internal/biz/model/schema_service_test.go
+++ b/internal/biz/model/schema_service_test.go
@@ -73,7 +73,7 @@ func TestCalculateTuples(t *testing.T) {
 			key, err := model.NewReporterResourceKey(
 				model.LocalResourceId("test-resource"),
 				model.ResourceType("host"),
-				model.ReporterType("HBI"),
+				model.ReporterType("hbi"),
 				model.ReporterInstanceId("test-instance"),
 			)
 			require.NoError(t, err)
@@ -151,7 +151,7 @@ func TestGetWorkspaceVersions(t *testing.T) {
 	key, err := model.NewReporterResourceKey(
 		model.LocalResourceId("test-resource"),
 		model.ResourceType("host"),
-		model.ReporterType("HBI"),
+		model.ReporterType("hbi"),
 		model.ReporterInstanceId("test-instance"),
 	)
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestCreateWorkspaceTuple(t *testing.T) {
 	key, err := model.NewReporterResourceKey(
 		model.LocalResourceId("test-resource"),
 		model.ResourceType("host"),
-		model.ReporterType("HBI"),
+		model.ReporterType("hbi"),
 		model.ReporterInstanceId("test-instance"),
 	)
 	require.NoError(t, err)
@@ -246,7 +246,7 @@ func TestDetermineTupleOperations(t *testing.T) {
 	key, err := model.NewReporterResourceKey(
 		model.LocalResourceId("test-resource"),
 		model.ResourceType("host"),
-		model.ReporterType("HBI"),
+		model.ReporterType("hbi"),
 		model.ReporterInstanceId("test-instance"),
 	)
 	require.NoError(t, err)
@@ -330,7 +330,7 @@ func TestCalculateTuples_OperationTypeScenarios(t *testing.T) {
 			key, err := model.NewReporterResourceKey(
 				model.LocalResourceId("test-resource"),
 				model.ResourceType("host"),
-				model.ReporterType("HBI"),
+				model.ReporterType("hbi"),
 				model.ReporterInstanceId("test-instance"),
 			)
 			require.NoError(t, err)

--- a/internal/data/schema_inmemory.go
+++ b/internal/data/schema_inmemory.go
@@ -36,8 +36,6 @@ func (o *InMemorySchemaRepository) GetResourceSchemas(ctx context.Context) ([]bi
 }
 
 func (o *InMemorySchemaRepository) CreateResourceSchema(ctx context.Context, resource bizmodel.ResourceSchema) error {
-	resource.ResourceType = NormalizeResourceType(resource.ResourceType)
-
 	if _, ok := o.content[resource.ResourceType.String()]; ok {
 		return fmt.Errorf("resource %s already exists", resource.ResourceType)
 	}
@@ -50,8 +48,6 @@ func (o *InMemorySchemaRepository) CreateResourceSchema(ctx context.Context, res
 }
 
 func (o *InMemorySchemaRepository) GetResourceSchema(ctx context.Context, resourceType bizmodel.ResourceType) (bizmodel.ResourceSchema, error) {
-	resourceType = NormalizeResourceType(resourceType)
-
 	resource, ok := o.content[resourceType.String()]
 	if !ok {
 		return bizmodel.ResourceSchema{}, bizmodel.ResourceSchemaNotFound
@@ -61,8 +57,6 @@ func (o *InMemorySchemaRepository) GetResourceSchema(ctx context.Context, resour
 }
 
 func (o *InMemorySchemaRepository) UpdateResourceSchema(ctx context.Context, resource bizmodel.ResourceSchema) error {
-	resource.ResourceType = NormalizeResourceType(resource.ResourceType)
-
 	entry, ok := o.content[resource.ResourceType.String()]
 	if !ok {
 		return bizmodel.ResourceSchemaNotFound
@@ -77,8 +71,6 @@ func (o *InMemorySchemaRepository) UpdateResourceSchema(ctx context.Context, res
 }
 
 func (o *InMemorySchemaRepository) DeleteResourceSchema(ctx context.Context, resourceType bizmodel.ResourceType) error {
-	resourceType = NormalizeResourceType(resourceType)
-
 	if _, ok := o.content[resourceType.String()]; !ok {
 		return bizmodel.ResourceSchemaNotFound
 	}
@@ -88,8 +80,6 @@ func (o *InMemorySchemaRepository) DeleteResourceSchema(ctx context.Context, res
 }
 
 func (o *InMemorySchemaRepository) GetReporterSchemas(ctx context.Context, resourceType bizmodel.ResourceType) ([]bizmodel.ReporterType, error) {
-	resourceType = NormalizeResourceType(resourceType)
-
 	entry, err := o.getResourceEntry(resourceType)
 	if err != nil {
 		return nil, err
@@ -104,9 +94,6 @@ func (o *InMemorySchemaRepository) GetReporterSchemas(ctx context.Context, resou
 }
 
 func (o *InMemorySchemaRepository) CreateReporterSchema(ctx context.Context, resourceReporter bizmodel.ReporterSchema) error {
-	resourceReporter.ResourceType = NormalizeResourceType(resourceReporter.ResourceType)
-	resourceReporter.ReporterType = NormalizeReporterType(resourceReporter.ReporterType)
-
 	entry, err := o.getResourceEntry(resourceReporter.ResourceType)
 	if err != nil {
 		return err
@@ -124,9 +111,6 @@ func (o *InMemorySchemaRepository) CreateReporterSchema(ctx context.Context, res
 }
 
 func (o *InMemorySchemaRepository) GetReporterSchema(ctx context.Context, resourceType bizmodel.ResourceType, reporterType bizmodel.ReporterType) (bizmodel.ReporterSchema, error) {
-	resourceType = NormalizeResourceType(resourceType)
-	reporterType = NormalizeReporterType(reporterType)
-
 	entry, err := o.getResourceEntry(resourceType)
 	if err != nil {
 		return bizmodel.ReporterSchema{}, err
@@ -141,9 +125,6 @@ func (o *InMemorySchemaRepository) GetReporterSchema(ctx context.Context, resour
 }
 
 func (o *InMemorySchemaRepository) UpdateReporterSchema(ctx context.Context, resourceReporter bizmodel.ReporterSchema) error {
-	resourceReporter.ResourceType = NormalizeResourceType(resourceReporter.ResourceType)
-	resourceReporter.ReporterType = NormalizeReporterType(resourceReporter.ReporterType)
-
 	entry, err := o.getResourceEntry(resourceReporter.ResourceType)
 	if err != nil {
 		return err
@@ -161,9 +142,6 @@ func (o *InMemorySchemaRepository) UpdateReporterSchema(ctx context.Context, res
 }
 
 func (o *InMemorySchemaRepository) DeleteReporterSchema(ctx context.Context, resourceType bizmodel.ResourceType, reporterType bizmodel.ReporterType) error {
-	resourceType = NormalizeResourceType(resourceType)
-	reporterType = NormalizeReporterType(reporterType)
-
 	entry, err := o.getResourceEntry(resourceType)
 	if err != nil {
 		return err
@@ -179,8 +157,6 @@ func (o *InMemorySchemaRepository) DeleteReporterSchema(ctx context.Context, res
 }
 
 func (o *InMemorySchemaRepository) getResourceEntry(resourceType bizmodel.ResourceType) (*resourceEntry, error) {
-	resourceType = NormalizeResourceType(resourceType)
-
 	if entry, ok := o.content[resourceType.String()]; ok {
 		return entry, nil
 	}
@@ -212,8 +188,6 @@ func NewInMemorySchemaRepositoryFromDir(ctx context.Context, resourceDir string,
 		if err != nil {
 			return nil, fmt.Errorf("invalid resource type directory %q: %w", dir.Name(), err)
 		}
-		resourceType = NormalizeResourceType(resourceType)
-
 		// Load and store common resource schema
 		commonResourceSchema, err := loadCommonResourceDataSchema(resourceType, resourceDir)
 		if err == nil {
@@ -374,13 +348,6 @@ func loadCommonResourceDataSchema(resourceType bizmodel.ResourceType, baseSchema
 	return string(data), nil
 }
 
-func NormalizeReporterType(reporterType bizmodel.ReporterType) bizmodel.ReporterType {
-	return bizmodel.DeserializeReporterType(strings.ToLower(reporterType.String()))
-}
-
-func NormalizeResourceType(resourceType bizmodel.ResourceType) bizmodel.ResourceType {
-	return bizmodel.DeserializeResourceType(strings.ToLower(strings.ReplaceAll(resourceType.String(), "/", "_")))
-}
 
 func findResourceTypeFromJsonKey(jsonKey string, resourceTypes []bizmodel.ResourceType) (bizmodel.ResourceType, bool) {
 	for _, rt := range resourceTypes {

--- a/internal/data/schema_inmemory.go
+++ b/internal/data/schema_inmemory.go
@@ -348,7 +348,6 @@ func loadCommonResourceDataSchema(resourceType bizmodel.ResourceType, baseSchema
 	return string(data), nil
 }
 
-
 func findResourceTypeFromJsonKey(jsonKey string, resourceTypes []bizmodel.ResourceType) (bizmodel.ResourceType, bool) {
 	for _, rt := range resourceTypes {
 		if strings.HasPrefix(jsonKey, rt.String()+":") {

--- a/internal/data/schema_inmemory_test.go
+++ b/internal/data/schema_inmemory_test.go
@@ -727,71 +727,32 @@ func TestLoadCommonResourceDataSchema(t *testing.T) {
 	}
 }
 
-func TestNormalizeResourceType(t *testing.T) {
+func TestNewResourceType_Normalization(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		expected string
+		name      string
+		input     string
+		expected  string
+		expectErr bool
 	}{
-		{
-			name:     "Resource type with forward slash",
-			input:    "rhel/host",
-			expected: "rhel_host",
-		},
-		{
-			name:     "Resource type without forward slash",
-			input:    "k8s_cluster",
-			expected: "k8s_cluster",
-		},
-		{
-			name:     "Resource type with multiple forward slashes",
-			input:    "org/team/resource",
-			expected: "org_team_resource",
-		},
-		{
-			name:     "Empty string",
-			input:    "",
-			expected: "",
-		},
-		{
-			name:     "Resource type already normalized",
-			input:    "host",
-			expected: "host",
-		},
-		{
-			name:     "K8s_CLUSTER",
-			input:    "K8s_CLUSTER",
-			expected: "k8s_cluster",
-		},
-		{
-			name:     "rhel/host",
-			input:    "rhel/host",
-			expected: "rhel_host",
-		},
-		{
-			name:     "TEST/RESOURCE",
-			input:    "TEST/RESOURCE",
-			expected: "test_resource",
-		},
-		{
-			name:     "resource",
-			input:    "resource",
-			expected: "resource",
-		},
+		{name: "forward slash replaced", input: "rhel/host", expected: "rhel_host"},
+		{name: "underscore preserved", input: "k8s_cluster", expected: "k8s_cluster"},
+		{name: "multiple slashes", input: "org/team/resource", expected: "org_team_resource"},
+		{name: "empty string", input: "", expectErr: true},
+		{name: "already normalized", input: "host", expected: "host"},
+		{name: "mixed case lowered", input: "K8s_CLUSTER", expected: "k8s_cluster"},
+		{name: "mixed case with slash", input: "TEST/RESOURCE", expected: "test_resource"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var input bizmodel.ResourceType
-			if tt.input == "" {
-				input = bizmodel.ResourceType("")
-			} else {
-				var err error
-				input, err = bizmodel.NewResourceType(tt.input)
-				require.NoError(t, err)
+			rt, err := bizmodel.NewResourceType(tt.input)
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
 			}
-			result := NormalizeResourceType(input).String()
-			assert.Equal(t, tt.expected, result)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, rt.String())
+			assert.Equal(t, tt.expected, rt.Serialize(), "Serialize() should return already-normalized value")
 		})
 	}
 }

--- a/internal/service/resources/kesselinventoryservice.go
+++ b/internal/service/resources/kesselinventoryservice.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 
-
 	"github.com/go-kratos/kratos/v2/log"
 	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
 	"github.com/project-kessel/inventory-api/internal/biz/model"
@@ -562,7 +561,6 @@ func ToLookupObjectsCommand(request *pb.StreamedListObjectsRequest) (resources.L
 		Consistency: consistencyFromProto(request.GetConsistency()),
 	}, nil
 }
-
 
 func ToLookupObjectsResponse(item model.LookupObjectsItem) *pb.StreamedListObjectsResponse {
 	obj := item.Object()

--- a/internal/service/resources/kesselinventoryservice.go
+++ b/internal/service/resources/kesselinventoryservice.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
+
 
 	"github.com/go-kratos/kratos/v2/log"
 	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
@@ -536,11 +536,11 @@ func ToLookupObjectsCommand(request *pb.StreamedListObjectsRequest) (resources.L
 	if request == nil {
 		return resources.LookupObjectsCommand{}, fmt.Errorf("request is nil")
 	}
-	resourceType, err := model.NewResourceType(NormalizeType(request.ObjectType.GetResourceType()))
+	resourceType, err := model.NewResourceType(request.ObjectType.GetResourceType())
 	if err != nil {
 		return resources.LookupObjectsCommand{}, fmt.Errorf("invalid resource type: %w", err)
 	}
-	reporterType, err := model.NewReporterType(NormalizeType(request.ObjectType.GetReporterType()))
+	reporterType, err := model.NewReporterType(request.ObjectType.GetReporterType())
 	if err != nil {
 		return resources.LookupObjectsCommand{}, fmt.Errorf("invalid reporter type: %w", err)
 	}
@@ -563,10 +563,6 @@ func ToLookupObjectsCommand(request *pb.StreamedListObjectsRequest) (resources.L
 	}, nil
 }
 
-func NormalizeType(val string) string {
-	normalized := strings.ToLower(val)
-	return normalized
-}
 
 func ToLookupObjectsResponse(item model.LookupObjectsItem) *pb.StreamedListObjectsResponse {
 	obj := item.Object()
@@ -600,11 +596,11 @@ func ToLookupSubjectsCommand(request *pb.StreamedListSubjectsRequest) (resources
 	if err != nil {
 		return resources.LookupSubjectsCommand{}, fmt.Errorf("invalid relation: %w", err)
 	}
-	subjectResType, err := model.NewResourceType(NormalizeType(request.SubjectType.GetResourceType()))
+	subjectResType, err := model.NewResourceType(request.SubjectType.GetResourceType())
 	if err != nil {
 		return resources.LookupSubjectsCommand{}, fmt.Errorf("invalid subject type: %w", err)
 	}
-	subjectReporter, err := model.NewReporterType(NormalizeType(request.SubjectType.GetReporterType()))
+	subjectReporter, err := model.NewReporterType(request.SubjectType.GetReporterType())
 	if err != nil {
 		return resources.LookupSubjectsCommand{}, fmt.Errorf("invalid subject reporter: %w", err)
 	}

--- a/internal/service/resources/kesselinventoryservice_test.go
+++ b/internal/service/resources/kesselinventoryservice_test.go
@@ -444,22 +444,21 @@ func TestToLookupSubjectsCommand_NoPagination(t *testing.T) {
 }
 
 func TestIsValidatedRepresentationType(t *testing.T) {
-
 	assert.True(t, IsValidType("hbi"))
 
-	// normalize then validate
-	normalized := svc.NormalizeType("HBI")
-	assert.True(t, IsValidType(normalized))
+	// constructors now normalize
+	rt, err := model.NewReporterType("HBI")
+	require.NoError(t, err)
+	assert.True(t, IsValidType(rt.String()))
+
 	// strange characters
 	assert.False(t, IsValidType("h?!!!"))
 }
 
 func TestNormalizeRepresentationType(t *testing.T) {
-	// normalize then validate
-	normalized := svc.NormalizeType("HBI")
-	assert.True(t, IsValidType(normalized))
-
-	assert.Equal(t, "hbi", normalized)
+	rt, err := model.NewReporterType("HBI")
+	require.NoError(t, err)
+	assert.Equal(t, "hbi", rt.String())
 }
 
 var typePattern = regexp.MustCompile(`^[A-Za-z0-9_]+$`)


### PR DESCRIPTION
## Summary

- Move lowercasing (and `/` -> `_` for ResourceType) into `New*` constructors so values are normalized from the moment of creation
- Simplify `Serialize()` to passthrough (no longer needs to lowercase)
- Delete `NormalizeResourceType`, `NormalizeReporterType` from `schema_inmemory.go` and `NormalizeType` from `kesselinventoryservice.go`
- Update `cmd/schema/schema.go` to rely on constructor normalization directly
- Keep `EqualFold` for key matching in `resource.go` — `LocalResourceId` is not normalized, and the safety net is worth keeping for all fields

## External impact

Kafka CloudEvents will now emit lowercase `resource_type`, `reporter_type`, and `reporter_instance_id` in event metadata. For the known downstream client (HBI), all values are already lowercase so this is a no-op.

## Test plan

- [x] Constructor normalization tests added to `schema_inmemory_test.go`
- [x] `go build ./...` succeeds
- [x] `make test` — all unit tests pass
- [x] `make lint` — clean (only pre-existing sanity_test.go issues)
- [x] Verified HBI client code is not affected by lowercasing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Normalization of resource and reporter types is now centralized at construction, removing duplicated normalization paths and improving consistency.

* **Documentation**
  * Clarified domain model conventions and guidance on using tiny-type constructors for validation/normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->