### PR TITLE
RHCLOUD-47590: updates the test ephem deployment for latest changes including new auth config

### DIFF
--- a/development/kessel-inventory-ephem-w-auth-test.yaml
+++ b/development/kessel-inventory-ephem-w-auth-test.yaml
@@ -170,33 +170,9 @@ parameters:
   - description: Number of replicas
     name: REPLICAS
     value: "1"
-  - name: TOPIC_HEARTBEAT_PREFIX
-    value: debezium-heartbeat
-    description: Prefix for the connector heartbeat topic
-  - name: DEBEZIUM_ACTION_QUERY
-    value: "SELECT pg_logical_emit_message(false, 'heartbeat', now()::varchar);"
-    description: Query action that runs for each heartbeat event
-  - name: DEBEZIUM_HEARTBEAT_INTERVAL_MS
-    value: "300000"
-    description: The interval for the Debezium heartbeat in ms
-  - name: DEBEZIUM_POLL_INTERVAL_MS
-    value: "250"
-    description: The interval for the Debezium batch processing
   - description: Name of the Inventory API Config K8s ConfigMap
     name: INVENTORY_API_CONFIG_NAME
     value: inventory-api-config
-  - description: Memory request for job
-    name: JOB_REQUESTS_MEMORY
-    value: '256Mi'
-  - description: CPU request for job
-    name: JOB_REQUESTS_CPU
-    value: '100m'
-  - description: Memory limit for job
-    name: JOB_LIMITS_MEMORY
-    value: '384Mi'
-  - description: CPU limit for job
-    name: JOB_LIMITS_CPU
-    value: '200m'
   - name: SSO_SERVER_URL
     description: URL for SSO Endpoint to validate clients
     required: true

--- a/development/kessel-inventory-ephem-w-auth-test.yaml
+++ b/development/kessel-inventory-ephem-w-auth-test.yaml
@@ -9,18 +9,34 @@ objects:
       name: inventory-api-config
     data:
       inventory-api-config.yaml: |
-        server:
-          grpc:
-            certfile: /serving-certs/tls.crt
-            keyfile: /serving-certs/tls.key
         storage:
           max-serialization-retries: 10
+          outbox-mode: wal
         authn:
-          oidc:
-            authn-server-url: ${SSO_SERVER_URL}
-            client-id: ${INVENTORY_CLIENT_ID}
-            skip-client-id-check: true
-            insecure-client: false
+          authenticator:
+            type: first_match
+            chain:
+              - type: oidc
+                enable: true
+                transport:
+                  http: false
+                  grpc: true
+                config:
+                  insecure-client: true
+                  authn-server-url: ${SSO_SERVER_URL}/auth/realms/redhat-external
+                  skip-client-id-check: true
+                  skip-issuer-check: true
+                  principal-user-domain: redhat.com
+              - type: x-rh-identity
+                enable: true
+                transport:
+                  http: true
+                  grpc: false
+              - type: allow-unauthenticated
+                enable: false
+                transport:
+                  http: false
+                  grpc: false
         authz:
           kessel:
             insecure-client: true
@@ -38,7 +54,11 @@ objects:
         consistency:
           read-after-write-enabled: true # false == off for all service providers
           read-after-write-allowlist: ["*"] # specify ["*"] to allow any request to optionally r-a-w
-          default-to-at-least-as-acknowledged: true
+        schema:
+          repository: in-memory
+          in-memory:
+            type: dir
+            path: /data/schema/resources
         log:
           level: "info"
   - apiVersion: v1
