### PR TITLE
Add streaming interceptor to read only mode flag

### DIFF
--- a/internal/server/grpc/grpc.go
+++ b/internal/server/grpc/grpc.go
@@ -133,7 +133,9 @@ func NewWithDeps(deps ServerConfig) (*kgrpc.Server, error) {
 		unaryInterceptor := []grpc.UnaryServerInterceptor{
 			m.UnaryReadOnlyInterceptor(),
 		}
-		opts = append(opts, kgrpc.Options(grpc.ChainUnaryInterceptor(unaryInterceptor...)))
+		opts = append(opts, kgrpc.Options(
+			grpc.ChainStreamInterceptor(streamingInterceptor...),
+			grpc.ChainUnaryInterceptor(unaryInterceptor...)))
 	}
 	opts = append(opts, deps.ServerOptions...)
 	srv := kgrpc.NewServer(opts...)


### PR DESCRIPTION
### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Enhanced read-only mode to consistently enforce request restrictions across both streaming and unary gRPC operations. Previously, streaming operations lacked the same protection applied to unary calls, potentially allowing unintended modifications in read-only environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->