### PR TITLE
RHCLOUD-47724: Add the ability to restrict specific grpc endpoints using oidc

### DIFF
--- a/.inventory-api.yaml
+++ b/.inventory-api.yaml
@@ -18,7 +18,7 @@ authn:
         enable: false
         transport:
           http: false
-          grpc: true
+          grpc: false
         config:
           insecure-client: true
           authn-server-url: http://127.0.0.1:8085/realms/redhat-external

--- a/.inventory-api.yaml
+++ b/.inventory-api.yaml
@@ -18,6 +18,8 @@ authn:
         enable: false
         transport:
           http: false
+          # setting 'true' for grpc, below, will enable for the grpc transport. If grpc-endpoints are specified, it will
+          # be enabled *only* for those endpoints. (And it *must* succeed for those endpoints or access is denied.)
           grpc: false
         config:
           insecure-client: true

--- a/.inventory-api.yaml
+++ b/.inventory-api.yaml
@@ -18,10 +18,16 @@ authn:
         enable: false
         transport:
           http: false
-          grpc: false
+          grpc: true
         config:
           insecure-client: true
           authn-server-url: http://127.0.0.1:8085/realms/redhat-external
+          client-id: "tuple-service-account"
+          grpc-endpoints:
+            - "/kessel.inventory.v1beta2.KesselTupleService/CreateTuples"
+            - "/kessel.inventory.v1beta2.KesselTupleService/DeleteTuples"
+            - "/kessel.inventory.v1beta2.KesselTupleService/ReadTuples"
+            - "/kessel.inventory.v1beta2.KesselTupleService/AcquireLock"
           skip-client-id-check: true
           skip-issuer-check: true
           principal-user-domain: localhost

