### PR TITLE
RHCLOUD-48141: Add smoke tests and skill to run them in epehemeral

### DIFF
--- a/.agents/skills/sanity-tests/SKILL.md
+++ b/.agents/skills/sanity-tests/SKILL.md
@@ -40,7 +40,23 @@ Ask the user which mode unless they've already specified:
 | **Build + deploy + test** | `-b` | Test the current branch from scratch (requires `QUAY_REPO`) |
 | **Deploy + test** | `-d` | Deploy whatever is in bonfire config (no local build) |
 
-### 3. Set QUAY_REPO (if using `-b` mode)
+### 3. Confirm the target namespace
+
+Before running, confirm which namespace the tests will target:
+
+```bash
+# Show current namespace and any reserved namespaces for the user
+oc project -q 2>/dev/null || echo "(no current project)"
+bonfire namespace list 2>/dev/null | grep "$(whoami)" || echo "(no reserved namespaces)"
+```
+
+Present the namespace to the user and ask them to confirm it is the correct environment:
+- **Tests only mode**: The user must have an existing namespace. Show the current one and ask "Run tests against `ephemeral-XXXXX`?"
+- **Deploy modes (`-b`/`-d`)**: Ask if they want to deploy to a specific existing namespace (`-n <ns>`) or let bonfire reserve a new one. Show any currently reserved namespaces so they can choose.
+
+Only proceed once the user confirms the target. Pass `-n <namespace>` to the script if they chose a specific one.
+
+### 4. Set QUAY_REPO (if using `-b` mode)
 
 The user needs a Quay.io repo to push images to. Check if it's set:
 
@@ -50,7 +66,7 @@ echo "QUAY_REPO=${QUAY_REPO:-<not set>}"
 
 If not set, ask the user for their Quay repo (e.g. `quay.io/<username>/kessel`).
 
-### 4. Run the sanity tests
+### 5. Run the sanity tests
 
 ```bash
 # Tests only (environment already deployed)
@@ -87,7 +103,7 @@ The script handles:
 - Running `go test -v -count=1 ./test/e2e/sanity/ -timeout 10m`
 - Cleaning up port-forwards on exit
 
-### 5. Interpret results
+### 6. Interpret results
 
 - **PASS**: All tests passed. The branch is safe to merge.
 - **FAIL**: Report which tests failed and the error messages. The most common failures:
@@ -96,7 +112,7 @@ The script handles:
   - Connection errors: port-forward may have dropped; restart and retry
   - `ReportDeleteReReport_Revive` timeout: known flake due to consumer latency; safe to re-run
 
-### 6. Run specific test groups (optional)
+### 7. Run specific test groups (optional)
 
 ```bash
 # Only Check tests (Groups 1-3)

--- a/.agents/skills/sanity-tests/SKILL.md
+++ b/.agents/skills/sanity-tests/SKILL.md
@@ -1,0 +1,136 @@
+# Sanity Tests Skill
+
+Run the E2E sanity test suite against an ephemeral OpenShift environment.
+
+## When to Use
+
+Use this skill when the user says any of:
+- "run sanity tests"
+- "run sanity tests against ephemeral"
+- "run e2e sanity"
+- "sanity check the ephemeral deployment"
+- "test the ephemeral environment"
+- "run sanity test in ephemeral"
+
+## Prerequisites
+
+- `oc` CLI must be logged in (`oc whoami` succeeds)
+- VPN connected (required for bonfire to reach app-interface)
+- Go toolchain available
+- For `-b` mode: `podman` available and `QUAY_REPO` env var set
+- For tests-only mode: an ephemeral namespace must already be deployed
+
+## Steps
+
+### 1. Verify OC login and VPN
+
+```bash
+oc whoami
+```
+
+If this fails with "Unauthorized", ask the user to log in with `oc login`.
+
+### 2. Choose the run mode
+
+Ask the user which mode unless they've already specified:
+
+| Mode | Flag | When to use |
+|------|------|-------------|
+| **Tests only** | _(no flag)_ | Namespace already deployed with the code you want to test |
+| **Build + deploy + test** | `-b` | Test the current branch from scratch (requires `QUAY_REPO`) |
+| **Deploy + test** | `-d` | Deploy whatever is in bonfire config (no local build) |
+
+### 3. Set QUAY_REPO (if using `-b` mode)
+
+The user needs a Quay.io repo to push images to. Check if it's set:
+
+```bash
+echo "QUAY_REPO=${QUAY_REPO:-<not set>}"
+```
+
+If not set, ask the user for their Quay repo (e.g. `quay.io/<username>/kessel`).
+
+### 4. Run the sanity tests
+
+```bash
+# Tests only (environment already deployed)
+./scripts/run-sanity-tests.sh
+
+# Build + push + deploy + test (full cycle)
+QUAY_REPO=<repo> ./scripts/run-sanity-tests.sh -b
+
+# Deploy existing bonfire config + test
+./scripts/run-sanity-tests.sh -d
+
+# Target a specific namespace
+./scripts/run-sanity-tests.sh -n ephemeral-abc123
+```
+
+**IMPORTANT**: Run the script in the background with output monitoring:
+- Set `block_until_ms: 0` so the agent can multitask
+- Monitor with pattern `(Total:.*Passed:|FAIL|deploy failed|Deployed to)` to catch results
+- The full cycle (`-b`) takes ~10-25 minutes; deploy-only (`-d`) takes ~5-15 minutes
+
+Script flags:
+- `-b` -- Build a fresh `linux/amd64` image, push to `QUAY_REPO`, update bonfire config, deploy, then test
+- `-d` -- Deploy whatever is in bonfire config to ephemeral, then test
+- `-n <ns>` -- Target a specific namespace (default: auto-detect via `oc project -q`)
+- `-p <port>` -- Local API port-forward port (default: 9000)
+- `-P <port>` -- Local DB port-forward port (default: 5432)
+
+The script handles:
+- Building and pushing the image (with `-b`)
+- Updating `~/.config/bonfire/config.yaml` with the new image tag (with `-b`)
+- Deploying via bonfire (with `-b` or `-d`)
+- Discovering DB credentials from the `kessel-inventory-db` secret
+- Setting up port-forwards to the API and DB
+- Running `go test -v -count=1 ./test/e2e/sanity/ -timeout 10m`
+- Cleaning up port-forwards on exit
+
+### 5. Interpret results
+
+- **PASS**: All tests passed. The branch is safe to merge.
+- **FAIL**: Report which tests failed and the error messages. The most common failures:
+  - Timeout polling for `ALLOWED_TRUE`: consumer may be slow or not running; check `kessel-inventory-consumer-*` pod logs
+  - DB assertion mismatch: the API behavior has changed; compare expected vs actual values
+  - Connection errors: port-forward may have dropped; restart and retry
+  - `ReportDeleteReReport_Revive` timeout: known flake due to consumer latency; safe to re-run
+
+### 6. Run specific test groups (optional)
+
+```bash
+# Only Check tests (Groups 1-3)
+go test -v -count=1 -run 'TestSanity_(Report|Delete|Check_)' ./test/e2e/sanity/ -timeout 10m
+
+# Only CheckForUpdate tests (Group 4)
+go test -v -count=1 -run 'TestSanity_CheckForUpdate' ./test/e2e/sanity/ -timeout 10m
+
+# Only Bulk tests (Group 5)
+go test -v -count=1 -run 'TestSanity_(CheckBulk|CheckSelf)' ./test/e2e/sanity/ -timeout 10m
+
+# Only Lifecycle tests (Group 6)
+go test -v -count=1 -run 'TestSanity_(Revive|MultiResource)' ./test/e2e/sanity/ -timeout 10m
+
+# Only Streaming tests (Group 7)
+go test -v -count=1 -run 'TestSanity_Streamed' ./test/e2e/sanity/ -timeout 10m
+```
+
+## Test Coverage
+
+| Group | File | RPCs Covered |
+|-------|------|-------------|
+| 1-3 | `check_test.go` | ReportResource, DeleteResource, Check |
+| 4 | `checkforupdate_test.go` | CheckForUpdate, CheckForUpdateBulk |
+| 5 | `bulk_test.go` | CheckBulk, CheckSelf, CheckSelfBulk |
+| 6 | `lifecycle_test.go` | Report/Delete/Re-report lifecycle |
+| 7 | `streaming_test.go` | StreamedListObjects, StreamedListSubjects |
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Unable to connect to app-interface` | VPN not connected | Connect to VPN, then retry |
+| `Unauthorized` from `oc` | OC session expired | Run `oc login` |
+| `QUAY_REPO not set` | Missing env var for `-b` mode | Set `QUAY_REPO=quay.io/<user>/kessel` |
+| Port-forward errors | Port already in use | Use `-p`/`-P` flags for alternate ports |
+| `PIDS[@]: unbound variable` | Old script version | Pull latest — this bug is fixed |

--- a/.agents/skills/sanity-tests/SKILL.md
+++ b/.agents/skills/sanity-tests/SKILL.md
@@ -100,20 +100,23 @@ The script handles:
 
 ```bash
 # Only Check tests (Groups 1-3)
-go test -v -count=1 -run 'TestSanity_(Report|Delete|Check_)' ./test/e2e/sanity/ -timeout 10m
+go test -v -count=1 -tags=sanity -run 'TestSanity_(Report|Delete|Check_)' ./test/e2e/sanity/ -timeout 10m
 
 # Only CheckForUpdate tests (Group 4)
-go test -v -count=1 -run 'TestSanity_CheckForUpdate' ./test/e2e/sanity/ -timeout 10m
+go test -v -count=1 -tags=sanity -run 'TestSanity_CheckForUpdate' ./test/e2e/sanity/ -timeout 10m
 
 # Only Bulk tests (Group 5)
-go test -v -count=1 -run 'TestSanity_(CheckBulk|CheckSelf)' ./test/e2e/sanity/ -timeout 10m
+go test -v -count=1 -tags=sanity -run 'TestSanity_(CheckBulk|CheckSelf)' ./test/e2e/sanity/ -timeout 10m
 
 # Only Lifecycle tests (Group 6)
-go test -v -count=1 -run 'TestSanity_(Revive|MultiResource)' ./test/e2e/sanity/ -timeout 10m
+go test -v -count=1 -tags=sanity -run 'TestSanity_(Revive|MultiResource)' ./test/e2e/sanity/ -timeout 10m
 
 # Only Streaming tests (Group 7)
-go test -v -count=1 -run 'TestSanity_Streamed' ./test/e2e/sanity/ -timeout 10m
+go test -v -count=1 -tags=sanity -run 'TestSanity_Streamed' ./test/e2e/sanity/ -timeout 10m
 ```
+
+**Note**: The `-tags=sanity` flag is required. Without it, `go test ./...` skips these files
+(they use `//go:build sanity` to avoid running in CI where no database is available).
 
 ## Test Coverage
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ The following domain-specific guidelines provide detailed, repo-specific convent
 - [Database Guidelines](docs/database-guidelines.md) - GORM models, transactions, migrations, outbox patterns, and query conventions
 - [Testing Guidelines](docs/testing-guidelines.md) - Test organization, infrastructure, fixtures, authorization testing, and coverage
 - [Integration Guidelines](docs/integration-guidelines.md) - Kafka consumers, Relations API, health checks, observability, and configuration
+- [Sanity Tests](.agents/skills/sanity-tests/SKILL.md) - Run E2E sanity tests against ephemeral OpenShift environments
 
 ## AI Guidance and Repo Conventions
 

