### PR TITLE
RHCLOUD-48665: Update golangci-lint to v2.12.2 to match CI workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,11 +167,11 @@ all:
 # run go linter with the repositories lint config
 lint:
 	@echo "Running golangci-lint"
-	@$(DOCKER) run -t --rm -v $(PWD):/app:rw,z -w /app golangci/golangci-lint:v2.6.2 golangci-lint run -v
+	@$(DOCKER) run -t --rm -v $(PWD):/app:rw,z -w /app golangci/golangci-lint:v2.12.2 golangci-lint run -v
 
 lint-fix:
 	@echo "Running golangci-lint run --fix"
-	@$(DOCKER) run -t --rm -v $(PWD):/app:rw,z -w /app golangci/golangci-lint:v2.6.2 golangci-lint run --fix -v
+	@$(DOCKER) run -t --rm -v $(PWD):/app:rw,z -w /app golangci/golangci-lint:v2.12.2 golangci-lint run --fix -v
 
 .PHONY: pr-check
 # generate pr-check


### PR DESCRIPTION
## Summary
- The Makefile `lint` and `lint-fix` targets used `golangci-lint:v2.6.2` (built with Go 1.25), causing `make lint` to fail with a Go version mismatch against the project's Go 1.26.2 target
- Updated to `v2.12.2` to match the version already used in `.github/workflows/golangci-lint.yml`

Running under `main`:
```shell
Running golangci-lint
INFO golangci-lint has version 2.6.2 built with go1.25.3 from dc16cf43 on 2025-11-14T13:00:52Z 
INFO [config_reader] Config search paths: [./ /app / /root] 
INFO [config_reader] Used config file .golangci.yaml 
INFO [config_reader] Module name "github.com/project-kessel/inventory-api" 
Error: can't load config: the Go language version (go1.25) used to build golangci-lint islower than the targeted Go version (1.26.2)
The command is terminated due to an error: can't load config: the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26.2)
make: *** [lint] Error 3
```

## Test plan
- [ ] Run `make lint` locally — confirm it passes without the Go version mismatch error

Jira: https://issues.redhat.com/browse/RHCLOUD-48665

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting tool to a newer version to enhance code quality checks and benefit from latest improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->