### PR TITLE
RHCLOUD-48646: Add support for optional ephemeral x-rh-identity heade…

### DIFF
--- a/deploy/kessel-inventory-ephem.yaml
+++ b/deploy/kessel-inventory-ephem.yaml
@@ -13,11 +13,26 @@ objects:
           max-serialization-retries: 10
           outbox-mode: wal
         authn:
-          allow-unauthenticated: true
+          authenticator:
+            type: first_match
+            chain:
+              - type: x-rh-identity
+                transport:
+                  http: true
+                  grpc: false
+              - type: allow-unauthenticated
         authz:
           kessel:
             insecure-client: true
             enable-oidc-auth: false
+        selfsubjectstrategy:
+          redhatRbacSelfSubjectStrategy:
+            enabled: true
+            issuerDomain: redhat
+            # oidcIssuerDomains is unused in ephemeral (no OIDC in the authn chain) but required by validation
+            oidcIssuerDomains:
+              - iss: https://not-used.example.com
+                domain: redhat
         consumer:
           enabled: true
           topic: outbox.event.kessel.tuples


### PR DESCRIPTION
- Enable checkself in ephemeral by adding x-rh-identity to the authn chain and configuring selfsubjectstrategy
- Backwards compatible, services without the header still fall through to allow-unauthenticated

Test results
```
  ┌───────────┬──────────┬───────────────┬───────────────────────────────────────────────┐
  │   Test    │ Protocol │   Identity    │                    Result                     │
  ├───────────┼──────────┼───────────────┼───────────────────────────────────────────────┤
  │ checkself │ HTTP     │ none          │ 403 meta authorization denied (correct)       │
  │           │ :8000    │               │                                               │
  ├───────────┼──────────┼───────────────┼───────────────────────────────────────────────┤
  │ checkself │ HTTP     │ x-rh-identity │ ALLOWED_FALSE + consistency token     │
  │           │ :8000    │               │                                               │
  ├───────────┼──────────┼───────────────┼───────────────────────────────────────────────┤
  │ check     │ gRPC     │ none          │ ALLOWED_FALSE + consistency token (backwards  │
  │           │ :9000    │               │ compatible)                                   │
  ├───────────┼──────────┼───────────────┼───────────────────────────────────────────────┤
  │           │ HTTP     │               │ 403 meta authorization denied (correct —      │
  │ check     │ :8000    │ none          │ check is a service-to-service op, should use  │
  │           │          │               │ gRPC)                                         │
  └───────────┴──────────┴───────────────┴───────────────────────────────────────────────┘
  
                            
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Chores**
  * Updated the service’s authentication handling to use identity headers first, with an automatic fallback to unauthenticated access.
  * Enhanced the authorization setup by enabling a Red Hat RBAC self-subject strategy, including the required OIDC issuer domain configuration for validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->