### PR TITLE
RHCLOUD-48028: adds HCC clusters to datasources for grafana

### DIFF
--- a/dashboards/grafana-dashboard-kessel-inventory-kafka-connect.configmap.yaml
+++ b/dashboards/grafana-dashboard-kessel-inventory-kafka-connect.configmap.yaml
@@ -4588,7 +4588,7 @@ data:
             "options": [],
             "query": "prometheus",
             "refresh": 1,
-            "regex": "/(crcp01ue1-prometheus)|(crcfrp01ugw1-prometheus)|(crcs02ue1-prometheus)|(crcfrs01ugw1-prometheus)|(insights-perf-prometheus)/",
+            "regex": "/(crcp01ue1-prometheus)|(crcfrp01ugw1-prometheus)|(crcs02ue1-prometheus)|(crcfrs01ugw1-prometheus)|(insights-perf-prometheus)|(hccs01ue1-prometheus)|(hccp01ue1-prometheus)/",
             "type": "datasource"
           },
           {


### PR DESCRIPTION
### PR Template:

## Describe your changes

* Updates the dashboard datasources variable to include HCC clusters

## Ticket reference (if applicable)
For RHCLOUD-48028


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the Grafana dashboard datasource selector to include two additional Prometheus clusters (`hccs01ue1-prometheus` and `hccp01ue1-prometheus`), allowing users to select from a broader range of datasource options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->