### PR TITLE
RHCLOUD-46118: Support for SpiceDB authz configuration

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -234,7 +234,7 @@ func NewCommand(
 			}
 
 			// construct relations repository
-			relationsRepo, err := data.NewRelationsRepository(ctx, authzConfig, log.NewHelper(log.With(logger, "subsystem", "relations")))
+			relationsRepo, err := data.NewRelationsRepository(ctx, authzConfig, log.With(logger, "subsystem", "relations"))
 			if err != nil {
 				return err
 			}
@@ -299,9 +299,15 @@ func NewCommand(
 			pbv1beta2.RegisterKesselInventoryServiceHTTPServer(server.HttpServer, inventory_service)
 
 			// DEPRECATED: Legacy tuple service for RBAC-only backward compatibility
+			var tupleMetaAuthorizer metaauthorizer.MetaAuthorizer
+			if authnOptions.AllowUnauthenticated != nil && *authnOptions.AllowUnauthenticated {
+				tupleMetaAuthorizer = metaauthorizer.NewSimpleMetaAuthorizer()
+			} else {
+				tupleMetaAuthorizer = metaauthorizer.NewWhitelistMetaAuthorizer(metaAuthorizerConfig.TupleCrudAllowlist)
+			}
 			tuple_crud_usecase := tuplesctl.New(
 				relationsRepo,
-				metaauthorizer.NewWhitelistMetaAuthorizer(metaAuthorizerConfig.TupleCrudAllowlist),
+				tupleMetaAuthorizer,
 				log.With(logger, "subsystem", "tuple_crud_controller"),
 			)
 			tuple_service := tuplesvc.New(tuple_crud_usecase)

--- a/development/configs/local-w-spicedb.yaml
+++ b/development/configs/local-w-spicedb.yaml
@@ -1,0 +1,39 @@
+server:
+  http:
+    address: 0.0.0.0:8000
+  grpc:
+    address: 0.0.0.0:9000
+authn:
+  allow-unauthenticated: true
+authz:
+  impl: spicedb
+  spicedb:
+    endpoint: spicedb:50051
+    token: foobar
+    schema-file: /schema.zed
+    use-tls: false
+    fully-consistent: true
+eventing:
+  eventer: stdout
+  kafka:
+storage:
+  max-serialization-retries: 10
+  outbox-mode: wal
+  database: postgres
+  postgres:
+    host: "invdatabase"
+    port: "5433"
+    user: "postgres"
+    password: "yPsw5e6ab4bvAGe5H"
+    dbname: "spicedb"
+schema:
+  repository: in-memory
+  in-memory:
+    type: json
+    path: schema_cache.json
+consumer:
+  enabled: false
+log:
+  level: "info"
+  livez: true
+  readyz: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,11 +89,18 @@ func LogConfigurationInfo(options *OptionsConfig) {
 		)
 	}
 