--- a/internal/authn/authn.go
+++ b/internal/authn/authn.go
@@ -96,7 +96,13 @@ func NewForProtocol(config CompletedConfig, protocol Protocol, logger *log.Helpe
 			if chainConfig.OIDCConfig == nil {
 				return nil, fmt.Errorf("oidc authenticator requires config at chain index %d", i)
 			}
-			logger.Infof("Loading OIDC info from %s", chainConfig.OIDCConfig.AuthorizationServerURL)
+			if len(chainConfig.OIDCConfig.GrpcEndpoints) > 0 {
+				logger.Infof("Loading OIDC authenticator from %s for specific endpoints: %v",
+					chainConfig.OIDCConfig.AuthorizationServerURL, chainConfig.OIDCConfig.GrpcEndpoints)
+			} else {
+				logger.Infof("Loading OIDC authenticator from %s for all endpoints",
+					chainConfig.OIDCConfig.AuthorizationServerURL)
+			}
 			auth, err = factory.CreateAuthenticator(factory.TypeOIDC, chainConfig.OIDCConfig)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create oidc authenticator: %w", err)

--- a/internal/authn/config.go
+++ b/internal/authn/config.go
@@ -285,6 +285,16 @@ func (c *Config) completeChainEntry(entry ChainEntry, index int) (ChainCompleted
 		if principalUserDomain, ok := entry.Config["principal-user-domain"].(string); ok {
 			oidcOpts.PrincipalUserDomain = principalUserDomain
 		}
+		// Pass gRPC endpoints from OIDC config to OIDC options
+		if grpcEndpoints, ok := entry.Config["grpc-endpoints"].([]interface{}); ok {
+			endpoints := make([]string, len(grpcEndpoints))
+			for i, ep := range grpcEndpoints {
+				if epStr, ok := ep.(string); ok {
+					endpoints[i] = epStr
+				}
+			}
+			oidcOpts.GrpcEndpoints = endpoints
+		}
 		oidcConfig := oidc.NewConfig(oidcOpts)
 		completedOIDC, err := oidcConfig.Complete()
 		if err != nil {

--- a/internal/authn/config.go
+++ b/internal/authn/config.go
@@ -286,13 +286,38 @@ func (c *Config) completeChainEntry(entry ChainEntry, index int) (ChainCompleted
 			oidcOpts.PrincipalUserDomain = principalUserDomain
 		}
 		// Pass gRPC endpoints from OIDC config to OIDC options
-		if grpcEndpoints, ok := entry.Config["grpc-endpoints"].([]interface{}); ok {
+		if grpcEndpointsRaw, exists := entry.Config["grpc-endpoints"]; exists {
+			// Only accept []interface{} (what YAML parsing via mapstructure produces)
+			grpcEndpoints, ok := grpcEndpointsRaw.([]interface{})
+			if !ok {
+				errs = append(errs, &ConfigError{
+					Message: fmt.Sprintf("grpc-endpoints must be an array at chain index %d", index),
+					Type:    entry.Type,
+				})
+				return chainConfig, errs
+			}
+
+			// Validate and convert each element to string
 			endpoints := make([]string, len(grpcEndpoints))
 			for i, ep := range grpcEndpoints {
-				if epStr, ok := ep.(string); ok {
-					endpoints[i] = epStr
+				epStr, ok := ep.(string)
+				if !ok {
+					errs = append(errs, &ConfigError{
+						Message: fmt.Sprintf("grpc-endpoints[%d] is not a string at chain index %d", i, index),
+						Type:    entry.Type,
+					})
+					return chainConfig, errs
 				}
+				if epStr == "" {
+					errs = append(errs, &ConfigError{
+						Message: fmt.Sprintf("grpc-endpoints[%d] is empty at chain index %d", i, index),
+						Type:    entry.Type,
+					})
+					return chainConfig, errs
+				}
+				endpoints[i] = epStr
 			}
+
 			oidcOpts.GrpcEndpoints = endpoints
 		}
 		oidcConfig := oidc.NewConfig(oidcOpts)

--- a/internal/authn/config_test.go
+++ b/internal/authn/config_test.go
@@ -129,6 +129,84 @@ func TestConfigComplete_WithGrpcEndpoints(t *testing.T) {
 			"/kessel.inventory.v1beta2.KesselTupleService/DeleteTuples",
 		}, oidcChainConfig.OIDCConfig.GrpcEndpoints)
 	})
+
+	t.Run("grpc-endpoints rejects empty string", func(t *testing.T) {
+		c := &Config{
+			Authenticator: &AuthenticatorConfig{
+				Type: "first_match",
+				Chain: []ChainEntry{
+					{
+						Type:      "oidc",
+						Transport: &Transport{HTTP: boolPtr(false), GRPC: boolPtr(true)},
+						Config: map[string]interface{}{
+							"authn-server-url": "https://example.com",
+							"client-id":        "test-client",
+							"grpc-endpoints": []interface{}{
+								"/kessel.inventory.v1beta2.KesselTupleService/CreateTuples",
+								"", // Empty string - should fail
+							},
+						},
+					},
+					{Type: "allow-unauthenticated", Transport: &Transport{HTTP: boolPtr(true), GRPC: boolPtr(true)}},
+				},
+			},
+		}
+
+		_, errs := c.Complete()
+		assert.NotEmpty(t, errs)
+		assert.Contains(t, errs[0].Error(), "grpc-endpoints[1] is empty")
+	})
+
+	t.Run("grpc-endpoints rejects non-string element", func(t *testing.T) {
+		c := &Config{
+			Authenticator: &AuthenticatorConfig{
+				Type: "first_match",
+				Chain: []ChainEntry{
+					{
+						Type:      "oidc",
+						Transport: &Transport{HTTP: boolPtr(false), GRPC: boolPtr(true)},
+						Config: map[string]interface{}{
+							"authn-server-url": "https://example.com",
+							"client-id":        "test-client",
+							"grpc-endpoints": []interface{}{
+								"/kessel.inventory.v1beta2.KesselTupleService/CreateTuples",
+								123, // Non-string - should fail
+							},
+						},
+					},
+					{Type: "allow-unauthenticated", Transport: &Transport{HTTP: boolPtr(true), GRPC: boolPtr(true)}},
+				},
+			},
+		}
+
+		_, errs := c.Complete()
+		assert.NotEmpty(t, errs)
+		assert.Contains(t, errs[0].Error(), "grpc-endpoints[1] is not a string")
+	})
+
+	t.Run("grpc-endpoints rejects wrong type", func(t *testing.T) {
+		c := &Config{
+			Authenticator: &AuthenticatorConfig{
+				Type: "first_match",
+				Chain: []ChainEntry{
+					{
+						Type:      "oidc",
+						Transport: &Transport{HTTP: boolPtr(false), GRPC: boolPtr(true)},
+						Config: map[string]interface{}{
+							"authn-server-url": "https://example.com",
+							"client-id":        "test-client",
+							"grpc-endpoints":   "not-an-array", // Wrong type - should fail
+						},
+					},
+					{Type: "allow-unauthenticated", Transport: &Transport{HTTP: boolPtr(true), GRPC: boolPtr(true)}},
+				},
+			},
+		}
+
+		_, errs := c.Complete()
+		assert.NotEmpty(t, errs)
+		assert.Contains(t, errs[0].Error(), "grpc-endpoints must be an array")
+	})
 }
 
 func boolPtr(v bool) *bool { return &v }

--- a/internal/authn/config_test.go
+++ b/internal/authn/config_test.go
@@ -92,4 +92,43 @@ func TestConfigComplete_EnableHTTP_EnableGRPC_RequiresAtLeastOneAuthenticatorPer
 	})
 }
 