@@ -47,68 +67,6 @@ objects:
       name: resources-tarball
     binaryData:
       resources.tar.gz: H4sIAAAAAAAAA+1c63OaShTP5/wVO97O9EuqvJQ7+WYNaZgYzfhIb+9tr0NwVVoEu0BvM53873dXxQACPorrJDm/L8jhAMueB+exWK6cHBwChVqtzrcUye38t6ioqiwokqiqlK6qUvUEVQ8/tJOTwPMNgtAJcV0/j2/T8WeKcmXiev5hlWAr+VcpjyirkkLlLwo1VQH588BS/qY7nbrOgOAZwR52fMO3XKf81XOdAu7BBFxTlEz5S+pC/jJVEkGVqPxrolo7QUIB996IVy7/X6cIld545gRPjdI5Kk18f3ZeqTDJv1tQyy4ZV4bEGPnvBLWyoP1ROmPn+Q8zzE5y779i01/QZsSdYeJb2KNH2NUp7T+XfPNmhokH1pBRn870fGI54xJ6pIyP8/MJ/h5YBDO+f1LOpqQvp4+np8eet5eClf07I2tcfjCmdvH32GT/Qi3p/2VBEsH+eYC6ezcg1LaYRZ4jpgynKxp9HbjEx8Q7p2b3Dk3uLbC7F4al/a8kfYhIcOf4X5RUSYX4jwfW5E+NvGgd2DL+r0k1kXp+kfl/pSqA/HkgVf6MVFTwf7Lx/U+tvTqXv8zURKR6IlZlWYH3Pw9wif89w8e2bflh/D+nUrrr4PZoFegzrKcGZ6g0csnU8BktCOgFFolCDv/M8KkqO4z47+fPw1+i8Pgm6ywnsO1F+sHwZb5dcpa84N4ziTVjufBgajjGGJMwgznII+QNxnI8azzxvaMNwKADuLfxgDmHPYQ4NX42sTP2J5QsVau7DCA1N2RZ4LGN5wUg1f8XnA1uzv9qifivWpPA/3NBev63UIaBY0wZjaZ97Ne8BnMOWeCLQrny7U9vMHNty3w4VBdgy/g/Uv+VaFQI8T8PxOR/oC7AJv+/Xv+nr4Iq+H8egPr/60bC/g/SBdg9/lNEBeI/LkjEf0/KkNkFqDduwPpeDGL2f6AuwFbxX9z+BbkG8R8PZMjfMKfF6cAe8q+qIH8uyJF/YdHARvmz+n9M/jUV6v98kPf+j1WBqEZEq0BsF8KA548c+3868JslgA3xvyhUk/E/9RYq2D8PcMn/h5Zn3Ns41vsLz713XRsbTilsB5WGeNV0Y8cv8MhysIesEfInGC0UElkeMgNCsOPbDwg786sjl6DwTtQ/EdfzkGHbiMp3jH2vXIo39/APTCz/IW1MYdcqpGMnmMY6XKWudqd19N6nQb/VvdUa+qWuXZTOUo63e1daJ3qk2f4Y3b3RLvT+TZRypX+4iu436HX0Rr1ZCptiWTPVo9MTPhWy6Q8budFJCycgp9SyElRykpZll2NrK6BolCuO61sjy5zXer2B5fh4TOY7hSUAW8X/sfpvVVSh/s8FefIvqh2wqf63Vv+XJEWF+j8XQP3/dSPf/ospAGyyf1FUk/G/LMP6fy5I5P8xZahElCGzHdBq92j026j39HarC2b53JBn/0W1A3av/6qSBPVfLthO/nG3sOs9dpa/JAkqfP/BBfvIP/OMjNxgU/1Pqipx+cuCxL7/gPf/4cEl/l+1EpYn7FFwi4UZW5XC2LVZASy8+RkaWT/xEPkuehu72ls0cgnyJ5aHlk8crxSuRm85VFccM/kVQ9ZDJMZUR4FjfQ8wsoY0l6YGhMnyxng1RhTe4gx5gTlBhocM5GHywzIxMkzTDRw/MTrbNQ17sIrO9hzaggGtUn22wwY2v3p0xMuKYni/LWqKceHnzWnmE0H18WBY9H9Mm7pBTA60AHj3+p8k1mR4//NAXP6HWQC8c/1PVJUa9P+4AOp/rxtJ+z/EAuBN/l8UkvU/RZag/s8FKet/lsqQuwB4se3Ot21YEPx8Ebf/wywA3r3+p0gS/P8DF2TJ3zCL04E95K/WoP7LBXnyL7L/t9v6X1WE77/5IPf9n1gA7MUXAHvw1n/+yLP/yJHfqgFssH9Zpjl/vP8jiDLk/1zAJf/HP9n/8Rh2qE3ZZYBlCTjko7LxA2+/jkGj2e/2tM6g26v3+t2shboJrrXluh2tfvEpSris6834JdqXl029pa2aErHyfPgkBBvevNie89Tfgns8+EGtz9qS0xm6ZL/Jue6/1wZ3Wuui3cmamSjL2rTUr7vRXS2+q8d327daq3ulX/aixA/XGTO2eKzt5sG03WA4mNmGz/7faF89afcvBrfNeu+y3bnJ1pMY19qEtNotbdC/1aO09/WOdqP16s2BnnUgcUb9YzfJy0hJrr/7HW2Nb05McOrvbxYD1zPoCX4m8zu900vyzyXYqzeusw8krvShcZvkZaQEV6vfq7f0v5KcITnBfde9pbO+9uQhOcHdXj1Iqpo57hCnehaDEOPhSWEsH0+jfOlub3kkxfktj7DIKVeXl3zmLNiGbYqnLnnIrqUuEDlnva4aHdjaENJutiJ9Wf56PN3Y/Evz/Ok+Pt1fpnnGFB+Y7jrSnQRUkKPIiv/cAj8A3if/h+9/+SBP/vzyf2Ut/5dliP95YPv8341/AEx3jz12wO8jz/6Pmf8rkP9zAeT/kP9D/g/5/5PMIf+H/B/y/9eC7P7PcfP/Gqz/4II8+fPL/9e+/xUl+P6HC3bp/6//ARg40eeOPPs/av8fvv/nAsj/If+H/B/y/yeZQ/4P+T/k/wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPCf8DzrcHBEAoAAA