-	if options.Authz.Authz == relations.Kessel {
+	switch options.Authz.Authz {
+	case relations.Kessel:
 		log.Debugf("Authz Configuration: URL: %s, Insecure?: %t, OIDC?: %t",
 			options.Authz.Kessel.URL,
 			options.Authz.Kessel.Insecure,
 			options.Authz.Kessel.EnableOidcAuth,
+		)
+	case relations.SpiceDB:
+		log.Debugf("Authz Configuration: SpiceDB Endpoint: %s, TLS?: %t, FullyConsistent?: %t",
+			options.Authz.SpiceDB.Endpoint,
+			options.Authz.SpiceDB.UseTLS,
+			options.Authz.SpiceDB.FullyConsistent,
 		)
 	}
 

--- a/internal/config/relations/config.go
+++ b/internal/config/relations/config.go
@@ -4,28 +4,35 @@ import (
 	"context"
 
 	"github.com/project-kessel/inventory-api/internal/config/relations/kessel"
+	"github.com/project-kessel/inventory-api/internal/config/relations/spicedb"
 )
 
 type Config struct {
-	Authz  string
-	Kessel *kessel.Config
+	Authz   string
+	Kessel  *kessel.Config
+	SpiceDB *spicedb.Config
 }
 
 func NewConfig(o *Options) *Config {
-	var kcfg *kessel.Config
-	if o.Authz == Kessel {
-		kcfg = kessel.NewConfig(o.Kessel)
+	cfg := &Config{
+		Authz: o.Authz,
 	}
 
-	return &Config{
-		Authz:  o.Authz,
-		Kessel: kcfg,
+	if o.Authz == Kessel {
+		cfg.Kessel = kessel.NewConfig(o.Kessel)
 	}
+
+	if o.Authz == SpiceDB {
+		cfg.SpiceDB = spicedb.NewConfig(o.SpiceDB)
+	}
+
+	return cfg
 }
 
 type completedConfig struct {
-	Authz  string
-	Kessel kessel.CompletedConfig
+	Authz   string
+	Kessel  kessel.CompletedConfig
+	SpiceDB spicedb.CompletedConfig
 }
 
 type CompletedConfig struct {
@@ -45,18 +52,22 @@ func (c *Config) Complete(ctx context.Context) (CompletedConfig, []error) {
 		}
 	}
 
+	if c.Authz == SpiceDB {
+		if sdb, errs := c.SpiceDB.Complete(); errs != nil {
+			return CompletedConfig{}, errs
+		} else {
+			cfg.SpiceDB = sdb
+		}
+	}
+
 	return CompletedConfig{cfg}, nil
 }
 
 func CheckRelationsImpl(config CompletedConfig) string {
-	var authType string
 	switch config.Authz {
-	case AllowAll:
-		authType = "AllowAll"
-	case Kessel:
-		authType = "Kessel"
+	case AllowAll, Kessel, SpiceDB:
+		return config.Authz
 	default:
-		authType = "Unknown"
+		return "unknown"
 	}
-	return authType
 }

--- a/internal/config/relations/config_test.go
+++ b/internal/config/relations/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/project-kessel/inventory-api/internal/config/relations/kessel"
+	"github.com/project-kessel/inventory-api/internal/config/relations/spicedb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,6 +21,26 @@ func TestConfig_Complete_AllowAll_Success(t *testing.T) {
 	assert.Nil(t, errs, "AllowAll config should complete without errors")
 	assert.NotNil(t, completed.completedConfig, "Completed config should not be nil")
 	assert.Equal(t, AllowAll, completed.Authz, "Authz should be AllowAll")
+}
+
+func TestConfig_Complete_SpiceDB_Success(t *testing.T) {
+	spicedbCfg := spicedb.NewConfig(&spicedb.Options{
+		Endpoint:   "localhost:50051",
+		TokenFile:  "/tmp/token",
+		SchemaFile: "/tmp/schema.zed",
+		UseTLS:     false,
+	})
+
+	cfg := &Config{
+		Authz:   SpiceDB,
+		SpiceDB: spicedbCfg,
+	}
+
+	completed, errs := cfg.Complete(context.Background())
+
+	assert.Nil(t, errs, "SpiceDB config should complete without errors")
+	assert.NotNil(t, completed.completedConfig, "Completed config should not be nil")
+	assert.Equal(t, SpiceDB, completed.Authz, "Authz should be SpiceDB")
 }
 
 func TestConfig_Complete_Kessel_SwallowsErrors(t *testing.T) {
@@ -75,24 +96,29 @@ func TestCheckRelationsImpl_AllCases(t *testing.T) {
 		expectedType string
 	}{
 		{
-			name:         "AllowAll returns AllowAll",
+			name:         "AllowAll returns allow-all",
 			authz:        AllowAll,
-			expectedType: "AllowAll",
+			expectedType: AllowAll,
 		},
 		{
-			name:         "Kessel returns Kessel",
+			name:         "Kessel returns kessel",
 			authz:        Kessel,
-			expectedType: "Kessel",
+			expectedType: Kessel,
 		},
 		{
-			name:         "Unknown value returns Unknown",
+			name:         "SpiceDB returns spicedb",
+			authz:        SpiceDB,
+			expectedType: SpiceDB,
+		},
+		{
+			name:         "Unknown value returns unknown",
 			authz:        "some-random-value",
-			expectedType: "Unknown",
+			expectedType: "unknown",
 		},
 		{
-			name:         "Empty string returns Unknown",
+			name:         "Empty string returns unknown",
 			authz:        "",
-			expectedType: "Unknown",
+			expectedType: "unknown",
 		},
 	}
 

--- a/internal/config/relations/options.go
+++ b/internal/config/relations/options.go
@@ -6,25 +6,29 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/project-kessel/inventory-api/internal/config/relations/kessel"
+	"github.com/project-kessel/inventory-api/internal/config/relations/spicedb"
 )
 
 type Options struct {
-	// Authz selects the relations implementation ("allow-all" or "kessel").
+	// Authz selects the relations implementation ("allow-all", "kessel", or "spicedb").
 	// Named "Authz" for backward compatibility with the --authz.* CLI flags.
-	Authz  string          `mapstructure:"impl"`
-	Kessel *kessel.Options `mapstructure:"kessel"`
+	Authz   string           `mapstructure:"impl"`
+	Kessel  *kessel.Options  `mapstructure:"kessel"`
+	SpiceDB *spicedb.Options `mapstructure:"spicedb"`
 }
 
 const (
 	AllowAll     = "allow-all"
 	Kessel       = "kessel"
+	SpiceDB      = "spicedb"
 	RelationsAPI = "kessel-relations"
 )
 
 func NewOptions() *Options {
 	return &Options{
-		Authz:  AllowAll,
-		Kessel: kessel.NewOptions(),
+		Authz:   AllowAll,
+		Kessel:  kessel.NewOptions(),
+		SpiceDB: spicedb.NewOptions(),
 	}
 }
 
@@ -33,19 +37,24 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 		prefix = prefix + "."
 	}
 