+func TestConfigComplete_WithGrpcEndpoints(t *testing.T) {
+	t.Run("grpc-endpoints converted from config map to OIDC options", func(t *testing.T) {
+		c := &Config{
+			Authenticator: &AuthenticatorConfig{
+				Type: "first_match",
+				Chain: []ChainEntry{
+					{
+						Type:      "oidc",
+						Transport: &Transport{HTTP: boolPtr(false), GRPC: boolPtr(true)},
+						Config: map[string]interface{}{
+							"authn-server-url": "https://example.com",
+							"client-id":        "test-client",
+							"grpc-endpoints": []interface{}{
+								"/kessel.inventory.v1beta2.KesselTupleService/CreateTuples",
+								"/kessel.inventory.v1beta2.KesselTupleService/DeleteTuples",
+							},
+						},
+					},
+					{Type: "allow-unauthenticated", Transport: &Transport{HTTP: boolPtr(true), GRPC: boolPtr(true)}},
+				},
+			},
+		}
+
+		completed, errs := c.Complete()
+		assert.Empty(t, errs)
+		assert.NotNil(t, completed.Authenticator)
+		assert.Len(t, completed.Authenticator.ChainConfigs, 2)
+
+		// Verify conversion from []interface{} (config map) to []string (GrpcEndpoints field)
+		oidcChainConfig := completed.Authenticator.ChainConfigs[0]
+		assert.Equal(t, "oidc", oidcChainConfig.Type)
+		assert.NotNil(t, oidcChainConfig.OIDCConfig)
+		assert.Equal(t, []string{
+			"/kessel.inventory.v1beta2.KesselTupleService/CreateTuples",
+			"/kessel.inventory.v1beta2.KesselTupleService/DeleteTuples",
+		}, oidcChainConfig.OIDCConfig.GrpcEndpoints)
+	})
+}
+
 func boolPtr(v bool) *bool { return &v }

