### PR TITLE
RHCLOUD-48136: Restore StreamValidationInterceptor for streaming RPCs

### DIFF
--- a/internal/middleware/validation.go
+++ b/internal/middleware/validation.go
@@ -7,6 +7,7 @@ import (
 	"buf.build/go/protovalidate"
 	"github.com/go-kratos/kratos/v2/errors"
 	"github.com/go-kratos/kratos/v2/middleware"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -43,6 +44,35 @@ func sanitizeReportResourceRequest(rr *pbv1beta2.ReportResourceRequest) error {
 	}
 
 	return sanitizeStruct(&rr.Representations.Reporter, "reporter")
+}
+
+// StreamValidationInterceptor returns a gRPC stream interceptor that validates
+// incoming messages using protovalidate. This ensures streaming RPCs (e.g.
+// StreamedListObjects) receive the same proto validation as unary RPCs.
+func StreamValidationInterceptor(validator protovalidate.Validator) grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		wrapper := &requestValidatingWrapper{ServerStream: ss, Validator: validator}
+		return handler(srv, wrapper)
+	}
+}
+
+type requestValidatingWrapper struct {
+	grpc.ServerStream
+	protovalidate.Validator
+}
+
+func (w *requestValidatingWrapper) RecvMsg(m interface{}) error {
+	if err := w.ServerStream.RecvMsg(m); err != nil {
+		return err
+	}
+
+	if v, ok := m.(proto.Message); ok {
+		if err := w.Validate(v); err != nil {
+			return errors.BadRequest("VALIDATOR", err.Error()).WithCause(err)
+		}
+	}
+
+	return nil
 }
 
 func sanitizeStruct(s **structpb.Struct, name string) error {

--- a/internal/server/grpc/grpc.go
+++ b/internal/server/grpc/grpc.go
@@ -93,6 +93,7 @@ func NewWithDeps(deps ServerConfig) (*kgrpc.Server, error) {
 		streamingInterceptor = append(streamingInterceptor, streamAuth.Interceptor())
 	}
 
+	streamingInterceptor = append(streamingInterceptor, m.StreamValidationInterceptor(deps.Validator))
 	streamingInterceptor = append(streamingInterceptor, m.ErrorMappingStreamInterceptor())
 
 	var authnMiddleware middleware.Middleware

--- a/internal/service/resources/kesselinventoryservice_test.go
+++ b/internal/service/resources/kesselinventoryservice_test.go
@@ -2156,6 +2156,89 @@ func TestInventoryService_StreamedListSubjects_ValidationRejectsMissingRelation(
 	assert.Equal(t, codes.InvalidArgument, grpcStatus.Code())
 }
 
+// --- Streaming proto-level validation (interceptor-dependent) ---
+//
+// These tests verify that protovalidate constraints (patterns, required fields)
+// are enforced on streaming RPCs via the StreamValidationInterceptor. They use
+// inputs that violate proto constraints but would pass handler-level validation,
+// so they fail if the interceptor is removed.
+
+func TestInventoryService_StreamedListObjects_ProtoPatternRejectsHyphen(t *testing.T) {
+	claims := &authnapi.Claims{
+		SubjectId: authnapi.SubjectId("user-abc"),
+		AuthType:  authnapi.AuthTypeXRhIdentity,
+	}
+
+	simpleAuthz := data.NewSimpleRelationsRepository()
+	uc := newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz})
+	client := newTestServer(t, TestServerConfig{
+		Usecase:       uc,
+		Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+	})
+
+	reporterType := "hbi"
+	req := &pb.StreamedListObjectsRequest{
+		ObjectType: &pb.RepresentationType{
+			ResourceType: "host-type",
+			ReporterType: &reporterType,
+		},
+		Relation: "view",
+		Subject: &pb.SubjectReference{
+			Resource: &pb.ResourceReference{
+				ResourceType: "principal",
+				ResourceId:   "subject-xyz",
+				Reporter:     &pb.ReporterReference{Type: "rbac"},
+			},
+		},
+	}
+
+	stream, err := client.StreamedListObjects(context.Background(), req)
+	require.NoError(t, err)
+
+	_, err = stream.Recv()
+	require.Error(t, err)
+	grpcStatus, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, grpcStatus.Code())
+	assert.Contains(t, grpcStatus.Message(), "does not match regex pattern")
+}
+
+func TestInventoryService_StreamedListSubjects_ProtoPatternRejectsHyphen(t *testing.T) {
+	claims := &authnapi.Claims{
+		SubjectId: authnapi.SubjectId("user-abc"),
+		AuthType:  authnapi.AuthTypeXRhIdentity,
+	}
+
+	simpleAuthz := data.NewSimpleRelationsRepository()
+	uc := newTestUsecase(t, testUsecaseConfig{Relations: simpleAuthz})
+	client := newTestServer(t, TestServerConfig{
+		Usecase:       uc,
+		Authenticator: &StubAuthenticator{Claims: claims, Decision: authnapi.Allow},
+	})
+
+	req := &pb.StreamedListSubjectsRequest{
+		Resource: &pb.ResourceReference{
+			ResourceType: "host",
+			ResourceId:   "host-1",
+			Reporter:     &pb.ReporterReference{Type: "hbi"},
+		},
+		Relation: "view",
+		SubjectType: &pb.RepresentationType{
+			ResourceType: "user-principal",
+		},
+	}
+
+	stream, err := client.StreamedListSubjects(context.Background(), req)
+	require.NoError(t, err)
+
+	_, err = stream.Recv()
+	require.Error(t, err)
+	grpcStatus, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, grpcStatus.Code())
+	assert.Contains(t, grpcStatus.Message(), "does not match regex pattern")
+}
+
 // --- CheckForUpdate with NoIdentity ---
 
 func TestInventoryService_CheckForUpdate_NoIdentity(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Re-adds `StreamValidationInterceptor`** to the gRPC streaming interceptor chain — it was inadvertently removed in commit 42dc02 (PR #1354) during the schema validation refactor
- **Streaming RPCs** (`StreamedListObjects`, `StreamedListSubjects`) now enforce `buf.validate` constraints (patterns, required fields, min_len) again
- **Adds two regression tests** that send proto-pattern-violating inputs (hyphenated `resource_type`) which only fail if the interceptor is missing

## Context

Jira: [RHCLOUD-48136](https://redhat.atlassian.net/browse/RHCLOUD-48136)
Epic: [RHCLOUD-44951](https://redhat.atlassian.net/browse/RHCLOUD-44951)

The `StreamValidationInterceptor` was removed under the assumption that app-level validation sufficed, but the Kratos `Validation` middleware only applies to unary RPCs. Streaming RPCs were left without proto validation, silently accepting malformed requests.

## Changes

| File | Change |
|------|--------|
| `internal/middleware/validation.go` | Re-implement `StreamValidationInterceptor` and `requestValidatingWrapper` |
| `internal/server/grpc/grpc.go` | Re-add interceptor to streaming chain |
| `internal/service/resources/kesselinventoryservice_test.go` | Add `TestInventoryService_StreamedListObjects_ProtoPatternRejectsHyphen` and `TestInventoryService_StreamedListSubjects_ProtoPatternRejectsHyphen` |

## Test plan

- [x] New tests pass with interceptor present
- [ ] Verify new tests fail when interceptor line is commented out (confirms they are interceptor-dependent)
- [ ] `make test` passes


Made with [Cursor](https://cursor.com)

[RHCLOUD-48136]: https://redhat.atlassian.net/browse/RHCLOUD-48136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHCLOUD-44951]: https://redhat.atlassian.net/browse/RHCLOUD-44951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation support for streaming RPC requests, ensuring data integrity for streaming API calls.
  * Streaming operations now enforce the same validation rules as standard API calls.

* **Tests**
  * Added validation tests for streaming operations to verify constraint enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->