-	fs.StringVar(&o.Authz, prefix+"impl", o.Authz, "Authz impl to use.  Options are 'allow-all' and 'kessel'.")
+	fs.StringVar(&o.Authz, prefix+"impl", o.Authz, "Authz impl to use.  Options are 'allow-all', 'kessel', and 'spicedb'.")
 	o.Kessel.AddFlags(fs, prefix+"kessel")
+	o.SpiceDB.AddFlags(fs, prefix+"spicedb")
 }
 
 func (o *Options) Validate() []error {
 	var errs []error
 
-	if o.Authz != AllowAll && o.Authz != Kessel {
-		errs = append(errs, fmt.Errorf("invalid authz.impl: %s.  Options are 'allow-all' and 'kessel'", o.Authz))
+	if o.Authz != AllowAll && o.Authz != Kessel && o.Authz != SpiceDB {
+		errs = append(errs, fmt.Errorf("invalid authz.impl: %s.  Options are 'allow-all', 'kessel', and 'spicedb'", o.Authz))
 	}
 
 	if o.Authz == Kessel {
 		errs = append(errs, o.Kessel.Validate()...)
+	}
+
+	if o.Authz == SpiceDB {
+		errs = append(errs, o.SpiceDB.Validate()...)
 	}
 
 	return errs

--- a/internal/config/relations/options_test.go
+++ b/internal/config/relations/options_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/project-kessel/inventory-api/internal/config/relations/kessel"
+	"github.com/project-kessel/inventory-api/internal/config/relations/spicedb"
 	"github.com/project-kessel/inventory-api/internal/helpers"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
@@ -16,8 +17,9 @@ func TestNewOptions(t *testing.T) {
 	}{
 		options: NewOptions(),
 		expectedOptions: &Options{
-			Authz:  AllowAll,
-			Kessel: kessel.NewOptions(),
+			Authz:   AllowAll,
+			Kessel:  kessel.NewOptions(),
+			SpiceDB: spicedb.NewOptions(),
 		},
 	}
 	assert.Equal(t, test.expectedOptions, NewOptions())
@@ -34,9 +36,9 @@ func TestOptions_AddFlags(t *testing.T) {
 	test.options.AddFlags(fs, prefix)
 
 	// the below logic ensures that every possible option defined in the Options type
-	// has a defined flag for that option; kessel section is skipped
+	// has a defined flag for that option; kessel and spicedb sections are skipped
 	// in favor of testing in their own packages or via config files
-	helpers.AllOptionsHaveFlags(t, prefix, fs, *test.options, []string{"kessel"})
+	helpers.AllOptionsHaveFlags(t, prefix, fs, *test.options, []string{"kessel", "spicedb"})
 }
 
 func TestOptions_Validate(t *testing.T) {
@@ -58,6 +60,18 @@ func TestOptions_Validate(t *testing.T) {
 				Authz: "kessel",
 				Kessel: &kessel.Options{
 					URL: "relations-api",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "spicedb impl",
+			options: &Options{
+				Authz: "spicedb",
+				SpiceDB: &spicedb.Options{
+					Endpoint:   "localhost:50051",
+					TokenFile:  "/tmp/token",
+					SchemaFile: "/tmp/schema.zed",
 				},
 			},
 			expectError: false,

--- a/internal/data/health/healthrepository.go
+++ b/internal/data/health/healthrepository.go
@@ -47,11 +47,12 @@ func (r *healthRepo) IsBackendAvailable(ctx context.Context) (model.HealthResult
 		log.Errorf("RELATIONS-API UNHEALTHY")
 		return model.NewHealthResult("RELATIONS-API UNHEALTHY", 500), nil
 	}
-	if relations.CheckRelationsImpl(r.RelationsConfig) == "Kessel" {
+	relImpl := relations.CheckRelationsImpl(r.RelationsConfig)
+	if relImpl == relations.Kessel || relImpl == relations.SpiceDB {
 		if viper.GetBool("log.readyz") {
-			log.Infof("Storage type %s and relations-api %s", storageType, health.Status())
+			log.Infof("Storage type %s and relations (%s) %s", storageType, relImpl, health.Status())
 		}
-		return model.NewHealthResult("STORAGE "+storageType+" and RELATIONS-API", 200), nil
+		return model.NewHealthResult("STORAGE "+storageType+" and RELATIONS-API ("+relImpl+")", 200), nil
 	}
 
 	return model.NewHealthResult("Storage type "+storageType, 200), nil
@@ -63,10 +64,11 @@ func (r *healthRepo) IsRelationsAvailable(ctx context.Context) (model.HealthResu
 		log.Errorf("RELATIONS-API UNHEALTHY")
 		return model.NewHealthResult("RELATIONS-API UNHEALTHY", 500), nil
 	}
-	if relations.CheckRelationsImpl(r.RelationsConfig) == "Kessel" {
+	relImpl := relations.CheckRelationsImpl(r.RelationsConfig)
+	if relImpl == relations.Kessel || relImpl == relations.SpiceDB {
 		if viper.GetBool("log.readyz") {
-			log.Infof("relations-api %s", health.Status())
+			log.Infof("relations (%s) %s", relImpl, health.Status())
 		}
 	}
-	return model.NewHealthResult("RELATIONS-API", 200), nil
+	return model.NewHealthResult("RELATIONS-API ("+relImpl+")", 200), nil
 }

--- a/internal/data/relations_repository_factory.go
+++ b/internal/data/relations_repository_factory.go
@@ -9,12 +9,19 @@ import (
 	"github.com/project-kessel/inventory-api/internal/config/relations"
 )
 
-func NewRelationsRepository(ctx context.Context, config relations.CompletedConfig, logger *log.Helper) (model.RelationsRepository, error) {
+func NewRelationsRepository(ctx context.Context, config relations.CompletedConfig, logger log.Logger) (model.RelationsRepository, error) {
+	helper := log.NewHelper(logger)
 	switch config.Authz {
 	case relations.AllowAll:
-		return NewAllowAllRelationsRepository(logger), nil
+		return NewAllowAllRelationsRepository(helper), nil
 	case relations.Kessel:
-		return NewGRPCRelationsRepository(ctx, config.Kessel, logger)
+		return NewGRPCRelationsRepository(ctx, config.Kessel, helper)
+	case relations.SpiceDB:
+		repo, _, err := NewSpiceDBRelationsRepository(NewSpiceDBConfigFromCompleted(config.SpiceDB), logger)
+		if err != nil {
+			return nil, fmt.Errorf("error creating spicedb relations repository: %w", err)
+		}
+		return repo, nil
 	default:
 		return nil, fmt.Errorf("unrecognized relations implementation: %s", config.Authz)
 	}

--- a/internal/data/spicedb_container.go
+++ b/internal/data/spicedb_container.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/project-kessel/inventory-api/internal/biz/model"
+	"github.com/project-kessel/inventory-api/internal/config/relations/spicedb"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/network"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -159,6 +160,18 @@ type SpiceDBConfig struct {
 	SchemaFile      string
 	UseTLS          bool
 	FullyConsistent bool
+}
+
+// NewSpiceDBConfigFromCompleted builds a SpiceDBConfig from a completed spicedb config.
+func NewSpiceDBConfigFromCompleted(c spicedb.CompletedConfig) *SpiceDBConfig {
+	return &SpiceDBConfig{
+		Endpoint:        c.Endpoint,
+		Token:           c.Token,
+		TokenFile:       c.TokenFile,
+		SchemaFile:      c.SchemaFile,
+		UseTLS:          c.UseTLS,
+		FullyConsistent: c.FullyConsistent,
+	}
 }
 
 // CreateSpiceDbRepository creates a repository that connects to the containerized SpiceDB instance

--- a/test/e2e/inventory_http_test.go
+++ b/test/e2e/inventory_http_test.go
@@ -154,7 +154,7 @@ func TestInventoryAPIHTTP_Readyz(t *testing.T) {
 	resp, err := healthClient.GetReadyz(context.Background(), &v1.GetReadyzRequest{})
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
-	expectedStatus := "STORAGE postgres and RELATIONS-API"
+	expectedStatus := "STORAGE postgres and RELATIONS-API (kessel)"
 	expectedCode := uint32(200)
 	assert.Equal(t, expectedStatus, resp.Status)
 	assert.Equal(t, expectedCode, resp.Code)


### PR DESCRIPTION
- Adds metaauthorizer branch in `serve.go` for unauthenticated dev access via compose or other local run options
- Adds SpiceDB auth configuration option to relations config
  - `SpiceDB` will route directly to a SpiceDB instance, bypassing Relations from the `Kessel` option
- Updated health checks based on `SpiceDB` config option
- Created `local-w-spicedb` configuration for use with upcoming compose PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SpiceDB as an alternative authorization backend alongside Kessel.
  * Added a local configuration example for running SpiceDB with both HTTP and gRPC enabled.

* **Improvements**
  * Health checks now recognize and report SpiceDB readiness for relations endpoints.
  * Configuration logging now includes SpiceDB-specific authorization details.
  * When unauthenticated access is enabled, authorization handling for tuple CRUD is adjusted accordingly.

* **Bug Fixes**
  * Updated readiness output expectations to include the relations implementation (e.g., Kessel).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->