### PR TITLE
updates the redis version for RBAC, ensures latest images always pulled

### DIFF
--- a/development/full-kessel/docker-compose.yaml
+++ b/development/full-kessel/docker-compose.yaml
@@ -299,7 +299,7 @@ services:
       - kessel
 
   redis:
-    image: redis:5.0.4
+    image: redis:8.2
     profiles: ["rbac"]
     ports:
       - "6379:6379"

--- a/docs/dev-guides/docker-compose-options.md
+++ b/docs/dev-guides/docker-compose-options.md
@@ -62,6 +62,12 @@ INVENTORY_CONSUMER_IMAGE=quay.io/redhat-services-prod/project-kessel-tenant/kess
 RBAC_IMAGE=quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac:latest
 ```
 
+By default, `make kessel-up` pulls the latest image from the registry on every run (`--pull always`). When using locally-built images (e.g., `localhost/...`), set `COMPOSE_PULL_MODE` to avoid overwriting them:
+
+```shell
+COMPOSE_PULL_MODE=missing make kessel-up
+```
+
 ### Using a Custom SpiceDB Schema
 
 To use a local schema file instead of downloading from GitHub:

--- a/scripts/start-full-kessel.sh
+++ b/scripts/start-full-kessel.sh
@@ -70,4 +70,4 @@ echo "Extracted $(ls "${RBAC_DEFS_DIR}"/*.json 2>/dev/null | wc -l) RBAC role de
 ${DOCKER} compose --env-file "${ENV_FILE}" \
   --profile relations --profile consumer --profile rbac "$@" \
   -f "${COMPOSE_DIR}/docker-compose.yaml" \
-  up --pull always -d
+  up --pull "${COMPOSE_PULL_MODE:-always}" -d

--- a/scripts/start-full-kessel.sh
+++ b/scripts/start-full-kessel.sh
@@ -70,4 +70,4 @@ echo "Extracted $(ls "${RBAC_DEFS_DIR}"/*.json 2>/dev/null | wc -l) RBAC role de
 ${DOCKER} compose --env-file "${ENV_FILE}" \
   --profile relations --profile consumer --profile rbac "$@" \
   -f "${COMPOSE_DIR}/docker-compose.yaml" \
-  up -d
+  up --pull always -d


### PR DESCRIPTION
### PR Template:

## Describe your changes
* bumps to latest Redis as RBAC updates to redis python packages requires a newer version (plus it aligns with elasticache version used in production)
* ensures podman always pulls latest image and doesnt use old cached images


### Validation

```
$ podman logs full-kessel-redis-1  | grep version
1:C 12 Jun 2026 13:20:40.916 * Redis version=8.2.7, bits=64, commit=00000000, modified=1, pid=1, just started
1:M 12 Jun 2026 13:20:40.918 * <bf> RedisBloom version 8.2.12 (Git=unknown)
1:M 12 Jun 2026 13:20:40.919 * <search> Redis version found by RedisSearch : 8.2.7 - oss
1:M 12 Jun 2026 13:20:40.919 * <search> RediSearch version 8.2.13 (Git=e9cf9bf)
1:M 12 Jun 2026 13:20:40.919 * <search> Low level api version 1 initialized successfully
1:M 12 Jun 2026 13:20:40.920 * <timeseries> RedisTimeSeries version 80210, git_sha=93993a3d3f8ab28dc2c86a3e917f5160a2617f8b
1:M 12 Jun 2026 13:20:40.920 * <timeseries> Redis version found by RedisTimeSeries : 8.2.7 - oss
1:M 12 Jun 2026 13:20:40.920 * <ReJSON> version: 80209 git sha: unknown branch: unknown


$ make kessel-compose-integration-test 
./scripts/kessel-integration-test.sh

=== Step 0: Prerequisites Check ===
  ✓ PASS: All prerequisites installed

=== Step 1: Service Health Checks ===
  ✓ PASS: Inventory API is ready
  ✓ PASS: Relations API is ready
  ✓ PASS: RBAC is ready
  ✓ PASS: Kafka Connect is ready

=== Step 2: Bootstrap Tenant via RBAC V2 ===
[INFO] Triggering tenant bootstrap for org_id=test-org-kessel-e2e
  ✓ PASS: Tenant bootstrapped — default workspace: 019ebbff-9ce0-7dc1-9b64-b32220e1f539
  ✓ PASS: Root workspace: 019ebbff-9ce0-7dc1-9b64-b3139b799142

=== Step 3: Verify Workspace Hierarchy in Relations API ===
[INFO] Polling Relations API for workspace tuples (up to 60s)...
  ✓ PASS: Found 6 workspace tuples in Relations API
  ✓ PASS: Default workspace has parent relationship to root workspace

=== Step 4: Publish Simulated HBI Host Event via kcat ===
[INFO] Publishing HBI host event to outbox.event.hbi.hosts
[INFO]   host_id=e2e10000-0000-0000-0000-2bcc941b75ad, workspace_id=019ebbff-9ce0-7dc1-9b64-b32220e1f539
  ✓ PASS: HBI host event published to Kafka

=== Step 5: Wait for Consumer Processing ===
[INFO] Polling Inventory API for the reported resource (up to 30s)...
  ✓ PASS: Resource confirmed in Inventory API (host_id=e2e10000-0000-0000-0000-2bcc941b75ad)

=== Step 6: Verify Resource-to-Workspace Tuple in Relations API ===
[INFO] Polling Relations API for host tuples (up to 60s)...
  ✓ PASS: Found 1 host tuple(s) in Relations API
  ✓ PASS: Host resource is linked to workspace 019ebbff-9ce0-7dc1-9b64-b32220e1f539

=== Step 7: RBAC Access Check ===
[INFO] Polling RBAC V2 roles (up to 60s for CDC replication)...
  ✓ PASS: RBAC V2 has 10 roles for tenant
  ✓ PASS: RBAC V2 lists 2 workspaces (root + default + any user-created)

=== Step 8: Resource Deletion Flow ===
[INFO] Deleting resource via Inventory API gRPC
  ✓ PASS: Resource deleted from Inventory API
[INFO] Waiting for tuple cleanup (up to 30s)...
  ✓ PASS: Host-to-workspace tuple removed from Relations API after deletion

=== Summary ===

  Passed: 17  /  Failed: 0  /  Total: 17

All integration tests passed.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Redis service to version 8.2.
  * Startup now supports configurable image-pull behavior (defaults to pulling latest images).

* **Documentation**
  * Added guidance explaining the default pull behavior and how to prevent overwriting locally built images (e.g., using a mode that skips pulling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->