--- a/scripts/run-sanity-tests.sh
+++ b/scripts/run-sanity-tests.sh
@@ -1,0 +1,288 @@
+#!/bin/bash
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+NAMESPACE=""
+API_PORT=9000
+DB_PORT=15432
+BUILD_IMAGE=false
+DEPLOY=false
+
+# QUAY_REPO env var: e.g. quay.io/sgunta/kessel (no tag)
+QUAY_REPO="${QUAY_REPO:-}"
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Modes:
+  (no flags)       Run tests against an already-deployed environment
+  -b               Build + push image, deploy, then test
+  -d               Deploy whatever is in bonfire config, then test
+
+Options:
+  -n <namespace>   OpenShift namespace (default: auto-detect via 'oc project -q')
+  -p <port>        Local port for API port-forward (default: 9000)
+  -P <port>        Local port for DB port-forward (default: 15432)
+  -h               Show this help
+
+Environment variables:
+  QUAY_REPO        Container image repo, e.g. quay.io/sgunta/kessel (required with -b)
+
+Examples:
+  # Tests only (environment already deployed)
+  ./scripts/run-sanity-tests.sh
+
+  # Build + push + deploy + test
+  QUAY_REPO=quay.io/sgunta/kessel ./scripts/run-sanity-tests.sh -b
+
+  # Deploy existing bonfire config + test
+  ./scripts/run-sanity-tests.sh -d
+EOF
+    exit 1
+}
+
+while getopts "n:p:P:bdh" opt; do
+    case $opt in
+        n) NAMESPACE="$OPTARG" ;;
+        p) API_PORT="$OPTARG" ;;
+        P) DB_PORT="$OPTARG" ;;
+        b) BUILD_IMAGE=true ;;
+        d) DEPLOY=true ;;
+        h) usage ;;
+        *) usage ;;
+    esac
+done
+
+# -b implies deploy since the new image needs to be rolled out
+if [ "$BUILD_IMAGE" = true ]; then
+    DEPLOY=true
+fi
+
+IMAGE_TAG=""
+
+# --- Port management helpers ---
+
+kill_port() {
+    local port=$1
+    local pids
+    pids=$(lsof -t -i:"$port" 2>/dev/null || true)
+    if [ -n "$pids" ]; then
+        log_warn "Killing processes on port $port (pids: $pids)..."
+        echo "$pids" | xargs kill 2>/dev/null || true
+        sleep 1
+        # Force-kill anything still hanging
+        pids=$(lsof -t -i:"$port" 2>/dev/null || true)
+        if [ -n "$pids" ]; then
+            echo "$pids" | xargs kill -9 2>/dev/null || true
+            sleep 1
+        fi
+    fi
+}
+
+wait_for_port() {
+    local port=$1
+    local timeout=${2:-15}
+    for i in $(seq 1 "$timeout"); do
+        if lsof -Pi :"$port" -sTCP:LISTEN -t >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+# --- Cleanup (runs on EXIT, INT, TERM) ---
+
+PIDS=()
+cleanup() {
+    log_info "Cleaning up..."
+    for pid in "${PIDS[@]+"${PIDS[@]}"}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+    sleep 1
+    # Force-kill any survivors
+    for pid in "${PIDS[@]+"${PIDS[@]}"}"; do
+        kill -9 "$pid" 2>/dev/null || true
+    done
+    # Ensure our ports are free
+    kill_port "$API_PORT"
+    kill_port "$DB_PORT"
+    log_info "Cleanup complete"
+}
+trap cleanup EXIT INT TERM
+
+# --- Phase 1: Build + Push (if -b) ---
+
+if [ "$BUILD_IMAGE" = true ]; then
+    if [ -z "$QUAY_REPO" ]; then
+        log_error "QUAY_REPO env var is required when using -b (e.g. QUAY_REPO=quay.io/sgunta/kessel)"
+        exit 1
+    fi
+
+    IMAGE_TAG="$(git rev-parse --short HEAD)-sanity"
+    FULL_IMAGE="${QUAY_REPO}:${IMAGE_TAG}"
+
+    log_info "Building image: $FULL_IMAGE (platform: linux/amd64)..."
+    podman build --platform linux/amd64 \
+        -f Dockerfile \
+        -t "$FULL_IMAGE" \
+        --build-arg GIT_COMMIT="$(git rev-parse HEAD)" \
+        .
+
+    log_info "Pushing image: $FULL_IMAGE..."
+    podman push "$FULL_IMAGE"
+    log_info "Image pushed successfully"
+
+    # Update bonfire config with new image tag
+    BONFIRE_CONFIG="$HOME/.config/bonfire/config.yaml"
+    if [ -f "$BONFIRE_CONFIG" ]; then
+        log_info "Updating bonfire config with IMAGE_TAG=$IMAGE_TAG, INVENTORY_IMAGE=$QUAY_REPO"
+        python3 -c "
+import yaml, sys
+with open('$BONFIRE_CONFIG', 'r') as f:
+    config = yaml.safe_load(f)
+for app in config.get('apps', []):
+    if app.get('name') == 'kessel':
+        for comp in app.get('components', []):
+            if comp.get('name') == 'kessel-inventory':
+                comp.setdefault('parameters', {})
+                comp['parameters']['INVENTORY_IMAGE'] = '$QUAY_REPO'
+                comp['parameters']['IMAGE_TAG'] = '$IMAGE_TAG'
+with open('$BONFIRE_CONFIG', 'w') as f:
+    yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+" 2>/dev/null || {
+            log_warn "python3+pyyaml not available, using sed for bonfire config update"
+            sed -i.bak "s|IMAGE_TAG:.*|IMAGE_TAG: ${IMAGE_TAG}|" "$BONFIRE_CONFIG"
+            sed -i.bak "s|INVENTORY_IMAGE:.*|INVENTORY_IMAGE: ${QUAY_REPO}|" "$BONFIRE_CONFIG"
+            rm -f "${BONFIRE_CONFIG}.bak"
+        }
+        log_info "Bonfire config updated"
+    else
+        log_warn "Bonfire config not found at $BONFIRE_CONFIG, skipping update"
+    fi
+fi
+
+# --- Phase 2: Deploy (if -b or -d) ---
+
+if [ "$DEPLOY" = true ]; then
+    log_info "Deploying kessel to ephemeral via bonfire..."
+
+    BONFIRE_DEPLOY_ARGS="kessel"
+    if [ -n "$NAMESPACE" ]; then
+        BONFIRE_DEPLOY_ARGS="$BONFIRE_DEPLOY_ARGS -n $NAMESPACE"
+    else
+        CURRENT_USER="${USER:-$(whoami)}"
+        RESERVED=$(bonfire namespace list 2>/dev/null | grep -E "^ephemeral-.*true.*${CURRENT_USER}" | awk '{print $1}' || true)
+        if [ -n "$RESERVED" ]; then
+            log_warn "Releasing existing reserved namespaces..."
+            echo "$RESERVED" | while read -r ns; do
+                bonfire namespace release "$ns" 2>&1 || true
+            done
+            sleep 3
+        fi
+    fi
+
+    if [ -t 1 ]; then
+        BONFIRE_OUTPUT=$(bonfire deploy $BONFIRE_DEPLOY_ARGS 2>&1 | tee /dev/tty)
+    else
+        BONFIRE_OUTPUT=$(bonfire deploy $BONFIRE_DEPLOY_ARGS 2>&1)
+        echo "$BONFIRE_OUTPUT"
+    fi
+    DEPLOY_EXIT=$?
+    if [ $DEPLOY_EXIT -ne 0 ]; then
+        log_error "Bonfire deploy failed (exit code: $DEPLOY_EXIT)"
+        exit 1
+    fi
+
+    NAMESPACE=$(echo "$BONFIRE_OUTPUT" | grep -oE "successfully deployed to namespace [a-z0-9-]+" | awk '{print $NF}' || true)
+    if [ -z "$NAMESPACE" ]; then
+        NAMESPACE=$(echo "$BONFIRE_OUTPUT" | tail -1 | tr -d '[:space:]')
+    fi
+
+    if [ -z "$NAMESPACE" ]; then
+        log_error "Could not determine namespace from bonfire output"
+        exit 1
+    fi
+    log_info "Deployed to namespace: $NAMESPACE"
+fi
+
+# --- Phase 3: Detect namespace ---
+
+if [ -z "$NAMESPACE" ]; then
+    NAMESPACE=$(oc project -q 2>/dev/null || true)
+    if [ -z "$NAMESPACE" ]; then
+        log_error "Could not detect namespace. Use -n <namespace>, -d to deploy, or set your oc project."
+        exit 1
+    fi
+fi
+
+log_info "Namespace: $NAMESPACE"
+
+# --- Phase 4: Discover DB credentials ---
+
+log_info "Discovering DB credentials..."
+POSTGRES_USER=$(oc get secret kessel-inventory-db -n "$NAMESPACE" -o jsonpath='{.data.db\.user}' | base64 -d)
+POSTGRES_PASSWORD=$(oc get secret kessel-inventory-db -n "$NAMESPACE" -o jsonpath='{.data.db\.password}' | base64 -d)
+POSTGRES_DB=$(oc get secret kessel-inventory-db -n "$NAMESPACE" -o jsonpath='{.data.db\.name}' | base64 -d)
+
+if [ -z "$POSTGRES_USER" ] || [ -z "$POSTGRES_PASSWORD" ] || [ -z "$POSTGRES_DB" ]; then
+    log_error "Failed to read DB credentials from secret kessel-inventory-db"
+    exit 1
+fi
+log_info "DB credentials discovered (user=$POSTGRES_USER, db=$POSTGRES_DB)"
+
+# --- Phase 5: Port-forward + Test ---
+
+# Free ports from any previous stale runs
+kill_port "$API_PORT"
+kill_port "$DB_PORT"
+
+log_info "Starting API port-forward (localhost:$API_PORT -> svc/kessel-inventory-api:9000)..."
+oc port-forward svc/kessel-inventory-api "$API_PORT":9000 -n "$NAMESPACE" &
+PIDS+=($!)
+
+log_info "Starting DB port-forward (localhost:$DB_PORT -> svc/kessel-inventory-db:5432)..."
+oc port-forward svc/kessel-inventory-db "$DB_PORT":5432 -n "$NAMESPACE" &
+PIDS+=($!)
+
+log_info "Waiting for port-forwards to be ready..."
+if ! wait_for_port "$API_PORT" 15; then
+    log_error "API port $API_PORT not ready after 15s"
+    exit 1
+fi
+if ! wait_for_port "$DB_PORT" 15; then
+    log_error "DB port $DB_PORT not ready after 15s"
+    exit 1
+fi
+log_info "Port-forwards ready"
+
+log_info "Running sanity tests..."
+echo "=============================================="
+
+TEST_EXIT=0
+INV_GRPC_URL="localhost:$API_PORT" \
+POSTGRES_HOST=localhost \
+POSTGRES_PORT="$DB_PORT" \
+POSTGRES_USER="$POSTGRES_USER" \
+POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+POSTGRES_DB="$POSTGRES_DB" \
+go test -v -count=1 ./test/e2e/sanity/ -timeout 10m || TEST_EXIT=$?
+
+echo "=============================================="
+
+if [ $TEST_EXIT -eq 0 ]; then
+    log_info "All sanity tests PASSED"
+else
+    log_error "Sanity tests FAILED (exit code: $TEST_EXIT)"
+fi
+
+exit $TEST_EXIT

--- a/scripts/run-sanity-tests.sh
+++ b/scripts/run-sanity-tests.sh
@@ -142,29 +142,13 @@ if [ "$BUILD_IMAGE" = true ]; then
     podman push "$FULL_IMAGE"
     log_info "Image pushed successfully"
 
-    # Update bonfire config with new image tag
+    # Update bonfire config with new image tag (surgical in-place edit)
     BONFIRE_CONFIG="$HOME/.config/bonfire/config.yaml"
     if [ -f "$BONFIRE_CONFIG" ]; then
         log_info "Updating bonfire config with IMAGE_TAG=$IMAGE_TAG, INVENTORY_IMAGE=$QUAY_REPO"
-        python3 -c "
-import yaml, sys
-with open('$BONFIRE_CONFIG', 'r') as f:
-    config = yaml.safe_load(f)
-for app in config.get('apps', []):
-    if app.get('name') == 'kessel':
-        for comp in app.get('components', []):
-            if comp.get('name') == 'kessel-inventory':
-                comp.setdefault('parameters', {})
-                comp['parameters']['INVENTORY_IMAGE'] = '$QUAY_REPO'
-                comp['parameters']['IMAGE_TAG'] = '$IMAGE_TAG'
-with open('$BONFIRE_CONFIG', 'w') as f:
-    yaml.dump(config, f, default_flow_style=False, sort_keys=False)
-" 2>/dev/null || {
-            log_warn "python3+pyyaml not available, using sed for bonfire config update"
-            sed -i.bak "s|IMAGE_TAG:.*|IMAGE_TAG: ${IMAGE_TAG}|" "$BONFIRE_CONFIG"
-            sed -i.bak "s|INVENTORY_IMAGE:.*|INVENTORY_IMAGE: ${QUAY_REPO}|" "$BONFIRE_CONFIG"
-            rm -f "${BONFIRE_CONFIG}.bak"
-        }
+        sed -i.bak "s|IMAGE_TAG:.*|IMAGE_TAG: ${IMAGE_TAG}|" "$BONFIRE_CONFIG"
+        sed -i.bak "s|INVENTORY_IMAGE:.*|INVENTORY_IMAGE: ${QUAY_REPO}|" "$BONFIRE_CONFIG"
+        rm -f "${BONFIRE_CONFIG}.bak"
         log_info "Bonfire config updated"
     else
         log_warn "Bonfire config not found at $BONFIRE_CONFIG, skipping update"

--- a/scripts/run-sanity-tests.sh
+++ b/scripts/run-sanity-tests.sh
@@ -268,6 +268,9 @@ log_info "Port-forwards ready"
 log_info "Running sanity tests..."
 echo "=============================================="
 
+TEST_LOG=$(mktemp /tmp/sanity-test-XXXXXX.log)
+trap 'rm -f "$TEST_LOG"; cleanup' EXIT INT TERM
+
 TEST_EXIT=0
 INV_GRPC_URL="localhost:$API_PORT" \
 POSTGRES_HOST=localhost \
@@ -275,14 +278,85 @@ POSTGRES_PORT="$DB_PORT" \
 POSTGRES_USER="$POSTGRES_USER" \
 POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
 POSTGRES_DB="$POSTGRES_DB" \
-go test -v -count=1 -tags=sanity ./test/e2e/sanity/ -timeout 10m || TEST_EXIT=$?
+go test -v -count=1 -tags=sanity ./test/e2e/sanity/ -timeout 10m 2>&1 | tee "$TEST_LOG" || TEST_EXIT=${PIPESTATUS[0]}
 
 echo "=============================================="
 
+# --- Final Report ---
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  SANITY TEST RUN REPORT"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "  Namespace:  $NAMESPACE"
+echo "  Branch:     $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'unknown')"
+echo "  Commit:     $(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')"
+if [ -n "$IMAGE_TAG" ]; then
+    echo "  Image:      ${QUAY_REPO}:${IMAGE_TAG}"
+fi
+echo "  Started:    $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+echo ""
+
+# Extract individual test results from go test output
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+echo "  Test Results:"
+echo "  ─────────────────────────────────────────────────────────────────────────────"
+while IFS= read -r line; do
+    test_name=$(echo "$line" | sed 's/^--- \(PASS\|FAIL\|SKIP\): \(.*\) (.*/\2/')
+    duration=$(echo "$line" | grep -oE '\([0-9]+\.[0-9]+s\)' || echo "")
+    if echo "$line" | grep -q "^--- PASS:"; then
+        PASS_COUNT=$((PASS_COUNT + 1))
+        printf "    ${GREEN}✓${NC}  %-60s %s\n" "$test_name" "$duration"
+    elif echo "$line" | grep -q "^--- FAIL:"; then
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        printf "    ${RED}✗${NC}  %-60s %s\n" "$test_name" "$duration"
+    elif echo "$line" | grep -q "^--- SKIP:"; then
+        SKIP_COUNT=$((SKIP_COUNT + 1))
+        printf "    ${YELLOW}○${NC}  %-60s %s\n" "$test_name" "$duration"
+    fi
+done < <(grep -E "^--- (PASS|FAIL|SKIP):" "$TEST_LOG")
+
+TOTAL=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))
+echo "  ─────────────────────────────────────────────────────────────────────────────"
+printf "    Total: %d  |  ${GREEN}Passed: %d${NC}  |  ${RED}Failed: %d${NC}  |  ${YELLOW}Skipped: %d${NC}\n" \
+    "$TOTAL" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
+echo ""
+
+# Show failure details if any
+if [ $FAIL_COUNT -gt 0 ]; then
+    echo "  Failed Test Details:"
+    echo "  ─────────────────────────────────────────────────────────────────────────────"
+    # For each failed test, extract the error output
+    grep -E "^--- FAIL:" "$TEST_LOG" | while IFS= read -r fail_line; do
+        failed_test=$(echo "$fail_line" | sed 's/^--- FAIL: \(.*\) (.*/\1/')
+        echo ""
+        printf "    ${RED}✗ %s${NC}\n" "$failed_test"
+        # Show the last few lines before the FAIL line for this test (error messages)
+        grep -B5 "FAIL: $failed_test" "$TEST_LOG" | grep -E "Error|assert|require|FATAL|fatal|panic|timeout|Fatalf" | while IFS= read -r err_line; do
+            echo "      $err_line"
+        done
+    done
+    echo ""
+fi
+
+# Overall duration from go test output
+OVERALL_DURATION=$(grep -oE '^(ok|FAIL)\s+\S+\s+[0-9]+\.[0-9]+s' "$TEST_LOG" | grep -oE '[0-9]+\.[0-9]+s' || echo "unknown")
+echo "  Duration:   $OVERALL_DURATION"
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
 if [ $TEST_EXIT -eq 0 ]; then