--- a/internal/authn/oidc/oidc.go
+++ b/internal/authn/oidc/oidc.go
@@ -43,11 +43,44 @@ func New(c CompletedConfig) (*OAuth2Authenticator, error) {
 }
 
 func (o *OAuth2Authenticator) Authenticate(ctx context.Context, t transport.Transporter) (*api.Claims, api.Decision) {
+	// Endpoint filtering: if endpoints are specified, only authenticate requests to those endpoints
+	if len(o.GrpcEndpoints) > 0 {
+		currentEndpoint := t.Operation()
+		matched := false
+		for _, endpoint := range o.GrpcEndpoints {
+			if endpoint == currentEndpoint {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			// This OIDC authenticator doesn't apply to this endpoint
+			return nil, api.Ignore
+		}
+		// Endpoint matched - OIDC authentication is REQUIRED for this endpoint
+		// Continue to token extraction, but return Deny (not Ignore) if no token present
+	}
+
 	// get the token from the request
 	rawToken := util.GetBearerToken(t)
 
 	// ensure we got one
 	if rawToken == "" {
+		if len(o.GrpcEndpoints) > 0 {
+			// GrpcEndpoints specified and matched, but no token present - DENY
+			// OIDC is required for this endpoint
+			return nil, api.Deny
+
+			// TODO: We would like to be able to return 'api.Ignore' here (as below), and (depending on the authn
+			// aggregator used) potentially provide for another authenticator to authenticate the call. The problem is
+			// that, with current configuration in many envs, "type: allow-unauthenticated" is the last authenticator in
+			// the chain, thus we default to 'api.Allow'. We therefore have no other way of enforcing OIDC on the
+			// endpoints without returning a 'api.Deny' here. In the future when we default to deny in the chain, we can
+			// remove this endpoints specific logic and go with the below behaviour. (See RHCLOUD-47724.)
+			// NOTE: since the "restricted by GrpcEndpoints" feature was introduced to support the deprecated Tuple CRUD
+			// endpoints, it may equally be removed in the meantime.
+		}
+		// No endpoints specified - current behavior (OIDC optional)
 		return nil, api.Ignore
 	}
 

--- a/internal/authn/oidc/oidc_test.go
+++ b/internal/authn/oidc/oidc_test.go
@@ -10,33 +10,33 @@ import (
 	"github.com/project-kessel/inventory-api/internal/authn/api"
 )
 
-type mockHeader struct {
+type fakeHeader struct {
 	headers map[string]string
 }
 
-func (m *mockHeader) Get(key string) string {
+func (m *fakeHeader) Get(key string) string {
 	if m.headers == nil {
 		return ""
 	}
 	return m.headers[key]
 }
-func (m *mockHeader) Set(key, value string)      {}
-func (m *mockHeader) Add(key, value string)      {}
-func (m *mockHeader) Keys() []string             { return nil }
-func (m *mockHeader) Values(key string) []string { return nil }
+func (m *fakeHeader) Set(key, value string)      {}
+func (m *fakeHeader) Add(key, value string)      {}
+func (m *fakeHeader) Keys() []string             { return nil }
+func (m *fakeHeader) Values(key string) []string { return nil }
 
-type mockTransporter struct {
+type fakeTransporter struct {
 	kind      transport.Kind
 	operation string
 	headers   map[string]string
 }
 
-func (m *mockTransporter) Kind() transport.Kind            { return m.kind }
-func (m *mockTransporter) Endpoint() string                { return "/test" }
-func (m *mockTransporter) Operation() string               { return m.operation }
-func (m *mockTransporter) RequestHeader() transport.Header { return &mockHeader{headers: m.headers} }
-func (m *mockTransporter) ReplyHeader() transport.Header {
-	return &mockHeader{headers: map[string]string{}}
+func (m *fakeTransporter) Kind() transport.Kind            { return m.kind }
+func (m *fakeTransporter) Endpoint() string                { return "/test" }
+func (m *fakeTransporter) Operation() string               { return m.operation }
+func (m *fakeTransporter) RequestHeader() transport.Header { return &fakeHeader{headers: m.headers} }
+func (m *fakeTransporter) ReplyHeader() transport.Header {
+	return &fakeHeader{headers: map[string]string{}}
 }
 
 // TestOAuth2Authenticator_Endpoints_NotMatched verifies that when endpoints are specified,
@@ -58,8 +58,8 @@ func TestOAuth2Authenticator_Endpoints_NotMatched(t *testing.T) {
 		},
 	}
 
-	// Mock transporter with non-matching endpoint
-	mockT := &mockTransporter{
+	// Fake transporter with non-matching endpoint
+	fakeT := &fakeTransporter{
 		kind:      transport.KindGRPC,
 		operation: "/kessel.inventory.v1beta2.KesselInventoryService/CreateResource",
 		headers: map[string]string{
@@ -68,7 +68,7 @@ func TestOAuth2Authenticator_Endpoints_NotMatched(t *testing.T) {
 	}
 
 	// Authenticate should return Ignore (endpoint not in list)
-	claims, decision := auth.Authenticate(context.Background(), mockT)
+	claims, decision := auth.Authenticate(context.Background(), fakeT)
 	assert.Nil(t, claims)
 	assert.Equal(t, api.Ignore, decision)
 }
@@ -92,15 +92,15 @@ func TestOAuth2Authenticator_Endpoints_MatchedNoToken(t *testing.T) {
 		},
 	}
 
-	// Mock transporter with matching endpoint but no token
-	mockT := &mockTransporter{
+	// Fake transporter with matching endpoint but no token
+	fakeT := &fakeTransporter{
 		kind:      transport.KindGRPC,
 		operation: "/kessel.inventory.v1beta2.KesselTupleService/CreateTuples",
 		headers:   map[string]string{}, // No authorization header
 	}
 
 	// Authenticate should return Deny (OIDC required for this endpoint)
-	claims, decision := auth.Authenticate(context.Background(), mockT)
+	claims, decision := auth.Authenticate(context.Background(), fakeT)
 	assert.Nil(t, claims)
 	assert.Equal(t, api.Deny, decision)
 }
@@ -121,15 +121,15 @@ func TestOAuth2Authenticator_NoEndpoints_NoToken(t *testing.T) {
 		},
 	}
 
-	// Mock transporter without token
-	mockT := &mockTransporter{
+	// Fake transporter without token
+	fakeT := &fakeTransporter{
 		kind:      transport.KindGRPC,
 		operation: "/any/endpoint",
 		headers:   map[string]string{},
 	}
 
 	// Authenticate should return Ignore (OIDC optional, current behavior)
-	claims, decision := auth.Authenticate(context.Background(), mockT)
+	claims, decision := auth.Authenticate(context.Background(), fakeT)
 	assert.Nil(t, claims)
 	assert.Equal(t, api.Ignore, decision)
 }
@@ -163,26 +163,26 @@ func TestOAuth2Authenticator_Endpoints_MultipleEndpoints(t *testing.T) {
 	// Test each endpoint matches and requires token
 	for _, endpoint := range endpoints {
 		t.Run(endpoint, func(t *testing.T) {
-			mockT := &mockTransporter{
+			fakeT := &fakeTransporter{
 				kind:      transport.KindGRPC,
 				operation: endpoint,
 				headers:   map[string]string{},
 			}
 
-			claims, decision := auth.Authenticate(context.Background(), mockT)
+			claims, decision := auth.Authenticate(context.Background(), fakeT)
 			assert.Nil(t, claims)
 			assert.Equal(t, api.Deny, decision, "Expected Deny for endpoint %s without token", endpoint)
 		})
 	}
 
 	// Test non-matching endpoint returns Ignore
-	mockT := &mockTransporter{
+	fakeT := &fakeTransporter{
 		kind:      transport.KindGRPC,
 		operation: "/some/other/endpoint",
 		headers:   map[string]string{},
 	}
 
-	claims, decision := auth.Authenticate(context.Background(), mockT)
+	claims, decision := auth.Authenticate(context.Background(), fakeT)
 	assert.Nil(t, claims)
 	assert.Equal(t, api.Ignore, decision)
 }

--- a/internal/authn/oidc/oidc_test.go
+++ b/internal/authn/oidc/oidc_test.go
@@ -1,0 +1,188 @@
+package oidc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kratos/kratos/v2/transport"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/project-kessel/inventory-api/internal/authn/api"
+)
+
+type mockHeader struct {
+	headers map[string]string
+}
+
+func (m *mockHeader) Get(key string) string {
+	if m.headers == nil {
+		return ""
+	}
+	return m.headers[key]
+}
+func (m *mockHeader) Set(key, value string)      {}
+func (m *mockHeader) Add(key, value string)      {}
+func (m *mockHeader) Keys() []string             { return nil }
+func (m *mockHeader) Values(key string) []string { return nil }
+
+type mockTransporter struct {
+	kind      transport.Kind
+	operation string
+	headers   map[string]string
+}
+
+func (m *mockTransporter) Kind() transport.Kind            { return m.kind }
+func (m *mockTransporter) Endpoint() string                { return "/test" }
+func (m *mockTransporter) Operation() string               { return m.operation }
+func (m *mockTransporter) RequestHeader() transport.Header { return &mockHeader{headers: m.headers} }
+func (m *mockTransporter) ReplyHeader() transport.Header {
+	return &mockHeader{headers: map[string]string{}}
+}
+
+// TestOAuth2Authenticator_Endpoints_NotMatched verifies that when endpoints are specified,
+// the authenticator returns Ignore for requests to non-matching endpoints.
+func TestOAuth2Authenticator_Endpoints_NotMatched(t *testing.T) {
+	// Create authenticator with endpoints list
+	auth := &OAuth2Authenticator{
+		CompletedConfig: CompletedConfig{
+			&completedConfig{
+				&Config{
+					Options: &Options{
+						GrpcEndpoints: []string{
+							"/kessel.inventory.v1beta2.KesselTupleService/CreateTuples",
+							"/kessel.inventory.v1beta2.KesselTupleService/DeleteTuples",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Mock transporter with non-matching endpoint
+	mockT := &mockTransporter{
+		kind:      transport.KindGRPC,
+		operation: "/kessel.inventory.v1beta2.KesselInventoryService/CreateResource",
+		headers: map[string]string{
+			"authorization": "Bearer valid-token-here",
+		},
+	}
+
+	// Authenticate should return Ignore (endpoint not in list)
+	claims, decision := auth.Authenticate(context.Background(), mockT)
+	assert.Nil(t, claims)
+	assert.Equal(t, api.Ignore, decision)
+}
+
+// TestOAuth2Authenticator_Endpoints_MatchedNoToken verifies that when endpoints are specified
+// and the endpoint matches, but no token is present, the authenticator returns Deny (not Ignore).
+func TestOAuth2Authenticator_Endpoints_MatchedNoToken(t *testing.T) {
+	// Create authenticator with endpoints list
+	auth := &OAuth2Authenticator{
+		CompletedConfig: CompletedConfig{
+			&completedConfig{
+				&Config{
+					Options: &Options{
+						GrpcEndpoints: []string{
+							"/kessel.inventory.v1beta2.KesselTupleService/CreateTuples",
+							"/kessel.inventory.v1beta2.KesselTupleService/DeleteTuples",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Mock transporter with matching endpoint but no token
+	mockT := &mockTransporter{
+		kind:      transport.KindGRPC,
+		operation: "/kessel.inventory.v1beta2.KesselTupleService/CreateTuples",
+		headers:   map[string]string{}, // No authorization header
+	}
+
+	// Authenticate should return Deny (OIDC required for this endpoint)
+	claims, decision := auth.Authenticate(context.Background(), mockT)
+	assert.Nil(t, claims)
+	assert.Equal(t, api.Deny, decision)
+}
+
+// TestOAuth2Authenticator_NoEndpoints_NoToken verifies that when no endpoints are specified
+// (current behavior), missing token returns Ignore (OIDC optional).
+func TestOAuth2Authenticator_NoEndpoints_NoToken(t *testing.T) {
+	// Create authenticator without endpoints list (current behavior)
+	auth := &OAuth2Authenticator{
+		CompletedConfig: CompletedConfig{
+			&completedConfig{
+				&Config{
+					Options: &Options{
+						GrpcEndpoints: []string{}, // Empty list = no endpoint filtering
+					},
+				},
+			},
+		},
+	}
+
+	// Mock transporter without token
+	mockT := &mockTransporter{
+		kind:      transport.KindGRPC,
+		operation: "/any/endpoint",
+		headers:   map[string]string{},
+	}
+
+	// Authenticate should return Ignore (OIDC optional, current behavior)
+	claims, decision := auth.Authenticate(context.Background(), mockT)
+	assert.Nil(t, claims)
+	assert.Equal(t, api.Ignore, decision)
+}
+
+// Note: Testing invalid token validation requires a real OIDC provider with a Verifier.
+// In unit tests without a mock OIDC provider, we can only test the endpoint filtering logic.
+// Token validation is tested in integration tests with a real Keycloak instance.
+
+// TestOAuth2Authenticator_Endpoints_MultipleEndpoints verifies that multiple endpoints
+// can be specified and any match triggers OIDC requirement.
+func TestOAuth2Authenticator_Endpoints_MultipleEndpoints(t *testing.T) {
+	endpoints := []string{
+		"/kessel.inventory.v1beta2.KesselTupleService/CreateTuples",
+		"/kessel.inventory.v1beta2.KesselTupleService/DeleteTuples",
+		"/kessel.inventory.v1beta2.KesselTupleService/ReadTuples",
+		"/kessel.inventory.v1beta2.KesselTupleService/AcquireLock",
+	}
+
+	auth := &OAuth2Authenticator{
+		CompletedConfig: CompletedConfig{
+			&completedConfig{
+				&Config{
+					Options: &Options{
+						GrpcEndpoints: endpoints,
+					},
+				},
+			},
+		},
+	}
+
+	// Test each endpoint matches and requires token
+	for _, endpoint := range endpoints {
+		t.Run(endpoint, func(t *testing.T) {
+			mockT := &mockTransporter{
+				kind:      transport.KindGRPC,
+				operation: endpoint,
+				headers:   map[string]string{},
+			}
+
+			claims, decision := auth.Authenticate(context.Background(), mockT)
+			assert.Nil(t, claims)
+			assert.Equal(t, api.Deny, decision, "Expected Deny for endpoint %s without token", endpoint)
+		})
+	}
+
+	// Test non-matching endpoint returns Ignore
+	mockT := &mockTransporter{
+		kind:      transport.KindGRPC,
+		operation: "/some/other/endpoint",
+		headers:   map[string]string{},
+	}
+
+	claims, decision := auth.Authenticate(context.Background(), mockT)
+	assert.Nil(t, claims)
+	assert.Equal(t, api.Ignore, decision)
+}

--- a/internal/authn/oidc/options.go
+++ b/internal/authn/oidc/options.go
@@ -12,6 +12,12 @@ type Options struct {
 	EnforceAudCheck        bool   `mapstructure:"enforce-aud-check"`
 	SkipIssuerCheck        bool   `mapstructure:"skip-issuer-check"`
 	PrincipalUserDomain    string `mapstructure:"principal-user-domain"`
+
+	// GrpcEndpoints specifies which gRPC endpoints this OIDC authenticator applies to (optional).
+	// If specified, the authenticator only participates for gRPC requests to these endpoints.
+	// If omitted or empty, the authenticator applies to all endpoints (current behavior).
+	// This feature is specific to deprecated tuple CRUD endpoints and will be removed in the future.
+	GrpcEndpoints []string `mapstructure:"grpc-endpoints"`
 }
 
 func NewOptions() *Options {

--- a/internal/authn/oidc/options_test.go
+++ b/internal/authn/oidc/options_test.go
@@ -29,5 +29,7 @@ func TestOptions_AddFlags(t *testing.T) {
 	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
 	test.options.AddFlags(fs, prefix)
 
-	helpers.AllOptionsHaveFlags(t, prefix, fs, *test.options, nil)
+	// GrpcEndpoints is configured via YAML, not CLI flags, so exclude it from flag check
+	exclude := []string{"grpc-endpoints"}
+	helpers.AllOptionsHaveFlags(t, prefix, fs, *test.options, exclude)
 }


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Allows oidc authenticators to be configured with an optional array of grpc endpoints, which force oidc auth for those endpoints.

## Ticket reference (if applicable)
Fixes #RHCLOUD-47724

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OIDC authenticator gains a YAML option to restrict authentication to specified gRPC endpoints; when set, those endpoints require auth, otherwise prior behavior remains.

* **Tests**
  * Added unit tests covering gRPC endpoint allowlist behavior and validation/error cases.

* **Chores**
  * Improved startup logging to show which endpoints are loaded and updated example configuration to list allowed gRPC RPCs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->