### PR TITLE
fixes issue with repeating panel that casuses panels to shuffle

### DIFF
--- a/dashboards/grafana-dashboard-kessel-inventory-kafka-connect.configmap.yaml
+++ b/dashboards/grafana-dashboard-kessel-inventory-kafka-connect.configmap.yaml
@@ -3650,8 +3650,6 @@ data:
             "wideLayout": true
           },
           "pluginVersion": "11.6.11",
-          "repeat": "instance",
-          "repeatDirection": "h",
           "targets": [
             {
               "datasource": {
@@ -4565,7 +4563,7 @@ data:
       "timezone": "",
       "title": "Kessel Inventory - Kafka Connect",
       "uid": "AEaSQ97mq",
-      "version": 4
+      "version": 5
     }
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
### PR Template:

## Describe your changes
Panel 230 ("Time since last rebalance") has "repeat": "instance" with "repeatDirection": "h". This tells Grafana to duplicate the panel horizontally for each value of the $instance template variable. We don't have an $instance variable defined in the dashboard's templating list, so Grafana can't resolve the repeat, and the panel rendering breaks. Removes the repeat to fix it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dashboard panel configuration to prevent unintended panel duplication in monitoring displays.
* **Chores**
  * Updated dashboard version to reflect configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->