+    echo ""
     log_info "All sanity tests PASSED"
 else
+    echo ""
     log_error "Sanity tests FAILED (exit code: $TEST_EXIT)"
+    echo ""
+    log_info "Full test log: $TEST_LOG"
+    # Don't delete the log on failure so it can be inspected
+    trap 'cleanup' EXIT INT TERM
 fi
 
 exit $TEST_EXIT

--- a/scripts/run-sanity-tests.sh
+++ b/scripts/run-sanity-tests.sh
@@ -275,7 +275,7 @@ POSTGRES_PORT="$DB_PORT" \
 POSTGRES_USER="$POSTGRES_USER" \
 POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
 POSTGRES_DB="$POSTGRES_DB" \
-go test -v -count=1 ./test/e2e/sanity/ -timeout 10m || TEST_EXIT=$?
+go test -v -count=1 -tags=sanity ./test/e2e/sanity/ -timeout 10m || TEST_EXIT=$?
 
 echo "=============================================="
 

--- a/test/e2e/sanity/bulk_test.go
+++ b/test/e2e/sanity/bulk_test.go
@@ -1,3 +1,5 @@
+//go:build sanity
+
 package sanity
 
 import (

--- a/test/e2e/sanity/bulk_test.go
+++ b/test/e2e/sanity/bulk_test.go
@@ -18,6 +18,13 @@ import (
 // --- Group 5: CheckBulk + CheckSelf ---
 
 func TestSanity_CheckBulk_MultipleHosts(t *testing.T) {
+	report.describe(t.Name(), testSpec{
+		description: "CheckBulk returns correct results for multiple host/workspace pairs in one call",
+		rpc:         "ReportResource ×2 → Check ×2 → CheckBulk",
+		given:       "Two hosts (A, B) reported in different workspaces (ws-A, ws-B)",
+		when:        "CheckBulk is called with hostA+wsA, hostB+wsB, and hostA+wsWrong",
+		then:        "First two pairs return ALLOWED_TRUE, third returns ALLOWED_FALSE",
+	})
 	client := newClient(t)
 	hostA := uniqueID("bulk-host-a")
 	hostB := uniqueID("bulk-host-b")
@@ -119,6 +126,13 @@ func TestSanity_CheckBulk_MultipleHosts(t *testing.T) {
 }
 
 func TestSanity_CheckSelf_ReturnsError(t *testing.T) {
+	report.describe(t.Name(), testSpec{
+		description: "CheckSelf fails in unauthenticated mode (no caller identity)",
+		rpc:         "ReportResource → CheckSelf",
+		given:       "A host resource reported by HBI",
+		when:        "CheckSelf is called (requires caller identity from auth context)",
+		then:        "Returns an error because ephemeral uses allow-unauthenticated mode",
+	})
 	client := newClient(t)
 	id := uniqueID("self-host")
 	ws := uniqueID("ws-self")
@@ -144,6 +158,13 @@ func TestSanity_CheckSelf_ReturnsError(t *testing.T) {
 }
 
 func TestSanity_CheckSelfBulk_ReturnsError(t *testing.T) {
+	report.describe(t.Name(), testSpec{
+		description: "CheckSelfBulk fails in unauthenticated mode (no caller identity)",
+		rpc:         "ReportResource → CheckSelfBulk",
+		given:       "A host resource reported by HBI",
+		when:        "CheckSelfBulk is called (requires caller identity from auth context)",
+		then:        "Returns an error because ephemeral uses allow-unauthenticated mode",
+	})
 	client := newClient(t)
 	id := uniqueID("selfbulk-host")
 	ws := uniqueID("ws-selfbulk")

--- a/test/e2e/sanity/bulk_test.go
+++ b/test/e2e/sanity/bulk_test.go
@@ -1,0 +1,171 @@
+package sanity
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+)
+
+// --- Group 5: CheckBulk + CheckSelf ---
+
+func TestSanity_CheckBulk_MultipleHosts(t *testing.T) {
+	client := newClient(t)
+	hostA := uniqueID("bulk-host-a")
+	hostB := uniqueID("bulk-host-b")
+	wsA := uniqueID("ws-bulk-a")
+	wsB := uniqueID("ws-bulk-b")
+	wsWrong := uniqueID("ws-bulk-wrong")
+	inst := "inst-1"
+
+	reportResource(t, client, "host", "hbi", inst, hostA, wsA)
+	t.Cleanup(func() { deleteResource(t, client, "host", hostA, "hbi", inst) })
+
+	reportResource(t, client, "host", "hbi", inst, hostB, wsB)
+	t.Cleanup(func() { deleteResource(t, client, "host", hostB, "hbi", inst) })
+
+	// DB assertions
+	assertReporterResource(t, hostA, "hbi", "host", 0, 0, false)
+	assertReporterResource(t, hostB, "hbi", "host", 0, 0, false)
+
+	// Wait for both tuples
+	pollCheck(t, client, makeCheckReq("host", hostA, "hbi", proto.String(inst), wsA),
+		pb.Allowed_ALLOWED_TRUE, defaultPollTimeout)
+	pollCheck(t, client, makeCheckReq("host", hostB, "hbi", proto.String(inst), wsB),
+		pb.Allowed_ALLOWED_TRUE, defaultPollTimeout)
+
+	bulkReq := &pb.CheckBulkRequest{
+		Items: []*pb.CheckBulkRequestItem{
+			{ // hostA + wsA -> TRUE
+				Object: &pb.ResourceReference{
+					ResourceType: "host", ResourceId: hostA,
+					Reporter: &pb.ReporterReference{Type: "hbi", InstanceId: proto.String(inst)},
+				},
+				Relation: "workspace",
+				Subject: &pb.SubjectReference{
+					Resource: &pb.ResourceReference{
+						ResourceType: "workspace", ResourceId: wsA,
+						Reporter: &pb.ReporterReference{Type: "rbac"},
+					},
+				},
+			},
+			{ // hostB + wsB -> TRUE
+				Object: &pb.ResourceReference{
+					ResourceType: "host", ResourceId: hostB,
+					Reporter: &pb.ReporterReference{Type: "hbi", InstanceId: proto.String(inst)},
+				},
+				Relation: "workspace",
+				Subject: &pb.SubjectReference{
+					Resource: &pb.ResourceReference{
+						ResourceType: "workspace", ResourceId: wsB,
+						Reporter: &pb.ReporterReference{Type: "rbac"},
+					},
+				},
+			},
+			{ // hostA + wsWrong -> FALSE
+				Object: &pb.ResourceReference{
+					ResourceType: "host", ResourceId: hostA,
+					Reporter: &pb.ReporterReference{Type: "hbi", InstanceId: proto.String(inst)},
+				},
+				Relation: "workspace",
+				Subject: &pb.SubjectReference{
+					Resource: &pb.ResourceReference{
+						ResourceType: "workspace", ResourceId: wsWrong,
+						Reporter: &pb.ReporterReference{Type: "rbac"},
+					},
+				},
+			},
+		},
+	}
+
+	// Retry CheckBulk to handle eventual consistency across SpiceDB nodes
+	var resp *pb.CheckBulkResponse
+	for attempt := 1; attempt <= defaultPollTimeout; attempt++ {
+		var err error
+		resp, err = client.CheckBulk(context.Background(), bulkReq)
+		require.NoError(t, err, "CheckBulk failed")
+		require.Len(t, resp.GetPairs(), 3, "expected 3 pairs")
+
+		if resp.GetPairs()[0].GetItem().GetAllowed() == pb.Allowed_ALLOWED_TRUE &&
+			resp.GetPairs()[1].GetItem().GetAllowed() == pb.Allowed_ALLOWED_TRUE &&
+			resp.GetPairs()[2].GetItem().GetAllowed() == pb.Allowed_ALLOWED_FALSE {
+			t.Logf("CheckBulk returned expected results on attempt %d", attempt)
+			break
+		}
+		if attempt == defaultPollTimeout {
+			t.Fatalf("CheckBulk did not converge within %d attempts", defaultPollTimeout)
+		}
+		t.Logf("CheckBulk attempt %d: results not yet consistent, retrying...", attempt)
+		time.Sleep(1 * time.Second)
+	}
+
+	assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.GetPairs()[0].GetItem().GetAllowed(), "pair[0] hostA+wsA should be TRUE")
+	assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.GetPairs()[1].GetItem().GetAllowed(), "pair[1] hostB+wsB should be TRUE")
+	assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.GetPairs()[2].GetItem().GetAllowed(), "pair[2] hostA+wsWrong should be FALSE")
+
+	recordBulkResult(t, "CheckBulk (3 items)", []string{
+		fmt.Sprintf("host/%s+wsA=%v", hostA, resp.GetPairs()[0].GetItem().GetAllowed()),
+		fmt.Sprintf("host/%s+wsB=%v", hostB, resp.GetPairs()[1].GetItem().GetAllowed()),
+		fmt.Sprintf("host/%s+wsWrong=%v", hostA, resp.GetPairs()[2].GetItem().GetAllowed()),
+	})
+}
+
+func TestSanity_CheckSelf_ReturnsError(t *testing.T) {
+	client := newClient(t)
+	id := uniqueID("self-host")
+	ws := uniqueID("ws-self")
+	inst := "inst-1"
+
+	reportResource(t, client, "host", "hbi", inst, id, ws)
+	t.Cleanup(func() { deleteResource(t, client, "host", id, "hbi", inst) })
+
+	assertReporterResource(t, id, "hbi", "host", 0, 0, false)
+
+	req := &pb.CheckSelfRequest{
+		Object: &pb.ResourceReference{
+			ResourceType: "host", ResourceId: id,
+			Reporter: &pb.ReporterReference{Type: "hbi", InstanceId: proto.String(inst)},
+		},
+		Relation: "workspace",
+	}
+
+	_, err := client.CheckSelf(context.Background(), req)
+	require.Error(t, err, "CheckSelf should fail in unauthenticated mode")
+	t.Logf("CheckSelf error (expected): %v", err)
+	recordError(t, "CheckSelf (expected error)", err)
+}
+
+func TestSanity_CheckSelfBulk_ReturnsError(t *testing.T) {
+	client := newClient(t)
+	id := uniqueID("selfbulk-host")
+	ws := uniqueID("ws-selfbulk")
+	inst := "inst-1"
+
+	reportResource(t, client, "host", "hbi", inst, id, ws)
+	t.Cleanup(func() { deleteResource(t, client, "host", id, "hbi", inst) })
+
+	assertReporterResource(t, id, "hbi", "host", 0, 0, false)
+
+	req := &pb.CheckSelfBulkRequest{
+		Items: []*pb.CheckSelfBulkRequestItem{
+			{
+				Object: &pb.ResourceReference{
+					ResourceType: "host", ResourceId: id,
+					Reporter: &pb.ReporterReference{Type: "hbi", InstanceId: proto.String(inst)},
+				},
+				Relation: "workspace",
+			},
+		},
+	}
+
+	_, err := client.CheckSelfBulk(context.Background(), req)
+	require.Error(t, err, "CheckSelfBulk should fail in unauthenticated mode")
+	t.Logf("CheckSelfBulk error (expected): %v", err)
+	recordError(t, "CheckSelfBulk (expected error)", err)
+}

--- a/test/e2e/sanity/check_test.go
+++ b/test/e2e/sanity/check_test.go
@@ -1,0 +1,128 @@
+package sanity
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+)
+
+// --- Group 1: Report + Check (Access Exists) ---
+
+func TestSanity_ReportHost_CheckAllowed(t *testing.T) {
+	client := newClient(t)
+	id := uniqueID("sanity-host")
+	ws := uniqueID("ws")
+	inst := "inst-1"
+
+	reportResource(t, client, "host", "hbi", inst, id, ws)
+	t.Cleanup(func() { deleteResource(t, client, "host", id, "hbi", inst) })
+
+	// DB assertions after report
+	assertReporterResource(t, id, "hbi", "host", 0, 0, false)
+	rr := findReporterResource(t, id, "hbi", "host")
+	assertReporterRepresentation(t, rr.ID, 0, 0, false)
+	res := findResourceByReporterKey(t, id, "hbi", "host")
+	assertCommonRepresentation(t, res.ID, 0, ws)
+
+	// Check workspace -> TRUE
+	req := makeCheckReq("host", id, "hbi", proto.String(inst), ws)
+	pollCheck(t, client, req, pb.Allowed_ALLOWED_TRUE, defaultPollTimeout)
+}
+
+func TestSanity_Check_WrongWorkspace(t *testing.T) {
+	client := newClient(t)
+	id := uniqueID("sanity-host-wrong")
+	wsRight := uniqueID("ws-right")
+	wsWrong := uniqueID("ws-wrong")
+	inst := "inst-1"
+
+	reportResource(t, client, "host", "hbi", inst, id, wsRight)
+	t.Cleanup(func() { deleteResource(t, client, "host", id, "hbi", inst) })
+
+	assertReporterResource(t, id, "hbi", "host", 0, 0, false)
+	res := findResourceByReporterKey(t, id, "hbi", "host")
+	assertCommonRepresentation(t, res.ID, 0, wsRight)
+
+	// Check with wrong workspace -> FALSE (no tuple exists for wsWrong)
+	req := makeCheckReq("host", id, "hbi", proto.String(inst), wsWrong)
+	pollCheck(t, client, req, pb.Allowed_ALLOWED_FALSE, 10)
+}
+
+// --- Group 2: Delete + Check (Access Lost) ---
+
+func TestSanity_DeleteHost_AccessLost(t *testing.T) {
+	client := newClient(t)
+	id := uniqueID("sanity-del-host")
+	ws := uniqueID("ws")
+	inst := "inst-1"
+
+	reportResource(t, client, "host", "hbi", inst, id, ws)
+	assertReporterResource(t, id, "hbi", "host", 0, 0, false)
+
+	// Confirm access exists
+	req := makeCheckReq("host", id, "hbi", proto.String(inst), ws)
+	pollCheck(t, client, req, pb.Allowed_ALLOWED_TRUE, defaultPollTimeout)
+
+	// Delete
+	deleteResource(t, client, "host", id, "hbi", inst)
+
+	// DB assertions after delete
+	assertReporterResource(t, id, "hbi", "host", 1, 0, true)
+	rr := findReporterResource(t, id, "hbi", "host")
+	assertReporterRepresentation(t, rr.ID, 1, 0, true)
+
+	// Confirm access lost
+	pollCheck(t, client, req, pb.Allowed_ALLOWED_FALSE, defaultPollTimeout)
+}
+
+// --- Group 3: Check Combinations (table-driven) ---
+
+func TestSanity_Check_Combinations(t *testing.T) {
+	tests := []struct {
+		name        string
+		wsReport    string
+		wsCheck     string
+		includeInst bool
+		expected    pb.Allowed
+	}{
+		{"matching_workspace", "ws-a", "ws-a", true, pb.Allowed_ALLOWED_TRUE},
+		{"non_matching_workspace", "ws-a", "ws-b", true, pb.Allowed_ALLOWED_FALSE},
+		{"no_instance_in_check_ref", "ws-f", "ws-f", false, pb.Allowed_ALLOWED_TRUE},
+		{"with_instance_in_check_ref", "ws-g", "ws-g", true, pb.Allowed_ALLOWED_TRUE},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newClient(t)
+			id := uniqueID("combo-" + tt.name)
+			ws := uniqueID(tt.wsReport)
+			wsCheck := ws
+			if tt.wsReport != tt.wsCheck {
+				wsCheck = uniqueID(tt.wsCheck)
+			}
+			inst := "inst-1"
+
+			reportResource(t, client, "host", "hbi", inst, id, ws)
+			t.Cleanup(func() { deleteResource(t, client, "host", id, "hbi", inst) })
+
+			// DB assertions
+			assertReporterResource(t, id, "hbi", "host", 0, 0, false)
+			res := findResourceByReporterKey(t, id, "hbi", "host")
+			assertCommonRepresentation(t, res.ID, 0, ws)
+
+			var instPtr *string
+			if tt.includeInst {
+				instPtr = proto.String(inst)
+			}
+			req := makeCheckReq("host", id, "hbi", instPtr, wsCheck)
+
+			timeout := defaultPollTimeout
+			if tt.expected == pb.Allowed_ALLOWED_FALSE {
+				timeout = 10
+			}
+			pollCheck(t, client, req, tt.expected, timeout)
+		})
+	}
+}