-  - apiVersion: kafka.strimzi.io/v1beta2
-    kind: KafkaConnect
-    metadata:
-      annotations:
-        strimzi.io/use-connector-resources: "true"
-      name: kessel-kafka-connect
-    spec:
-      bootstrapServers: ${ENV_NAME}-kafka-bootstrap:9092
-      config:
-        config.storage.replication.factor: ${CONFIG_STORAGE_REPLICATION_FACTOR}
-        config.storage.topic: kessel-kafka-connect-cluster-configs
-        connector.client.config.override.policy: All
-        group.id: kessel-kafka-connect-cluster
-        offset.storage.replication.factor: ${OFFSET_STORAGE_REPLICATION_FACTOR}
-        offset.storage.topic: kessel-kafka-connect-cluster-offsets
-        status.storage.replication.factor: ${STATUS_STORAGE_REPLICATION_FACTOR}
-        status.storage.topic: kessel-kafka-connect-cluster-status
-        config.providers: secrets
-        config.providers.secrets.class: io.strimzi.kafka.KubernetesSecretConfigProvider
-      image: ${KAFKA_CONNECT_IMAGE}
-      replicas: ${{CONNECT_REPLICAS}}
-      resources:
-        limits:
-          cpu: 500m
-          memory: 1Gi
-        requests:
-          cpu: 250m
-          memory: 512Mi
-      template:
-        pod:
-          imagePullSecrets:
-            - name: quay-cloudservices-pull
-      version: ${VERSION}
-  - apiVersion: kafka.strimzi.io/v1beta2
-    kind: KafkaConnector
-    metadata:
-      name: kessel-inventory-source-connector
-      labels:
-        strimzi.io/cluster: kessel-kafka-connect
-    spec:
-      class: io.debezium.connector.postgresql.PostgresConnector
-      tasksMax: 1 # source connector only supports 1 task
-      config:
-        slot.name: kessel_inventory_debezium
-        database.server.name: kessel-inventory-db
-        database.dbname: ${secrets:kessel-inventory-db:db.name}
-        database.hostname: ${secrets:kessel-inventory-db:db.host}
-        database.port: ${secrets:kessel-inventory-db:db.port}
-        database.user: ${secrets:kessel-inventory-db:db.user}
-        database.password: ${secrets:kessel-inventory-db:db.password}
-        topic.prefix: kessel-inventory
-        table.include.list: public.outbox_events
-        transforms: outbox
-        transforms.outbox.type: io.debezium.transforms.outbox.EventRouter
-        transforms.outbox.table.fields.additional.placement: operation:header, txid:header
-        transforms.outbox.table.expand.json.payload: true
-        value.converter: org.apache.kafka.connect.json.JsonConverter
-        plugin.name: pgoutput
-        heartbeat.interval.ms: ${DEBEZIUM_HEARTBEAT_INTERVAL_MS}
-        heartbeat.action.query: ${DEBEZIUM_ACTION_QUERY}
-        topic.heartbeat.prefix: ${TOPIC_HEARTBEAT_PREFIX}
-        poll.interval.ms: ${DEBEZIUM_POLL_INTERVAL_MS}
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
     metadata:
