### PR TITLE
RHCLOUD-47148: minor bug fix when providing custom schema for full kessel compose

### DIFF
--- a/scripts/start-full-kessel.sh
+++ b/scripts/start-full-kessel.sh
@@ -6,11 +6,16 @@ source ./scripts/check_docker_podman.sh
 COMPOSE_DIR="development/full-kessel"
 ENV_FILE="${COMPOSE_DIR}/.env"
 
-# Load .env for schema handling
+# Load .env defaults without overriding caller's environment
 if [ -f "${ENV_FILE}" ]; then
+  _saved_schema_zed_file="${SCHEMA_ZED_FILE:-}"
+  _saved_rbac_config_file="${RBAC_CONFIG_FILE:-}"
   set -a
   source "${ENV_FILE}"
   set +a
+  [ -n "${_saved_schema_zed_file}" ] && SCHEMA_ZED_FILE="${_saved_schema_zed_file}"
+  [ -n "${_saved_rbac_config_file}" ] && RBAC_CONFIG_FILE="${_saved_rbac_config_file}"
+  unset _saved_schema_zed_file _saved_rbac_config_file
 fi
 
 # Check yq is installed (needed to extract RBAC role definitions from configmap YAML)

--- a/scripts/start-full-kessel.sh
+++ b/scripts/start-full-kessel.sh
@@ -8,14 +8,16 @@ ENV_FILE="${COMPOSE_DIR}/.env"
 
 # Load .env defaults without overriding caller's environment
 if [ -f "${ENV_FILE}" ]; then
-  _saved_schema_zed_file="${SCHEMA_ZED_FILE:-}"
-  _saved_rbac_config_file="${RBAC_CONFIG_FILE:-}"
+  saved_schema_zed_file_set="${SCHEMA_ZED_FILE+x}"
+  saved_schema_zed_file="${SCHEMA_ZED_FILE:-}"
+  saved_rbac_config_file_set="${RBAC_CONFIG_FILE+x}"
+  saved_rbac_config_file="${RBAC_CONFIG_FILE:-}"
   set -a
   source "${ENV_FILE}"
   set +a
-  [ -n "${_saved_schema_zed_file}" ] && SCHEMA_ZED_FILE="${_saved_schema_zed_file}"
-  [ -n "${_saved_rbac_config_file}" ] && RBAC_CONFIG_FILE="${_saved_rbac_config_file}"
-  unset _saved_schema_zed_file _saved_rbac_config_file
+  [ -n "${saved_schema_zed_file_set}" ] && SCHEMA_ZED_FILE="${saved_schema_zed_file}"
+  [ -n "${saved_rbac_config_file_set}" ] && RBAC_CONFIG_FILE="${saved_rbac_config_file}"
+  unset saved_schema_zed_file saved_rbac_config_file saved_schema_zed_file_set saved_rbac_config_file_set
 fi
 
 # Check yq is installed (needed to extract RBAC role definitions from configmap YAML)


### PR DESCRIPTION
### PR Template:

## Describe your changes
Found a bug in the full kessel setup when trying to provide a custom schema file during testing for RHCLOUD-47148
The .env file explicitly sets `SCHEMA_ZED_FILE=""`. The script then sources this file and overwrites the environment variable passed in, clobbering it

This fixes the issue by only letting the .env file set defaults, not override explicit environment variables.

## Ticket reference (if applicable)
For RHCLOUD-47148


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup script now treats .env entries as default values and preserves any environment variables already set before launch. This prevents overwriting user-provided configuration during initialization, ensuring custom settings supplied in the shell are respected and retained for more reliable and predictable startups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->