--- a/test/e2e/sanity/check_test.go
+++ b/test/e2e/sanity/check_test.go
@@ -1,3 +1,5 @@
+//go:build sanity
+
 package sanity
 
 import (

--- a/test/e2e/sanity/check_test.go
+++ b/test/e2e/sanity/check_test.go
@@ -13,6 +13,13 @@ import (
 // --- Group 1: Report + Check (Access Exists) ---
 
 func TestSanity_ReportHost_CheckAllowed(t *testing.T) {
+	report.describe(t.Name(), testSpec{
+		description: "Reporting a resource creates a workspace tuple that grants access",
+		rpc:         "ReportResource → Check",
+		given:       "A host resource reported by HBI with a workspace",
+		when:        "Check is called with the correct workspace as subject",
+		then:        "Check returns ALLOWED_TRUE and DB shows ver=0, gen=0, tombstone=false",
+	})
 	client := newClient(t)
 	id := uniqueID("sanity-host")
 	ws := uniqueID("ws")
@@ -34,6 +41,13 @@ func TestSanity_ReportHost_CheckAllowed(t *testing.T) {
 }
 
 func TestSanity_Check_WrongWorkspace(t *testing.T) {
+	report.describe(t.Name(), testSpec{
+		description: "Check denies access when the workspace does not match",
+		rpc:         "ReportResource → Check",
+		given:       "A host resource reported with workspace-A",
+		when:        "Check is called with workspace-B as subject",
+		then:        "Check returns ALLOWED_FALSE",
+	})
 	client := newClient(t)
 	id := uniqueID("sanity-host-wrong")
 	wsRight := uniqueID("ws-right")
@@ -55,6 +69,13 @@ func TestSanity_Check_WrongWorkspace(t *testing.T) {
 // --- Group 2: Delete + Check (Access Lost) ---
 
 func TestSanity_DeleteHost_AccessLost(t *testing.T) {
+	report.describe(t.Name(), testSpec{
+		description: "Deleting a resource removes the workspace tuple and revokes access",
+		rpc:         "ReportResource → Check → DeleteResource → Check",
+		given:       "A host resource with confirmed ALLOWED_TRUE access",
+		when:        "The resource is deleted",
+		then:        "Check returns ALLOWED_FALSE and DB shows tombstone=true",
+	})
 	client := newClient(t)
 	id := uniqueID("sanity-del-host")
 	ws := uniqueID("ws")
@@ -82,6 +103,13 @@ func TestSanity_DeleteHost_AccessLost(t *testing.T) {
 // --- Group 3: Check Combinations (table-driven) ---
 
 func TestSanity_Check_Combinations(t *testing.T) {
+	report.describe(t.Name(), testSpec{
+		description: "Check returns correct results across workspace and instance_id combinations",
+		rpc:         "ReportResource → Check",
+		given:       "A host resource reported with a specific workspace",
+		when:        "Check is called with matching/non-matching workspace, with/without instance_id",
+		then:        "Each combination returns the expected ALLOWED_TRUE or ALLOWED_FALSE",
+	})
 	tests := []struct {
 		name        string
 		wsReport    string

--- a/test/e2e/sanity/checkforupdate_test.go
+++ b/test/e2e/sanity/checkforupdate_test.go
@@ -17,6 +17,13 @@ import (
 // --- Group 4: CheckForUpdate combinations ---
 
 func TestSanity_CheckForUpdate_Combinations(t *testing.T) {
+	report.describe(t.Name(), testSpec{
+		description: "CheckForUpdate returns correct allowed status and consistency tokens",
+		rpc:         "ReportResource → CheckForUpdate",
+		given:       "A host resource reported with a workspace",
+		when:        "CheckForUpdate is called with matching, non-matching, and post-delete scenarios",
+		then:        "Matching returns ALLOWED_TRUE+token, non-matching returns ALLOWED_FALSE, deleted returns ALLOWED_FALSE",
+	})
 	tests := []struct {
 		name        string
 		wsReport    string
@@ -68,6 +75,13 @@ func TestSanity_CheckForUpdate_Combinations(t *testing.T) {
 }
 
 func TestSanity_CheckForUpdateBulk_MixedResults(t *testing.T) {
+	report.describe(t.Name(), testSpec{
+		description: "CheckForUpdateBulk returns mixed TRUE/FALSE for multiple workspace checks",
+		rpc:         "ReportResource → Check → CheckForUpdateBulk",
+		given:       "A host resource reported with workspace-A",
+		when:        "CheckForUpdateBulk is called with workspace-A (match) and workspace-B (no match)",
+		then:        "First pair returns ALLOWED_TRUE, second returns ALLOWED_FALSE",
+	})
 	client := newClient(t)
 	id := uniqueID("cfubulk")
 	wsA := uniqueID("ws-cfubulk-a")

--- a/test/e2e/sanity/checkforupdate_test.go
+++ b/test/e2e/sanity/checkforupdate_test.go
@@ -1,3 +1,5 @@
+//go:build sanity
+
 package sanity
 
 import (

--- a/test/e2e/sanity/checkforupdate_test.go
+++ b/test/e2e/sanity/checkforupdate_test.go
@@ -1,0 +1,130 @@
+package sanity
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+)
+
+// --- Group 4: CheckForUpdate combinations ---
+
+func TestSanity_CheckForUpdate_Combinations(t *testing.T) {
+	tests := []struct {
+		name        string
+		wsReport    string
+		wsCheck     string
+		deleteFirst bool
+		expected    pb.Allowed
+		expectToken bool
+	}{
+		{"matching", "ws-cfu-a", "ws-cfu-a", false, pb.Allowed_ALLOWED_TRUE, true},
+		{"non_matching", "ws-cfu-a", "ws-cfu-b", false, pb.Allowed_ALLOWED_FALSE, false},
+		{"after_delete", "ws-cfu-d", "ws-cfu-d", true, pb.Allowed_ALLOWED_FALSE, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newClient(t)
+			id := uniqueID("cfu-" + tt.name)
+			ws := uniqueID(tt.wsReport)
+			wsCheck := ws
+			if tt.wsReport != tt.wsCheck {
+				wsCheck = uniqueID(tt.wsCheck)
+			}
+			inst := "inst-1"
+
+			reportResource(t, client, "host", "hbi", inst, id, ws)
+
+			if tt.deleteFirst {
+				checkReq := makeCheckReq("host", id, "hbi", proto.String(inst), ws)
+				pollCheck(t, client, checkReq, pb.Allowed_ALLOWED_TRUE, defaultPollTimeout)
+
+				deleteResource(t, client, "host", id, "hbi", inst)
+				assertReporterResource(t, id, "hbi", "host", 1, 0, true)
+
+				pollCheck(t, client, checkReq, pb.Allowed_ALLOWED_FALSE, defaultPollTimeout)
+			} else {
+				t.Cleanup(func() { deleteResource(t, client, "host", id, "hbi", inst) })
+				assertReporterResource(t, id, "hbi", "host", 0, 0, false)
+			}
+
+			cfuReq := makeCheckForUpdateReq("host", id, "hbi", proto.String(inst), wsCheck)
+			resp := pollCheckForUpdate(t, client, cfuReq, tt.expected, defaultPollTimeout)
+
+			if tt.expectToken {
+				assert.NotNil(t, resp.GetConsistencyToken(), "expected non-nil consistency token")
+				assert.NotEmpty(t, resp.GetConsistencyToken().GetToken(), "expected non-empty consistency token")
+			}
+		})
+	}
+}
+
+func TestSanity_CheckForUpdateBulk_MixedResults(t *testing.T) {
+	client := newClient(t)
+	id := uniqueID("cfubulk")
+	wsA := uniqueID("ws-cfubulk-a")
+	wsB := uniqueID("ws-cfubulk-b")
+	inst := "inst-1"
+
+	reportResource(t, client, "host", "hbi", inst, id, wsA)
+	t.Cleanup(func() { deleteResource(t, client, "host", id, "hbi", inst) })
+
+	assertReporterResource(t, id, "hbi", "host", 0, 0, false)
+
+	// Wait for SpiceDB tuple to be created
+	checkReq := makeCheckReq("host", id, "hbi", proto.String(inst), wsA)
+	pollCheck(t, client, checkReq, pb.Allowed_ALLOWED_TRUE, defaultPollTimeout)
+
+	bulkReq := &pb.CheckForUpdateBulkRequest{
+		Items: []*pb.CheckBulkRequestItem{
+			{
+				Object: &pb.ResourceReference{
+					ResourceType: "host",
+					ResourceId:   id,
+					Reporter:     &pb.ReporterReference{Type: "hbi", InstanceId: proto.String(inst)},
+				},
+				Relation: "workspace",
+				Subject: &pb.SubjectReference{
+					Resource: &pb.ResourceReference{
+						ResourceType: "workspace",
+						ResourceId:   wsA,
+						Reporter:     &pb.ReporterReference{Type: "rbac"},
+					},
+				},
+			},
+			{
+				Object: &pb.ResourceReference{
+					ResourceType: "host",
+					ResourceId:   id,
+					Reporter:     &pb.ReporterReference{Type: "hbi", InstanceId: proto.String(inst)},
+				},
+				Relation: "workspace",
+				Subject: &pb.SubjectReference{
+					Resource: &pb.ResourceReference{
+						ResourceType: "workspace",
+						ResourceId:   wsB,
+						Reporter:     &pb.ReporterReference{Type: "rbac"},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := client.CheckForUpdateBulk(context.Background(), bulkReq)
+	require.NoError(t, err, "CheckForUpdateBulk failed")
+	require.Len(t, resp.GetPairs(), 2, "expected 2 pairs")
+
+	assert.Equal(t, pb.Allowed_ALLOWED_TRUE, resp.GetPairs()[0].GetItem().GetAllowed(), "pair[0] should be TRUE")
+	assert.Equal(t, pb.Allowed_ALLOWED_FALSE, resp.GetPairs()[1].GetItem().GetAllowed(), "pair[1] should be FALSE")
+
+	recordBulkResult(t, "CheckForUpdateBulk (2 items)", []string{
+		fmt.Sprintf("host/%s+wsA=%v", id, resp.GetPairs()[0].GetItem().GetAllowed()),
+		fmt.Sprintf("host/%s+wsB=%v", id, resp.GetPairs()[1].GetItem().GetAllowed()),
+	})
+}

--- a/test/e2e/sanity/lifecycle_test.go
+++ b/test/e2e/sanity/lifecycle_test.go
@@ -13,6 +13,13 @@ import (
 // --- Group 6: Lifecycle / Churn ---
 
 func TestSanity_ReportDeleteReReport_Revive(t *testing.T) {
+	report.describe(t.Name(), testSpec{
+		description: "A deleted resource can be revived by re-reporting, restoring access",
+		rpc:         "ReportResource → Check → DeleteResource → Check → ReportResource → Check",
+		given:       "A host resource that was reported, confirmed accessible, then deleted",
+		when:        "The same resource is re-reported (revived)",
+		then:        "Access is restored (ALLOWED_TRUE), generation increments to 1, tombstone cleared",
+	})
 	client := newClient(t)
 	id := uniqueID("revive-host")
 	ws := uniqueID("ws-revive")
@@ -50,6 +57,13 @@ func TestSanity_ReportDeleteReReport_Revive(t *testing.T) {
 }
 
 func TestSanity_MultiResourceChurn(t *testing.T) {
+	report.describe(t.Name(), testSpec{
+		description: "Deleting individual resources only revokes access for those resources",
+		rpc:         "ReportResource ×3 → Check ×3 → DeleteResource → Check → DeleteResource ×2 → Check ×2",
+		given:       "Three host resources (A, B, C) reported in the same workspace",
+		when:        "Host B is deleted, then A and C are deleted",
+		then:        "Only the deleted hosts lose access; remaining hosts are unaffected until deleted",
+	})
 	client := newClient(t)
 	idA := uniqueID("churn-a")
 	idB := uniqueID("churn-b")

--- a/test/e2e/sanity/lifecycle_test.go
+++ b/test/e2e/sanity/lifecycle_test.go
@@ -1,3 +1,5 @@
+//go:build sanity
+
 package sanity
 
 import (

--- a/test/e2e/sanity/lifecycle_test.go
+++ b/test/e2e/sanity/lifecycle_test.go
@@ -1,0 +1,95 @@
+package sanity
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+)
+
+// --- Group 6: Lifecycle / Churn ---
+
+func TestSanity_ReportDeleteReReport_Revive(t *testing.T) {
+	client := newClient(t)
+	id := uniqueID("revive-host")
+	ws := uniqueID("ws-revive")
+	inst := "inst-1"
+
+	// Step 1: Report -> TRUE
+	reportResource(t, client, "host", "hbi", inst, id, ws)
+	assertReporterResource(t, id, "hbi", "host", 0, 0, false)
+	res := findResourceByReporterKey(t, id, "hbi", "host")
+	assertCommonRepresentation(t, res.ID, 0, ws)
+
+	req := makeCheckReq("host", id, "hbi", proto.String(inst), ws)
+	pollCheck(t, client, req, pb.Allowed_ALLOWED_TRUE, defaultPollTimeout)
+
+	// Step 2: Delete -> FALSE
+	deleteResource(t, client, "host", id, "hbi", inst)
+	assertReporterResource(t, id, "hbi", "host", 1, 0, true)
+	rr := findReporterResource(t, id, "hbi", "host")
+	assertReporterRepresentation(t, rr.ID, 1, 0, true)
+
+	pollCheck(t, client, req, pb.Allowed_ALLOWED_FALSE, defaultPollTimeout)
+
+	// Step 3: Re-report (revive) -> TRUE
+	reportResource(t, client, "host", "hbi", inst, id, ws)
+	t.Cleanup(func() { deleteResource(t, client, "host", id, "hbi", inst) })
+
+	// After revive: generation=1, rep_version=0, tombstone=false
+	assertReporterResource(t, id, "hbi", "host", 0, 1, false)
+	rr = findReporterResource(t, id, "hbi", "host")
+	assertReporterRepresentation(t, rr.ID, 0, 1, false)
+	res = findResourceByReporterKey(t, id, "hbi", "host")
+	assertCommonRepresentation(t, res.ID, 1, ws)
+
+	pollCheck(t, client, req, pb.Allowed_ALLOWED_TRUE, defaultPollTimeout)
+}
+
+func TestSanity_MultiResourceChurn(t *testing.T) {
+	client := newClient(t)
+	idA := uniqueID("churn-a")
+	idB := uniqueID("churn-b")
+	idC := uniqueID("churn-c")
+	ws := uniqueID("ws-churn")
+	inst := "inst-1"
+
+	// Step 1: Report 3 hosts
+	reportResource(t, client, "host", "hbi", inst, idA, ws)
+	reportResource(t, client, "host", "hbi", inst, idB, ws)
+	reportResource(t, client, "host", "hbi", inst, idC, ws)
+
+	for _, id := range []string{idA, idB, idC} {
+		assertReporterResource(t, id, "hbi", "host", 0, 0, false)
+	}
+
+	reqA := makeCheckReq("host", idA, "hbi", proto.String(inst), ws)
+	reqB := makeCheckReq("host", idB, "hbi", proto.String(inst), ws)
+	reqC := makeCheckReq("host", idC, "hbi", proto.String(inst), ws)
+
+	pollCheck(t, client, reqA, pb.Allowed_ALLOWED_TRUE, defaultPollTimeout)
+	pollCheck(t, client, reqB, pb.Allowed_ALLOWED_TRUE, defaultPollTimeout)
+	pollCheck(t, client, reqC, pb.Allowed_ALLOWED_TRUE, defaultPollTimeout)
+
+	// Step 2: Delete host-b
+	deleteResource(t, client, "host", idB, "hbi", inst)
+
+	assertReporterResource(t, idA, "hbi", "host", 0, 0, false) // unchanged
+	assertReporterResource(t, idB, "hbi", "host", 1, 0, true)  // tombstoned
+	assertReporterResource(t, idC, "hbi", "host", 0, 0, false) // unchanged
+
+	pollCheck(t, client, reqB, pb.Allowed_ALLOWED_FALSE, defaultPollTimeout)
+	// A and C should still be TRUE (no change needed, already confirmed)
+
+	// Step 3: Delete host-a and host-c
+	deleteResource(t, client, "host", idA, "hbi", inst)
+	deleteResource(t, client, "host", idC, "hbi", inst)
+
+	for _, id := range []string{idA, idB, idC} {
+		assertReporterResource(t, id, "hbi", "host", 1, 0, true)
+	}
+
+	pollCheck(t, client, reqA, pb.Allowed_ALLOWED_FALSE, defaultPollTimeout)
+	pollCheck(t, client, reqC, pb.Allowed_ALLOWED_FALSE, defaultPollTimeout)
+}

--- a/test/e2e/sanity/sanity_test.go
+++ b/test/e2e/sanity/sanity_test.go
@@ -1,0 +1,516 @@
+package sanity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	datamodel "github.com/project-kessel/inventory-api/internal/data/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	grpcinsecure "google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+)
+
+var (
+	grpcURL string
+	db      *gorm.DB
+)
+
+// --- Test report infrastructure ---
+
+type stepEntry struct {
+	action      string
+	dbState     string
+	checkResult string
+}
+
+type testReportCollector struct {
+	mu      sync.Mutex
+	order   []string
+	steps   map[string][]stepEntry
+	results map[string]string
+	count   int
+}
+
+var report = &testReportCollector{
+	steps:   make(map[string][]stepEntry),
+	results: make(map[string]string),
+}
+
+func (r *testReportCollector) startTest(testName string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.count++
+	n := r.count
+	sep := strings.Repeat("─", 80)
+	_, _ = fmt.Fprintf(os.Stdout, "\n%s%s%s\n", colorDim, sep, colorReset)
+	_, _ = fmt.Fprintf(os.Stdout, "%s[%d] %s%s\n", colorBold, n, testName, colorReset)
+	_, _ = fmt.Fprintf(os.Stdout, "%s%s%s\n", colorDim, sep, colorReset)
+	return n
+}
+
+func (r *testReportCollector) addStep(testName, action, dbState, checkResult string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.steps[testName]; !exists {
+		r.order = append(r.order, testName)
+	}
+	r.steps[testName] = append(r.steps[testName], stepEntry{
+		action:      action,
+		dbState:     dbState,
+		checkResult: checkResult,
+	})
+}
+
+func (r *testReportCollector) setResult(testName, result string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.results[testName] = result
+}
+
+const (
+	colorReset  = "\033[0m"
+	colorRed    = "\033[31m"
+	colorGreen  = "\033[32m"
+	colorYellow = "\033[33m"
+	colorCyan   = "\033[36m"
+	colorBold   = "\033[1m"
+	colorDim    = "\033[2m"
+)
+
+func printReport() {
+	report.mu.Lock()
+	defer report.mu.Unlock()
+
+	separator := strings.Repeat("═", 80)
+	_, _ = fmt.Fprintf(os.Stdout, "\n%s%s%s\n", colorBold, separator, colorReset)
+	_, _ = fmt.Fprintf(os.Stdout, "%s  SANITY TEST REPORT%s\n", colorBold, colorReset)
+	_, _ = fmt.Fprintf(os.Stdout, "%s%s%s\n\n", colorBold, separator, colorReset)
+
+	passed, failed, total := 0, 0, 0
+	for _, name := range report.order {
+		total++
+		result := report.results[name]
+		var resultColor string
+		switch result {
+		case "PASS":
+			resultColor = colorGreen
+			passed++
+		case "FAIL":
+			resultColor = colorRed
+			failed++
+		default:
+			result = "?"
+			resultColor = colorYellow
+		}
+
+		_, _ = fmt.Fprintf(os.Stdout, "%s▸ [%d] %s%s  %s[%s]%s\n",
+			colorBold, total, name, colorReset, resultColor, result, colorReset)
+
+		steps := report.steps[name]
+		for i, s := range steps {
+			stepNum := fmt.Sprintf("%d", i+1)
+
+			_, _ = fmt.Fprintf(os.Stdout, "  %s%s.%s %s\n",
+				colorCyan, stepNum, colorReset, s.action)
+
+			if s.dbState != "" {
+				_, _ = fmt.Fprintf(os.Stdout, "     %sDB: %s%s\n",
+					colorDim, s.dbState, colorReset)
+			}
+			if s.checkResult != "" {
+				resultColor := colorGreen
+				if strings.Contains(s.checkResult, "FALSE") || strings.Contains(s.checkResult, "TIMEOUT") || strings.Contains(s.checkResult, "error") {
+					resultColor = colorYellow
+				}
+				_, _ = fmt.Fprintf(os.Stdout, "     %s→ %s%s\n",
+					resultColor, s.checkResult, colorReset)
+			}
+		}
+		_, _ = fmt.Fprintln(os.Stdout)
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "%s%s%s\n", colorBold, strings.Repeat("─", 80), colorReset)
+	_, _ = fmt.Fprintf(os.Stdout, "  Total: %d  |  %sPassed: %d%s  |  %sFailed: %d%s\n",
+		total, colorGreen, passed, colorReset, colorRed, failed, colorReset)
+	_, _ = fmt.Fprintf(os.Stdout, "%s%s%s\n\n", colorBold, strings.Repeat("─", 80), colorReset)
+}
+
+// --- TestMain ---
+
+func TestMain(m *testing.M) {
+	grpcURL = envOr("INV_GRPC_URL", "localhost:9000")
+
+	dsn := fmt.Sprintf("host=%s user=%s password=%s port=%s dbname=%s sslmode=disable",
+		envOr("POSTGRES_HOST", "localhost"),
+		envOr("POSTGRES_USER", "postgres"),
+		envOr("POSTGRES_PASSWORD", ""),
+		envOr("POSTGRES_PORT", "5432"),
+		envOr("POSTGRES_DB", "kessel-inventory"),
+	)
+	var err error
+	db, err = gorm.Open(postgres.Open(dsn), &gorm.Config{TranslateError: true})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: failed to connect to database: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	printReport()
+	os.Exit(code)
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// --- gRPC helpers ---
+
+type bearerAuth struct {
+	token string
+}
+
+func (b *bearerAuth) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {
+	return map[string]string{"authorization": fmt.Sprintf("Bearer %s", b.token)}, nil
+}
+
+func (b *bearerAuth) RequireTransportSecurity() bool { return false }
+
+func newClient(t *testing.T) pb.KesselInventoryServiceClient {
+	t.Helper()
+	report.startTest(t.Name())
+	conn, err := grpc.NewClient(
+		grpcURL,
+		grpc.WithTransportCredentials(grpcinsecure.NewCredentials()),
+		grpc.WithPerRPCCredentials(&bearerAuth{token: "1234"}),
+	)
+	require.NoError(t, err, "Failed to create gRPC client")
+	t.Cleanup(func() {
+		_ = conn.Close()
+		if t.Failed() {
+			report.setResult(t.Name(), "FAIL")
+		} else {
+			report.setResult(t.Name(), "PASS")
+		}
+	})
+	conn.Connect()
+	return pb.NewKesselInventoryServiceClient(conn)
+}
+
+func uniqueID(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+}
+
+// --- DB snapshot for report ---
+
+func snapshotDBState(localResourceId, reporterType, resourceType string) string {
+	var rr datamodel.ReporterResource
+	err := db.Where("local_resource_id = ? AND reporter_type = ? AND resource_type = ?",
+		localResourceId, reporterType, resourceType).
+		First(&rr).Error
+	if err != nil {
+		return "not found"
+	}
+	return fmt.Sprintf("ver=%d gen=%d tombstone=%v", rr.RepresentationVersion, rr.Generation, rr.Tombstone)
+}
+
+// --- API action helpers ---
+
+func reportResource(t *testing.T, client pb.KesselInventoryServiceClient,
+	resourceType, reporterType, instanceId, localResourceId, workspaceId string,
+) {
+	t.Helper()
+	reporterStruct, err := structpb.NewStruct(map[string]interface{}{
+		"ansible_host": "test-host.example.com",
+	})
+	require.NoError(t, err)
+
+	_, err = client.ReportResource(context.Background(), &pb.ReportResourceRequest{
+		WriteVisibility:    pb.WriteVisibility_MINIMIZE_LATENCY,
+		Type:               resourceType,
+		ReporterType:       reporterType,
+		ReporterInstanceId: instanceId,
+		Representations: &pb.ResourceRepresentations{
+			Metadata: &pb.RepresentationMetadata{
+				LocalResourceId: localResourceId,
+				ApiHref:         "https://example.com/api",
+				ConsoleHref:     proto.String("https://example.com/console"),
+				ReporterVersion: proto.String("0.1"),
+			},
+			Common: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"workspace_id": structpb.NewStringValue(workspaceId),
+				},
+			},
+			Reporter: reporterStruct,
+		},
+	})
+	require.NoError(t, err, "ReportResource failed")
+
+	dbState := snapshotDBState(localResourceId, reporterType, resourceType)
+	report.addStep(t.Name(),
+		fmt.Sprintf("ReportResource %s/%s (%s, workspace=%s)", resourceType, localResourceId, reporterType, workspaceId),
+		dbState, "")
+}
+
+func deleteResource(t *testing.T, client pb.KesselInventoryServiceClient,
+	resourceType, localResourceId, reporterType, instanceId string,
+) {
+	t.Helper()
+	_, err := client.DeleteResource(context.Background(), &pb.DeleteResourceRequest{
+		Reference: &pb.ResourceReference{
+			ResourceType: resourceType,
+			ResourceId:   localResourceId,
+			Reporter: &pb.ReporterReference{
+				Type:       reporterType,
+				InstanceId: proto.String(instanceId),
+			},
+		},
+	})
+	require.NoError(t, err, "DeleteResource failed")
+
+	dbState := snapshotDBState(localResourceId, reporterType, resourceType)
+	report.addStep(t.Name(),
+		fmt.Sprintf("DeleteResource %s/%s (%s)", resourceType, localResourceId, reporterType),
+		dbState, "")
+}
+
+func makeCheckReq(resourceType, resourceId, reporterType string, instanceId *string, workspaceId string) *pb.CheckRequest {
+	reporter := &pb.ReporterReference{Type: reporterType}
+	if instanceId != nil {
+		reporter.InstanceId = instanceId
+	}
+	return &pb.CheckRequest{
+		Object: &pb.ResourceReference{
+			ResourceType: resourceType,
+			ResourceId:   resourceId,
+			Reporter:     reporter,
+		},
+		Relation: "workspace",
+		Subject: &pb.SubjectReference{
+			Resource: &pb.ResourceReference{
+				ResourceType: "workspace",
+				ResourceId:   workspaceId,
+				Reporter:     &pb.ReporterReference{Type: "rbac"},
+			},
+		},
+	}
+}
+
+func makeCheckForUpdateReq(resourceType, resourceId, reporterType string, instanceId *string, workspaceId string) *pb.CheckForUpdateRequest {
+	reporter := &pb.ReporterReference{Type: reporterType}
+	if instanceId != nil {
+		reporter.InstanceId = instanceId
+	}
+	return &pb.CheckForUpdateRequest{
+		Object: &pb.ResourceReference{
+			ResourceType: resourceType,
+			ResourceId:   resourceId,
+			Reporter:     reporter,
+		},
+		Relation: "workspace",
+		Subject: &pb.SubjectReference{
+			Resource: &pb.ResourceReference{
+				ResourceType: "workspace",
+				ResourceId:   workspaceId,
+				Reporter:     &pb.ReporterReference{Type: "rbac"},
+			},
+		},
+	}
+}
+
+const (
+	maxConsecutiveConnErrors = 5
+	defaultPollTimeout       = 30
+)
+
+func checkActionLabel(req *pb.CheckRequest) string {
+	return fmt.Sprintf("Check %s/%s (workspace=%s)",
+		req.GetObject().GetResourceType(),
+		req.GetObject().GetResourceId(),
+		req.GetSubject().GetResource().GetResourceId())
+}
+
+func pollCheck(t *testing.T, client pb.KesselInventoryServiceClient,
+	req *pb.CheckRequest, expected pb.Allowed, timeoutSec int,
+) *pb.ConsistencyToken {
+	t.Helper()
+	ctx := context.Background()
+	connErrors := 0
+	label := checkActionLabel(req)
+
+	for i := 0; i < timeoutSec; i++ {
+		resp, err := client.Check(ctx, req)
+		if err == nil && resp.GetAllowed() == expected {
+			t.Logf("Check returned %v on attempt %d", expected, i+1)
+			report.addStep(t.Name(), label, "",
+				fmt.Sprintf("%v (attempt %d)", expected, i+1))
+			return resp.GetConsistencyToken()
+		}
+		if err != nil {
+			t.Logf("Check attempt %d: %v", i+1, err)
+			if isConnectionError(err) {
+				connErrors++
+				if connErrors >= maxConsecutiveConnErrors {
+					report.addStep(t.Name(), label, "",
+						fmt.Sprintf("UNREACHABLE after %d conn errors", connErrors))
+					t.Fatalf("Service unreachable after %d consecutive connection errors", connErrors)
+				}
+			}
+		} else {
+			connErrors = 0
+			t.Logf("Check attempt %d: got %v, want %v", i+1, resp.GetAllowed(), expected)
+		}
+		time.Sleep(1 * time.Second)
+	}
+	report.addStep(t.Name(), label, "",
+		fmt.Sprintf("TIMEOUT waiting for %v after %ds", expected, timeoutSec))
+	t.Fatalf("Check did not return %v within %ds", expected, timeoutSec)
+	return nil
+}
+
+func checkForUpdateActionLabel(req *pb.CheckForUpdateRequest) string {
+	return fmt.Sprintf("CheckForUpdate %s/%s (workspace=%s)",
+		req.GetObject().GetResourceType(),
+		req.GetObject().GetResourceId(),
+		req.GetSubject().GetResource().GetResourceId())
+}
+
+func pollCheckForUpdate(t *testing.T, client pb.KesselInventoryServiceClient,
+	req *pb.CheckForUpdateRequest, expected pb.Allowed, timeoutSec int,
+) *pb.CheckForUpdateResponse {
+	t.Helper()
+	ctx := context.Background()
+	connErrors := 0
+	label := checkForUpdateActionLabel(req)
+
+	for i := 0; i < timeoutSec; i++ {
+		resp, err := client.CheckForUpdate(ctx, req)
+		if err == nil && resp.GetAllowed() == expected {
+			t.Logf("CheckForUpdate returned %v on attempt %d", expected, i+1)
+			tokenInfo := ""
+			if resp.GetConsistencyToken() != nil && resp.GetConsistencyToken().GetToken() != "" {
+				tokenInfo = " +token"
+			}
+			report.addStep(t.Name(), label, "",
+				fmt.Sprintf("%v (attempt %d)%s", expected, i+1, tokenInfo))
+			return resp
+		}
+		if err != nil {
+			t.Logf("CheckForUpdate attempt %d: %v", i+1, err)
+			if isConnectionError(err) {
+				connErrors++
+				if connErrors >= maxConsecutiveConnErrors {
+					report.addStep(t.Name(), label, "",
+						fmt.Sprintf("UNREACHABLE after %d conn errors", connErrors))
+					t.Fatalf("Service unreachable after %d consecutive connection errors", connErrors)
+				}
+			}
+		} else {
+			connErrors = 0
+			t.Logf("CheckForUpdate attempt %d: got %v, want %v", i+1, resp.GetAllowed(), expected)
+		}
+		time.Sleep(1 * time.Second)
+	}
+	report.addStep(t.Name(), label, "",
+		fmt.Sprintf("TIMEOUT waiting for %v after %ds", expected, timeoutSec))
+	t.Fatalf("CheckForUpdate did not return %v within %ds", expected, timeoutSec)
+	return nil
+}
+
+func isConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "transport is closing")
+}
+
+// recordBulkResult records a bulk check result in the report without polling.
+func recordBulkResult(t *testing.T, action string, results []string) {
+	t.Helper()
+	report.addStep(t.Name(), action, "", strings.Join(results, ", "))
+}
+
+// recordError records an expected error in the report.
+func recordError(t *testing.T, action string, err error) {
+	t.Helper()
+	report.addStep(t.Name(), action, "", fmt.Sprintf("error: %v", err))
+}
+
+// --- DB assertion helpers ---
+
+func findReporterResource(t *testing.T, localResourceId, reporterType, resourceType string) datamodel.ReporterResource {
+	t.Helper()
+	var rr datamodel.ReporterResource
+	err := db.Where("local_resource_id = ? AND reporter_type = ? AND resource_type = ?",
+		localResourceId, reporterType, resourceType).
+		First(&rr).Error
+	require.NoError(t, err, "reporter_resources row not found for %s/%s/%s", reporterType, resourceType, localResourceId)
+	return rr
+}
+
+func findResourceByReporterKey(t *testing.T, localResourceId, reporterType, resourceType string) datamodel.Resource {
+	t.Helper()
+	rr := findReporterResource(t, localResourceId, reporterType, resourceType)
+	var res datamodel.Resource
+	err := db.Where("id = ?", rr.ResourceID).First(&res).Error
+	require.NoError(t, err, "resource row not found for id %s", rr.ResourceID)
+	return res
+}
+
+func assertReporterResource(t *testing.T, localResourceId, reporterType, resourceType string,
+	expectedRepVersion, expectedGeneration uint, expectedTombstone bool,
+) {
+	t.Helper()
+	rr := findReporterResource(t, localResourceId, reporterType, resourceType)
+	assert.Equal(t, expectedRepVersion, rr.RepresentationVersion, "representation_version mismatch")
+	assert.Equal(t, expectedGeneration, rr.Generation, "generation mismatch")
+	assert.Equal(t, expectedTombstone, rr.Tombstone, "tombstone mismatch")
+}
+
+func assertReporterRepresentation(t *testing.T, reporterResourceID uuid.UUID,
+	expectedVersion, expectedGeneration uint, expectedTombstone bool,
+) {
+	t.Helper()
+	var rep datamodel.ReporterRepresentation
+	err := db.Where("reporter_resource_id = ? AND version = ? AND generation = ?",
+		reporterResourceID, expectedVersion, expectedGeneration).
+		First(&rep).Error
+	require.NoError(t, err, "reporter_representations row not found for rrID=%s version=%d gen=%d",
+		reporterResourceID, expectedVersion, expectedGeneration)
+	assert.Equal(t, expectedTombstone, rep.Tombstone, "reporter_representations tombstone mismatch")
+}
+
+func assertCommonRepresentation(t *testing.T, resourceID uuid.UUID, expectedVersion uint, expectedWorkspaceId string) {
+	t.Helper()
+	var cr datamodel.CommonRepresentation
+	err := db.Where("resource_id = ? AND version = ?", resourceID, expectedVersion).
+		First(&cr).Error
+	require.NoError(t, err, "common_representations row not found for resourceID=%s version=%d",
+		resourceID, expectedVersion)
+
+	raw, err := json.Marshal(cr.Data)
+	require.NoError(t, err)
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &data))
+	assert.Equal(t, expectedWorkspaceId, data["workspace_id"], "workspace_id mismatch in common_representations")
+}

--- a/test/e2e/sanity/sanity_test.go
+++ b/test/e2e/sanity/sanity_test.go
@@ -1,3 +1,5 @@
+//go:build sanity
+
 package sanity
 
 import (

--- a/test/e2e/sanity/sanity_test.go
+++ b/test/e2e/sanity/sanity_test.go
@@ -33,8 +33,19 @@ var (
 
 // --- Test report infrastructure ---
 
+type testSpec struct {
+	description string
+	given       string
+	when        string
+	then        string
+	rpc         string
+}
+
 type stepEntry struct {
+	phase       string // "given", "when", "then"
 	action      string
+	input       string
+	output      string
 	dbState     string
 	checkResult string
 }
@@ -42,14 +53,22 @@ type stepEntry struct {
 type testReportCollector struct {
 	mu      sync.Mutex
 	order   []string
+	specs   map[string]testSpec
 	steps   map[string][]stepEntry
 	results map[string]string
 	count   int
 }
 
 var report = &testReportCollector{
+	specs:   make(map[string]testSpec),
 	steps:   make(map[string][]stepEntry),
 	results: make(map[string]string),
+}
+
+func (r *testReportCollector) describe(testName string, spec testSpec) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.specs[testName] = spec
 }
 
 func (r *testReportCollector) startTest(testName string) int {
@@ -60,6 +79,9 @@ func (r *testReportCollector) startTest(testName string) int {
 	sep := strings.Repeat("─", 80)
 	_, _ = fmt.Fprintf(os.Stdout, "\n%s%s%s\n", colorDim, sep, colorReset)
 	_, _ = fmt.Fprintf(os.Stdout, "%s[%d] %s%s\n", colorBold, n, testName, colorReset)
+	if spec, ok := r.specs[testName]; ok {
+		_, _ = fmt.Fprintf(os.Stdout, "  %s%s%s\n", colorDim, spec.description, colorReset)
+	}
 	_, _ = fmt.Fprintf(os.Stdout, "%s%s%s\n", colorDim, sep, colorReset)
 	return n
 }
@@ -77,6 +99,15 @@ func (r *testReportCollector) addStep(testName, action, dbState, checkResult str
 	})
 }
 
+func (r *testReportCollector) addDetailedStep(testName string, step stepEntry) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.steps[testName]; !exists {
+		r.order = append(r.order, testName)
+	}
+	r.steps[testName] = append(r.steps[testName], step)
+}
+
 func (r *testReportCollector) setResult(testName, result string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -89,6 +120,7 @@ const (
 	colorGreen  = "\033[32m"
 	colorYellow = "\033[33m"
 	colorCyan   = "\033[36m"
+	colorBlue   = "\033[34m"
 	colorBold   = "\033[1m"
 	colorDim    = "\033[2m"
 )
@@ -97,7 +129,7 @@ func printReport() {
 	report.mu.Lock()
 	defer report.mu.Unlock()
 
-	separator := strings.Repeat("═", 80)
+	separator := strings.Repeat("═", 90)
 	_, _ = fmt.Fprintf(os.Stdout, "\n%s%s%s\n", colorBold, separator, colorReset)
 	_, _ = fmt.Fprintf(os.Stdout, "%s  SANITY TEST REPORT%s\n", colorBold, colorReset)
 	_, _ = fmt.Fprintf(os.Stdout, "%s%s%s\n\n", colorBold, separator, colorReset)
@@ -122,33 +154,51 @@ func printReport() {
 		_, _ = fmt.Fprintf(os.Stdout, "%s▸ [%d] %s%s  %s[%s]%s\n",
 			colorBold, total, name, colorReset, resultColor, result, colorReset)
 
+		if spec, ok := report.specs[name]; ok {
+			_, _ = fmt.Fprintf(os.Stdout, "  %sDescription:%s %s\n", colorDim, colorReset, spec.description)
+			_, _ = fmt.Fprintf(os.Stdout, "  %sRPC:%s         %s\n", colorDim, colorReset, spec.rpc)
+			_, _ = fmt.Fprintf(os.Stdout, "  %sGiven:%s       %s\n", colorBlue, colorReset, spec.given)
+			_, _ = fmt.Fprintf(os.Stdout, "  %sWhen:%s        %s\n", colorBlue, colorReset, spec.when)
+			_, _ = fmt.Fprintf(os.Stdout, "  %sThen:%s        %s\n", colorBlue, colorReset, spec.then)
+		}
+
+		_, _ = fmt.Fprintf(os.Stdout, "  %sSteps:%s\n", colorDim, colorReset)
 		steps := report.steps[name]
 		for i, s := range steps {
 			stepNum := fmt.Sprintf("%d", i+1)
 
-			_, _ = fmt.Fprintf(os.Stdout, "  %s%s.%s %s\n",
-				colorCyan, stepNum, colorReset, s.action)
+			phaseLabel := ""
+			if s.phase != "" {
+				phaseLabel = fmt.Sprintf(" %s[%s]%s", colorBlue, s.phase, colorReset)
+			}
 
+			_, _ = fmt.Fprintf(os.Stdout, "    %s%s.%s%s %s\n",
+				colorCyan, stepNum, colorReset, phaseLabel, s.action)
+
+			if s.input != "" {
+				_, _ = fmt.Fprintf(os.Stdout, "       %sInput:  %s%s\n", colorDim, s.input, colorReset)
+			}
 			if s.dbState != "" {
-				_, _ = fmt.Fprintf(os.Stdout, "     %sDB: %s%s\n",
-					colorDim, s.dbState, colorReset)
+				_, _ = fmt.Fprintf(os.Stdout, "       %sDB:     %s%s\n", colorDim, s.dbState, colorReset)
+			}
+			if s.output != "" {
+				_, _ = fmt.Fprintf(os.Stdout, "       %sOutput: %s%s\n", colorDim, s.output, colorReset)
 			}
 			if s.checkResult != "" {
 				resultColor := colorGreen
 				if strings.Contains(s.checkResult, "FALSE") || strings.Contains(s.checkResult, "TIMEOUT") || strings.Contains(s.checkResult, "error") {
 					resultColor = colorYellow
 				}
-				_, _ = fmt.Fprintf(os.Stdout, "     %s→ %s%s\n",
-					resultColor, s.checkResult, colorReset)
+				_, _ = fmt.Fprintf(os.Stdout, "       %s→ %s%s\n", resultColor, s.checkResult, colorReset)
 			}
 		}
 		_, _ = fmt.Fprintln(os.Stdout)
 	}
 
-	_, _ = fmt.Fprintf(os.Stdout, "%s%s%s\n", colorBold, strings.Repeat("─", 80), colorReset)
+	_, _ = fmt.Fprintf(os.Stdout, "%s%s%s\n", colorBold, strings.Repeat("─", 90), colorReset)
 	_, _ = fmt.Fprintf(os.Stdout, "  Total: %d  |  %sPassed: %d%s  |  %sFailed: %d%s\n",
 		total, colorGreen, passed, colorReset, colorRed, failed, colorReset)
-	_, _ = fmt.Fprintf(os.Stdout, "%s%s%s\n\n", colorBold, strings.Repeat("─", 80), colorReset)
+	_, _ = fmt.Fprintf(os.Stdout, "%s%s%s\n\n", colorBold, strings.Repeat("─", 90), colorReset)
 }
 
 // --- TestMain ---
@@ -266,9 +316,13 @@ func reportResource(t *testing.T, client pb.KesselInventoryServiceClient,
 	require.NoError(t, err, "ReportResource failed")
 
 	dbState := snapshotDBState(localResourceId, reporterType, resourceType)
-	report.addStep(t.Name(),
-		fmt.Sprintf("ReportResource %s/%s (%s, workspace=%s)", resourceType, localResourceId, reporterType, workspaceId),
-		dbState, "")
+	report.addDetailedStep(t.Name(), stepEntry{
+		phase:  "given",
+		action: fmt.Sprintf("ReportResource %s/%s (%s)", resourceType, localResourceId, reporterType),
+		input:  fmt.Sprintf("type=%s reporter=%s instance=%s local_id=%s workspace=%s", resourceType, reporterType, instanceId, localResourceId, workspaceId),
+		output: "ok",
+		dbState: dbState,
+	})
 }
 
 func deleteResource(t *testing.T, client pb.KesselInventoryServiceClient,
@@ -288,9 +342,13 @@ func deleteResource(t *testing.T, client pb.KesselInventoryServiceClient,
 	require.NoError(t, err, "DeleteResource failed")
 
 	dbState := snapshotDBState(localResourceId, reporterType, resourceType)
-	report.addStep(t.Name(),
-		fmt.Sprintf("DeleteResource %s/%s (%s)", resourceType, localResourceId, reporterType),
-		dbState, "")
+	report.addDetailedStep(t.Name(), stepEntry{
+		phase:   "when",
+		action:  fmt.Sprintf("DeleteResource %s/%s (%s)", resourceType, localResourceId, reporterType),
+		input:   fmt.Sprintf("type=%s local_id=%s reporter=%s instance=%s", resourceType, localResourceId, reporterType, instanceId),
+		output:  "ok",
+		dbState: dbState,
+	})
 }
 
 func makeCheckReq(resourceType, resourceId, reporterType string, instanceId *string, workspaceId string) *pb.CheckRequest {
@@ -357,12 +415,22 @@ func pollCheck(t *testing.T, client pb.KesselInventoryServiceClient,
 	connErrors := 0
 	label := checkActionLabel(req)
 
+	inputDesc := fmt.Sprintf("object=%s/%s relation=%s subject=%s/%s",
+		req.GetObject().GetResourceType(), req.GetObject().GetResourceId(),
+		req.GetRelation(),
+		req.GetSubject().GetResource().GetResourceType(), req.GetSubject().GetResource().GetResourceId())
+
 	for i := 0; i < timeoutSec; i++ {
 		resp, err := client.Check(ctx, req)
 		if err == nil && resp.GetAllowed() == expected {
 			t.Logf("Check returned %v on attempt %d", expected, i+1)
-			report.addStep(t.Name(), label, "",
-				fmt.Sprintf("%v (attempt %d)", expected, i+1))
+			report.addDetailedStep(t.Name(), stepEntry{
+				phase:       "then",
+				action:      label,
+				input:       inputDesc,
+				output:      fmt.Sprintf("allowed=%v", expected),
+				checkResult: fmt.Sprintf("%v (attempt %d)", expected, i+1),
+			})
 			return resp.GetConsistencyToken()
 		}
 		if err != nil {
@@ -370,8 +438,12 @@ func pollCheck(t *testing.T, client pb.KesselInventoryServiceClient,
 			if isConnectionError(err) {
 				connErrors++
 				if connErrors >= maxConsecutiveConnErrors {
-					report.addStep(t.Name(), label, "",
-						fmt.Sprintf("UNREACHABLE after %d conn errors", connErrors))
+					report.addDetailedStep(t.Name(), stepEntry{
+						phase:       "then",
+						action:      label,
+						input:       inputDesc,
+						checkResult: fmt.Sprintf("UNREACHABLE after %d conn errors", connErrors),
+					})
 					t.Fatalf("Service unreachable after %d consecutive connection errors", connErrors)
 				}
 			}
@@ -381,8 +453,12 @@ func pollCheck(t *testing.T, client pb.KesselInventoryServiceClient,
 		}
 		time.Sleep(1 * time.Second)
 	}
-	report.addStep(t.Name(), label, "",
-		fmt.Sprintf("TIMEOUT waiting for %v after %ds", expected, timeoutSec))
+	report.addDetailedStep(t.Name(), stepEntry{
+		phase:       "then",
+		action:      label,
+		input:       inputDesc,
+		checkResult: fmt.Sprintf("TIMEOUT waiting for %v after %ds", expected, timeoutSec),
+	})
 	t.Fatalf("Check did not return %v within %ds", expected, timeoutSec)
 	return nil
 }
@@ -402,6 +478,11 @@ func pollCheckForUpdate(t *testing.T, client pb.KesselInventoryServiceClient,
 	connErrors := 0
 	label := checkForUpdateActionLabel(req)
 
+	inputDesc := fmt.Sprintf("object=%s/%s relation=%s subject=%s/%s",
+		req.GetObject().GetResourceType(), req.GetObject().GetResourceId(),
+		req.GetRelation(),
+		req.GetSubject().GetResource().GetResourceType(), req.GetSubject().GetResource().GetResourceId())
+
 	for i := 0; i < timeoutSec; i++ {
 		resp, err := client.CheckForUpdate(ctx, req)
 		if err == nil && resp.GetAllowed() == expected {
@@ -410,8 +491,13 @@ func pollCheckForUpdate(t *testing.T, client pb.KesselInventoryServiceClient,
 			if resp.GetConsistencyToken() != nil && resp.GetConsistencyToken().GetToken() != "" {
 				tokenInfo = " +token"
 			}
-			report.addStep(t.Name(), label, "",
-				fmt.Sprintf("%v (attempt %d)%s", expected, i+1, tokenInfo))
+			report.addDetailedStep(t.Name(), stepEntry{
+				phase:       "then",
+				action:      label,
+				input:       inputDesc,
+				output:      fmt.Sprintf("allowed=%v%s", expected, tokenInfo),
+				checkResult: fmt.Sprintf("%v (attempt %d)%s", expected, i+1, tokenInfo),
+			})
 			return resp
 		}
 		if err != nil {
@@ -419,8 +505,12 @@ func pollCheckForUpdate(t *testing.T, client pb.KesselInventoryServiceClient,
 			if isConnectionError(err) {
 				connErrors++
 				if connErrors >= maxConsecutiveConnErrors {
-					report.addStep(t.Name(), label, "",
-						fmt.Sprintf("UNREACHABLE after %d conn errors", connErrors))
+					report.addDetailedStep(t.Name(), stepEntry{
+						phase:       "then",
+						action:      label,
+						input:       inputDesc,
+						checkResult: fmt.Sprintf("UNREACHABLE after %d conn errors", connErrors),
+					})
 					t.Fatalf("Service unreachable after %d consecutive connection errors", connErrors)
 				}
 			}
@@ -430,8 +520,12 @@ func pollCheckForUpdate(t *testing.T, client pb.KesselInventoryServiceClient,
 		}
 		time.Sleep(1 * time.Second)
 	}
-	report.addStep(t.Name(), label, "",
-		fmt.Sprintf("TIMEOUT waiting for %v after %ds", expected, timeoutSec))
+	report.addDetailedStep(t.Name(), stepEntry{
+		phase:       "then",
+		action:      label,
+		input:       inputDesc,
+		checkResult: fmt.Sprintf("TIMEOUT waiting for %v after %ds", expected, timeoutSec),
+	})
 	t.Fatalf("CheckForUpdate did not return %v within %ds", expected, timeoutSec)
 	return nil
 }
@@ -449,13 +543,23 @@ func isConnectionError(err error) bool {
 // recordBulkResult records a bulk check result in the report without polling.
 func recordBulkResult(t *testing.T, action string, results []string) {
 	t.Helper()
-	report.addStep(t.Name(), action, "", strings.Join(results, ", "))
+	report.addDetailedStep(t.Name(), stepEntry{
+		phase:       "then",
+		action:      action,
+		output:      strings.Join(results, ", "),
+		checkResult: fmt.Sprintf("%d results returned", len(results)),
+	})
 }
 
 // recordError records an expected error in the report.
 func recordError(t *testing.T, action string, err error) {
 	t.Helper()
-	report.addStep(t.Name(), action, "", fmt.Sprintf("error: %v", err))
+	report.addDetailedStep(t.Name(), stepEntry{
+		phase:       "then",
+		action:      action,
+		output:      fmt.Sprintf("error: %v", err),
+		checkResult: "expected error received ✓",
+	})
 }
 
 // --- DB assertion helpers ---

--- a/test/e2e/sanity/streaming_test.go
+++ b/test/e2e/sanity/streaming_test.go
@@ -1,3 +1,5 @@
+//go:build sanity
+
 package sanity
 
 import (

--- a/test/e2e/sanity/streaming_test.go
+++ b/test/e2e/sanity/streaming_test.go
@@ -20,6 +20,13 @@ import (
 // --- Group 7: Streaming ListObjects / ListSubjects ---
 
 func TestSanity_StreamedListObjects_ReturnsReportedResource(t *testing.T) {
+	report.describe(t.Name(), testSpec{
+		description: "StreamedListObjects returns a resource that was just reported",
+		rpc:         "ReportResource → Check → StreamedListObjects",
+		given:       "A host resource reported by HBI with a workspace, tuple confirmed via Check",
+		when:        "StreamedListObjects is called with the workspace as subject",
+		then:        "The stream includes the reported resource ID",
+	})
 	client := newClient(t)
 	id := uniqueID("stream-obj")
 	ws := uniqueID("ws-stream-obj")
@@ -53,12 +60,23 @@ func TestSanity_StreamedListObjects_ReturnsReportedResource(t *testing.T) {
 	resourceIDs := pollStreamedListObjects(t, client, listReq, id, defaultPollTimeout)
 	assert.Contains(t, resourceIDs, id, "expected reported resource in StreamedListObjects results")
 
-	report.addStep(t.Name(),
-		fmt.Sprintf("StreamedListObjects host (workspace=%s)", ws), "",
-		fmt.Sprintf("returned %d objects, contains %s", len(resourceIDs), id))
+	report.addDetailedStep(t.Name(), stepEntry{
+		phase:  "then",
+		action: "StreamedListObjects",
+		input:  fmt.Sprintf("object_type=host/hbi relation=workspace subject=workspace/%s", ws),
+		output: fmt.Sprintf("streamed %d objects", len(resourceIDs)),
+		checkResult: fmt.Sprintf("contains %s ✓", id),
+	})
 }
 
 func TestSanity_StreamedListObjects_EmptyAfterDelete(t *testing.T) {
+	report.describe(t.Name(), testSpec{
+		description: "StreamedListObjects excludes a resource after it is deleted",
+		rpc:         "ReportResource → Check → DeleteResource → Check → StreamedListObjects",
+		given:       "A host resource that was reported, confirmed accessible, then deleted",
+		when:        "StreamedListObjects is called after deletion is confirmed",
+		then:        "The stream does not include the deleted resource ID",
+	})
 	client := newClient(t)
 	id := uniqueID("stream-del")
 	ws := uniqueID("ws-stream-del")
@@ -95,12 +113,23 @@ func TestSanity_StreamedListObjects_EmptyAfterDelete(t *testing.T) {
 	resourceIDs := collectStreamedListObjects(t, client, listReq)
 	assert.NotContains(t, resourceIDs, id, "deleted resource should not appear in StreamedListObjects")
 
-	report.addStep(t.Name(),
-		fmt.Sprintf("StreamedListObjects host after delete (workspace=%s)", ws), "",
-		fmt.Sprintf("returned %d objects, does not contain %s", len(resourceIDs), id))
+	report.addDetailedStep(t.Name(), stepEntry{
+		phase:       "then",
+		action:      "StreamedListObjects after delete",
+		input:       fmt.Sprintf("object_type=host/hbi relation=workspace subject=workspace/%s", ws),
+		output:      fmt.Sprintf("streamed %d objects", len(resourceIDs)),
+		checkResult: fmt.Sprintf("does not contain %s ✓", id),
+	})
 }
 
 func TestSanity_StreamedListObjects_MultipleResources(t *testing.T) {
+	report.describe(t.Name(), testSpec{
+		description: "StreamedListObjects returns all resources in a workspace",
+		rpc:         "ReportResource ×2 → Check ×2 → StreamedListObjects",
+		given:       "Two host resources (A, B) reported in the same workspace",
+		when:        "StreamedListObjects is called with that workspace as subject",
+		then:        "The stream includes both resource IDs",
+	})
 	client := newClient(t)
 	idA := uniqueID("stream-multi-a")
 	idB := uniqueID("stream-multi-b")
@@ -141,12 +170,23 @@ func TestSanity_StreamedListObjects_MultipleResources(t *testing.T) {
 	assert.Contains(t, resourceIDs, idA, "expected host A in StreamedListObjects")
 	assert.Contains(t, resourceIDs, idB, "expected host B in StreamedListObjects")
 
-	report.addStep(t.Name(),
-		fmt.Sprintf("StreamedListObjects host (workspace=%s)", ws), "",
-		fmt.Sprintf("returned %d objects, contains both %s and %s", len(resourceIDs), idA, idB))
+	report.addDetailedStep(t.Name(), stepEntry{
+		phase:       "then",
+		action:      "StreamedListObjects (multiple resources)",
+		input:       fmt.Sprintf("object_type=host/hbi relation=workspace subject=workspace/%s", ws),
+		output:      fmt.Sprintf("streamed %d objects", len(resourceIDs)),
+		checkResult: fmt.Sprintf("contains %s and %s ✓", idA, idB),
+	})
 }
 
 func TestSanity_StreamedListSubjects_ReturnsWorkspace(t *testing.T) {
+	report.describe(t.Name(), testSpec{
+		description: "StreamedListSubjects returns the workspace that a resource belongs to",
+		rpc:         "ReportResource → Check → StreamedListSubjects",
+		given:       "A host resource reported with a workspace, tuple confirmed via Check",
+		when:        "StreamedListSubjects is called with the host as resource and relation=workspace",
+		then:        "The stream includes the workspace ID as a subject",
+	})
 	client := newClient(t)
 	id := uniqueID("stream-subj")
 	ws := uniqueID("ws-stream-subj")
@@ -177,9 +217,13 @@ func TestSanity_StreamedListSubjects_ReturnsWorkspace(t *testing.T) {
 	subjectIDs := pollStreamedListSubjects(t, client, listReq, ws, defaultPollTimeout)
 	assert.Contains(t, subjectIDs, ws, "expected workspace in StreamedListSubjects results")
 
-	report.addStep(t.Name(),
-		fmt.Sprintf("StreamedListSubjects host/%s relation=workspace", id), "",
-		fmt.Sprintf("returned %d subjects, contains %s", len(subjectIDs), ws))
+	report.addDetailedStep(t.Name(), stepEntry{
+		phase:       "then",
+		action:      "StreamedListSubjects",
+		input:       fmt.Sprintf("resource=host/%s reporter=hbi relation=workspace subject_type=workspace/rbac", id),
+		output:      fmt.Sprintf("streamed %d subjects", len(subjectIDs)),
+		checkResult: fmt.Sprintf("contains workspace %s ✓", ws),
+	})
 }
 
 // --- Streaming helpers ---

--- a/test/e2e/sanity/streaming_test.go
+++ b/test/e2e/sanity/streaming_test.go
@@ -1,0 +1,289 @@
+package sanity
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	pb "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+)
+
+// --- Group 7: Streaming ListObjects / ListSubjects ---
+
+func TestSanity_StreamedListObjects_ReturnsReportedResource(t *testing.T) {
+	client := newClient(t)
+	id := uniqueID("stream-obj")
+	ws := uniqueID("ws-stream-obj")
+	inst := "inst-1"
+
+	reportResource(t, client, "host", "hbi", inst, id, ws)
+	t.Cleanup(func() { deleteResource(t, client, "host", id, "hbi", inst) })
+
+	assertReporterResource(t, id, "hbi", "host", 0, 0, false)
+
+	// Wait for the tuple to propagate
+	req := makeCheckReq("host", id, "hbi", proto.String(inst), ws)
+	pollCheck(t, client, req, pb.Allowed_ALLOWED_TRUE, defaultPollTimeout)
+
+	reporterType := "hbi"
+	listReq := &pb.StreamedListObjectsRequest{
+		ObjectType: &pb.RepresentationType{
+			ResourceType: "host",
+			ReporterType: &reporterType,
+		},
+		Relation: "workspace",
+		Subject: &pb.SubjectReference{
+			Resource: &pb.ResourceReference{
+				ResourceType: "workspace",
+				ResourceId:   ws,
+				Reporter:     &pb.ReporterReference{Type: "rbac"},
+			},
+		},
+	}
+
+	resourceIDs := pollStreamedListObjects(t, client, listReq, id, defaultPollTimeout)
+	assert.Contains(t, resourceIDs, id, "expected reported resource in StreamedListObjects results")
+
+	report.addStep(t.Name(),
+		fmt.Sprintf("StreamedListObjects host (workspace=%s)", ws), "",
+		fmt.Sprintf("returned %d objects, contains %s", len(resourceIDs), id))
+}
+
+func TestSanity_StreamedListObjects_EmptyAfterDelete(t *testing.T) {
+	client := newClient(t)
+	id := uniqueID("stream-del")
+	ws := uniqueID("ws-stream-del")
+	inst := "inst-1"
+
+	reportResource(t, client, "host", "hbi", inst, id, ws)
+
+	assertReporterResource(t, id, "hbi", "host", 0, 0, false)
+
+	checkReq := makeCheckReq("host", id, "hbi", proto.String(inst), ws)
+	pollCheck(t, client, checkReq, pb.Allowed_ALLOWED_TRUE, defaultPollTimeout)
+
+	deleteResource(t, client, "host", id, "hbi", inst)
+	assertReporterResource(t, id, "hbi", "host", 1, 0, true)
+
+	pollCheck(t, client, checkReq, pb.Allowed_ALLOWED_FALSE, defaultPollTimeout)
+
+	reporterType := "hbi"
+	listReq := &pb.StreamedListObjectsRequest{
+		ObjectType: &pb.RepresentationType{
+			ResourceType: "host",
+			ReporterType: &reporterType,
+		},
+		Relation: "workspace",
+		Subject: &pb.SubjectReference{
+			Resource: &pb.ResourceReference{
+				ResourceType: "workspace",
+				ResourceId:   ws,
+				Reporter:     &pb.ReporterReference{Type: "rbac"},
+			},
+		},
+	}
+
+	resourceIDs := collectStreamedListObjects(t, client, listReq)
+	assert.NotContains(t, resourceIDs, id, "deleted resource should not appear in StreamedListObjects")
+
+	report.addStep(t.Name(),
+		fmt.Sprintf("StreamedListObjects host after delete (workspace=%s)", ws), "",
+		fmt.Sprintf("returned %d objects, does not contain %s", len(resourceIDs), id))
+}
+
+func TestSanity_StreamedListObjects_MultipleResources(t *testing.T) {
+	client := newClient(t)
+	idA := uniqueID("stream-multi-a")
+	idB := uniqueID("stream-multi-b")
+	ws := uniqueID("ws-stream-multi")
+	inst := "inst-1"
+
+	reportResource(t, client, "host", "hbi", inst, idA, ws)
+	t.Cleanup(func() { deleteResource(t, client, "host", idA, "hbi", inst) })
+
+	reportResource(t, client, "host", "hbi", inst, idB, ws)
+	t.Cleanup(func() { deleteResource(t, client, "host", idB, "hbi", inst) })
+
+	assertReporterResource(t, idA, "hbi", "host", 0, 0, false)
+	assertReporterResource(t, idB, "hbi", "host", 0, 0, false)
+
+	pollCheck(t, client, makeCheckReq("host", idA, "hbi", proto.String(inst), ws),
+		pb.Allowed_ALLOWED_TRUE, defaultPollTimeout)
+	pollCheck(t, client, makeCheckReq("host", idB, "hbi", proto.String(inst), ws),
+		pb.Allowed_ALLOWED_TRUE, defaultPollTimeout)
+
+	reporterType := "hbi"
+	listReq := &pb.StreamedListObjectsRequest{
+		ObjectType: &pb.RepresentationType{
+			ResourceType: "host",
+			ReporterType: &reporterType,
+		},
+		Relation: "workspace",
+		Subject: &pb.SubjectReference{
+			Resource: &pb.ResourceReference{
+				ResourceType: "workspace",
+				ResourceId:   ws,
+				Reporter:     &pb.ReporterReference{Type: "rbac"},
+			},
+		},
+	}
+
+	resourceIDs := pollStreamedListObjectsAll(t, client, listReq, []string{idA, idB}, defaultPollTimeout)
+	assert.Contains(t, resourceIDs, idA, "expected host A in StreamedListObjects")
+	assert.Contains(t, resourceIDs, idB, "expected host B in StreamedListObjects")
+
+	report.addStep(t.Name(),
+		fmt.Sprintf("StreamedListObjects host (workspace=%s)", ws), "",
+		fmt.Sprintf("returned %d objects, contains both %s and %s", len(resourceIDs), idA, idB))
+}
+
+func TestSanity_StreamedListSubjects_ReturnsWorkspace(t *testing.T) {
+	client := newClient(t)
+	id := uniqueID("stream-subj")
+	ws := uniqueID("ws-stream-subj")
+	inst := "inst-1"
+
+	reportResource(t, client, "host", "hbi", inst, id, ws)
+	t.Cleanup(func() { deleteResource(t, client, "host", id, "hbi", inst) })
+
+	assertReporterResource(t, id, "hbi", "host", 0, 0, false)
+
+	checkReq := makeCheckReq("host", id, "hbi", proto.String(inst), ws)
+	pollCheck(t, client, checkReq, pb.Allowed_ALLOWED_TRUE, defaultPollTimeout)
+
+	subjectReporterType := "rbac"
+	listReq := &pb.StreamedListSubjectsRequest{
+		Resource: &pb.ResourceReference{
+			ResourceType: "host",
+			ResourceId:   id,
+			Reporter:     &pb.ReporterReference{Type: "hbi", InstanceId: proto.String(inst)},
+		},
+		Relation: "workspace",
+		SubjectType: &pb.RepresentationType{
+			ResourceType: "workspace",
+			ReporterType: &subjectReporterType,
+		},
+	}
+
+	subjectIDs := pollStreamedListSubjects(t, client, listReq, ws, defaultPollTimeout)
+	assert.Contains(t, subjectIDs, ws, "expected workspace in StreamedListSubjects results")
+
+	report.addStep(t.Name(),
+		fmt.Sprintf("StreamedListSubjects host/%s relation=workspace", id), "",
+		fmt.Sprintf("returned %d subjects, contains %s", len(subjectIDs), ws))
+}
+
+// --- Streaming helpers ---
+
+func collectStreamedListObjects(t *testing.T, client pb.KesselInventoryServiceClient, req *pb.StreamedListObjectsRequest) []string {
+	t.Helper()
+	stream, err := client.StreamedListObjects(context.Background(), req)
+	require.NoError(t, err, "StreamedListObjects stream creation failed")
+
+	var ids []string
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err, "StreamedListObjects Recv failed")
+		ids = append(ids, resp.GetObject().GetResourceId())
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func collectStreamedListSubjects(t *testing.T, client pb.KesselInventoryServiceClient, req *pb.StreamedListSubjectsRequest) []string {
+	t.Helper()
+	stream, err := client.StreamedListSubjects(context.Background(), req)
+	require.NoError(t, err, "StreamedListSubjects stream creation failed")
+
+	var ids []string
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err, "StreamedListSubjects Recv failed")
+		ids = append(ids, resp.GetSubject().GetResource().GetResourceId())
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// pollStreamedListObjects retries StreamedListObjects until the target ID
+// appears in the results, handling eventual consistency with SpiceDB.
+func pollStreamedListObjects(t *testing.T, client pb.KesselInventoryServiceClient,
+	req *pb.StreamedListObjectsRequest, targetID string, timeoutSec int,
+) []string {
+	t.Helper()
+	for i := 0; i < timeoutSec; i++ {
+		ids := collectStreamedListObjects(t, client, req)
+		for _, id := range ids {
+			if id == targetID {
+				t.Logf("StreamedListObjects returned target %s on attempt %d", targetID, i+1)
+				return ids
+			}
+		}
+		t.Logf("StreamedListObjects attempt %d: %d results, target %s not yet present", i+1, len(ids), targetID)
+		time.Sleep(1 * time.Second)
+	}
+	t.Fatalf("StreamedListObjects did not return target %s within %ds", targetID, timeoutSec)
+	return nil
+}
+
+// pollStreamedListObjectsAll retries until all target IDs appear.
+func pollStreamedListObjectsAll(t *testing.T, client pb.KesselInventoryServiceClient,
+	req *pb.StreamedListObjectsRequest, targetIDs []string, timeoutSec int,
+) []string {
+	t.Helper()
+	for i := 0; i < timeoutSec; i++ {
+		ids := collectStreamedListObjects(t, client, req)
+		idSet := make(map[string]bool, len(ids))
+		for _, id := range ids {
+			idSet[id] = true
+		}
+		allPresent := true
+		for _, target := range targetIDs {
+			if !idSet[target] {
+				allPresent = false
+				break
+			}
+		}
+		if allPresent {
+			t.Logf("StreamedListObjects returned all %d targets on attempt %d", len(targetIDs), i+1)
+			return ids
+		}
+		t.Logf("StreamedListObjects attempt %d: %d results, not all targets present yet", i+1, len(ids))
+		time.Sleep(1 * time.Second)
+	}
+	t.Fatalf("StreamedListObjects did not return all targets within %ds", timeoutSec)
+	return nil
+}
+
+// pollStreamedListSubjects retries StreamedListSubjects until the target ID appears.
+func pollStreamedListSubjects(t *testing.T, client pb.KesselInventoryServiceClient,
+	req *pb.StreamedListSubjectsRequest, targetID string, timeoutSec int,
+) []string {
+	t.Helper()
+	for i := 0; i < timeoutSec; i++ {
+		ids := collectStreamedListSubjects(t, client, req)
+		for _, id := range ids {
+			if id == targetID {
+				t.Logf("StreamedListSubjects returned target %s on attempt %d", targetID, i+1)
+				return ids
+			}
+		}
+		t.Logf("StreamedListSubjects attempt %d: %d results, target %s not yet present", i+1, len(ids), targetID)
+		time.Sleep(1 * time.Second)
+	}
+	t.Fatalf("StreamedListSubjects did not return target %s within %ds", targetID, timeoutSec)
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds **4 new E2E sanity tests** covering `StreamedListObjects` and `StreamedListSubjects` streaming RPCs
- The sanity suite previously had zero streaming coverage, which meant regressions like the `StreamValidationInterceptor` removal (fixed in #1367) went undetected at the integration level
- Tests use polling with eventual consistency handling, matching the existing `Check`-based test patterns

Jira: [RHCLOUD-48141](https://redhat.atlassian.net/browse/RHCLOUD-48141)
Epic: [RHCLOUD-48140](https://redhat.atlassian.net/browse/RHCLOUD-48140) (Kessel | Inventory Tech Debt & Test Coverage)

## New Tests

| Test | Validates |
|------|-----------|
| `TestSanity_StreamedListObjects_ReturnsReportedResource` | A reported resource appears in streamed results |
| `TestSanity_StreamedListObjects_EmptyAfterDelete` | A deleted resource no longer appears in streamed results |
| `TestSanity_StreamedListObjects_MultipleResources` | Multiple resources in same workspace all appear |
| `TestSanity_StreamedListSubjects_ReturnsWorkspace` | The workspace subject is returned for a resource |

## Test plan

- [x] All 4 new streaming tests pass in ephemeral
- [x] All 16 pre-existing sanity tests still pass (1 pre-existing flake in `Revive` test due to consumer latency, unrelated)
- [x] `go vet ./test/e2e/sanity/` clean


Made with [Cursor](https://cursor.com)

[RHCLOUD-48141]: https://redhat.atlassian.net/browse/RHCLOUD-48141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHCLOUD-48140]: https://redhat.atlassian.net/browse/RHCLOUD-48140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive end-to-end sanity test suite validating reporting, checks, streaming listings, bulk/self checks, lifecycle churn, and consistency across create/delete/multiple-resource scenarios.
  * Included harness-level reporting, DB assertions, polling, and stream-collection helpers to stabilize eventual-consistency checks.

* **Documentation**
  * Added a how-to guide for running the sanity suite and linked it from agent guidelines.

* **Chores**
  * Added an executable runner script to build/deploy and execute the sanity tests against ephemeral environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->