@@ -117,7 +75,7 @@ objects:
       envName: ${ENV_NAME}
       database:
         name: kessel-inventory
-        version: 17
+        version: 16
       kafkaTopics:
         - topicName: outbox.event.kessel.tuples
           partitions: 1
@@ -127,6 +85,7 @@ objects:
           replicas: 3
       optionalDependencies:
         - kessel-relations
+        - kessel-kafkaconnect
       deployments:
         - name: api
           replicas: ${{REPLICAS}}
@@ -179,27 +138,24 @@ objects:
                 mountPath: "/data/schema/resources"
               - name: resources-tarball
                 mountPath: "/mnt/resources"
-              - name: serving-certs
-                mountPath: "/serving-certs"
             volumes:
               - name: config-volume
                 configMap:
-                  name: inventory-api-config
+                  name: ${INVENTORY_API_CONFIG_NAME}
               - name: resource-volume
                 emptyDir: {}
               - name: resources-tarball
                 configMap:
                   name: resources-tarball
-              - name: serving-certs
-                secret:
-                  secretName: kessel-inventory-api-serving-cert
           webServices:
             public:
               enabled: true
-              apiPath: inventory
-              tls: true
+              h2cEnabled: true
+              h2cTargetPort: 9000
+              apiPath: kessel
       testing:
         iqePlugin: kessel-inventory
+
 parameters:
   - description: ClowdEnvironment name (ephemeral, stage, prod)
     name: ENV_NAME
@@ -226,26 +182,21 @@ parameters:
   - name: DEBEZIUM_POLL_INTERVAL_MS
     value: "250"
     description: The interval for the Debezium batch processing
-  - name: CONFIG_STORAGE_REPLICATION_FACTOR
-    description: Replication factor for the topic where connector configurations are stored
-    value: "1"
-  - name: OFFSET_STORAGE_REPLICATION_FACTOR
-    description: Replication factor for the topic where source connector offsets are store
-    value: "1"
-  - name: STATUS_STORAGE_REPLICATION_FACTOR
-    description: Replication factor for the topic where connector and task status are stored
-    value: "1"
-  - name: KAFKA_CONNECT_IMAGE
-    value: quay.io/redhat-services-prod/project-kessel-tenant/kessel-kafka-connect:latest
-    description: Container image name for the connect cluster pods
-  - name: CONNECT_REPLICAS
-    description: Number of replicas in the connect cluster
-    value: "1"
-  - name: VERSION
-    description: Kafka Connect version to use (should match the Kafka version of cluster and connect base image)
-    value: "3.9.0"
+  - description: Name of the Inventory API Config K8s ConfigMap
+    name: INVENTORY_API_CONFIG_NAME
+    value: inventory-api-config
+  - description: Memory request for job
+    name: JOB_REQUESTS_MEMORY
+    value: '256Mi'
+  - description: CPU request for job
+    name: JOB_REQUESTS_CPU
+    value: '100m'
+  - description: Memory limit for job
+    name: JOB_LIMITS_MEMORY
+    value: '384Mi'
+  - description: CPU limit for job
+    name: JOB_LIMITS_CPU
+    value: '200m'
   - name: SSO_SERVER_URL
     description: URL for SSO Endpoint to validate clients
     required: true
-  - name: INVENTORY_CLIENT_ID
-    description: Inventory client-id with access to SSO


### PR DESCRIPTION
### PR Template:

## Describe your changes
* updates `development/kessel-inventory-ephem-w-auth-test.yaml` for changes in authn configuration, as well as numerous other updates that are in the standard ephemeral deployment (schema changes, WAL mode, etc)

This is part of updating the [Using Authentication](https://project-kessel.github.io/docs-internal-overlay/for-red-hatters/using-kessel/inventory-api/using-authentication/) guide in the internal docs. Looking to leverage this template to simplify the process for SP's wanting to test their auth credentials in ephemeral before rolling out to stage

## Ticket reference (if applicable)
For RHCLOUD-47590

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched API authentication to a chained authenticator with OIDC plus identity fallback.
  * Changed schema storage to in-memory backed resources and removed a consistency flag.
  * Switched public service to an h2c-enabled endpoint and adjusted application versioning/dependencies.
  * Removed Kafka Connect / Debezium outbox connectors and cleaned up related template parameters; added a new API config parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->