### PR TITLE
RHCLOUD-48064: Bump go to 1.26.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,5 +18,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.6.2
+          version: v2.12.2
           args: --timeout=10m

--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -69,7 +69,7 @@ func IsNil(i interface{}) bool {
 		return true
 	}
 	switch reflect.TypeOf(i).Kind() {
-	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.UnsafePointer, reflect.Interface, reflect.Slice:
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.UnsafePointer, reflect.Interface, reflect.Slice:
 		return reflect.ValueOf(i).IsNil()
 	case reflect.Array:
 		return reflect.ValueOf(i).IsZero()

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/project-kessel/inventory-api
 
 // Tke care to bump versions with FIPS compliance in mind
-go 1.25.8
+go 1.26.2
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1

--- a/internal/data/model/reporter_representation_test.go
+++ b/internal/data/model/reporter_representation_test.go
@@ -142,7 +142,7 @@ func TestReporterRepresentation_Structure(t *testing.T) {
 			}
 
 			// Check if it's a pointer type
-			if field.Type.Kind() != reflect.Ptr {
+			if field.Type.Kind() != reflect.Pointer {
 				t.Errorf("Field %s should be a pointer type for nullable field", fieldName)
 			}
 

--- a/internal/data/model/testdata.go
+++ b/internal/data/model/testdata.go
@@ -577,7 +577,7 @@ func AssertGORMTag(t *testing.T, model interface{}, fieldName string, expectedTa
 	t.Helper()
 
 	modelType := reflect.TypeOf(model)
-	if modelType.Kind() == reflect.Ptr {
+	if modelType.Kind() == reflect.Pointer {
 		modelType = modelType.Elem()
 	}
 
@@ -598,7 +598,7 @@ func AssertFieldType(t *testing.T, model interface{}, fieldName string, expected
 	t.Helper()
 
 	modelType := reflect.TypeOf(model)
-	if modelType.Kind() == reflect.Ptr {
+	if modelType.Kind() == reflect.Pointer {
 		modelType = modelType.Elem()
 	}
 


### PR DESCRIPTION
- Bump `go` directive in go.mod from 1.25.8 to 1.26.2
- Update golangci-lint CI action from v2.6.2 to v2.12.2 for Go 1.26 compatibility
- Replace deprecated `reflect.Ptr` with `reflect.Pointer` (deprecated in Go 1.26)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Go toolchain requirement to 1.26.2.
  * Upgraded the CI linter used in automated checks to v2.12.2.

* **Tests**
  * Adjusted internal tests to align with updated Go reflection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->