### PR TITLE
RHCLOUD-48646: Add compose options for Inventory w/ SpiceDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,5 @@ scripts/kubeconfig-global-hub
 
 development/configs/monitoring/ephemeral-prometheus.yml
 development/full-kessel/configs/schema.zed
+development/configs/schema.zed
 development/full-kessel/configs/rbac-role-definitions/

--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,10 @@ inventory-up-split:
 inventory-up-split-relations-ready:
 	./scripts/start-inventory.sh base 8081 9081 invmigrate kafka-connect-setup kafka-setup
 
+.PHONY: inventory-up-spicedb
+inventory-up-spicedb:
+	./scripts/start-inventory-spicedb.sh
+
 .PHONY: inventory-up-sso
 inventory-up-sso:
 	./scripts/start-inventory.sh authn-sso 8081 9081 inventory-api kafka-connect-setup kafka-setup keycloak

--- a/development/configs/local-w-spicedb.yaml
+++ b/development/configs/local-w-spicedb.yaml
@@ -32,7 +32,14 @@ schema:
     type: json
     path: schema_cache.json
 consumer:
-  enabled: false
+  enabled: true
+  bootstrap-servers: kafka:9093
+  retry-options:
+    consumer-max-retries: 3
+    operation-max-retries: 4
+    backoff-factor: 5
+  auth:
+    enabled: false
 log:
   level: "info"
   livez: true

--- a/development/docker-compose.spicedb.yaml
+++ b/development/docker-compose.spicedb.yaml
@@ -1,0 +1,52 @@
+services:
+  inventory-api:
+    volumes:
+      - ./configs/schema.zed:/schema.zed:ro,z
+
+  ### ---------- SpiceDB Stack ----------
+
+  spicedb-database:
+    image: "postgres"
+    command: -c track_commit_timestamp=on
+    hostname: spicedb-database
+    ports:
+      - "5432:5432"
+    environment:
+      - "POSTGRES_PASSWORD=yPsw5e6ab4bvAGe5H"
+      - "POSTGRES_DB=spicedb"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -p 5432"]
+      interval: 5s
+      timeout: 3s
+      retries: 15
+    networks:
+      - kessel
+
+  spicedb-migrate:
+    image: "authzed/spicedb"
+    command: "migrate head"
+    restart: "on-failure"
+    environment:
+      - "SPICEDB_DATASTORE_ENGINE=postgres"
+      - "SPICEDB_DATASTORE_CONN_URI=postgres://postgres:yPsw5e6ab4bvAGe5H@spicedb-database:5432/spicedb?sslmode=disable"
+    depends_on:
+      spicedb-database:
+        condition: service_healthy
+    networks:
+      - kessel
+
+  spicedb:
+    image: "authzed/spicedb"
+    command: "serve"
+    restart: "always"
+    ports:
+      - "50051:50051"
+    environment:
+      - "SPICEDB_GRPC_PRESHARED_KEY=foobar"
+      - "SPICEDB_DATASTORE_ENGINE=postgres"
+      - "SPICEDB_DATASTORE_CONN_URI=postgres://postgres:yPsw5e6ab4bvAGe5H@spicedb-database:5432/spicedb?sslmode=disable"
+    depends_on:
+      spicedb-migrate:
+        condition: service_completed_successfully
+    networks:
+      - kessel

--- a/development/full-kessel/.env
+++ b/development/full-kessel/.env
@@ -6,13 +6,13 @@ RBAC_IMAGE=quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rba
 
 ### SpiceDB schema
 # Default: download from stage rbac-config repo
-SCHEMA_ZED_URL=https://raw.githubusercontent.com/RedHatInsights/rbac-config/refs/heads/master/configs/stage/schemas/schema.zed
+SCHEMA_ZED_URL=https://raw.githubusercontent.com/project-kessel/rbac-config/refs/heads/master/configs/stage/schemas/schema.zed
 # Override with a local file path instead of downloading (leave empty to use URL)
 SCHEMA_ZED_FILE=
 
 ### RBAC role definitions (stage configmap)
 # Default: download stage configmap from rbac-config repo and extract role JSON files
-RBAC_CONFIG_URL=https://raw.githubusercontent.com/RedHatInsights/rbac-config/refs/heads/master/_private/configmaps/stage/rbac-config.yml
+RBAC_CONFIG_URL=https://raw.githubusercontent.com/project-kessel/rbac-config/refs/heads/master/_private/configmaps/stage/rbac-config.yml
 # Override with a local file path instead of downloading (leave empty to use URL)
 RBAC_CONFIG_FILE=
 

--- a/docs/dev-guides/docker-compose-options.md
+++ b/docs/dev-guides/docker-compose-options.md
@@ -11,6 +11,7 @@
 | `make inventory-up-relations-ready` | Inventory API (built from source, x-rh-identity auth) | Testing with external Relations API |
 | `make inventory-up-w-monitoring` | Inventory API + monitoring stack | Inventory metrics testing |
 | `make inventory-up-sso` | Inventory API + Keycloak SSO | Testing OIDC authentication |
+| `make inventory-up-spicedb` | Inventory API + SpiceDB + Kafka | Testing embedded SpiceDB authz |
 | `make inventory-up-split` | Infra only (Postgres, Kafka, Connect) | Debugging with local binary + debugger |
 | `make inventory-up-split-relations-ready` | Infra only (relations-compatible ports) | Debugging with local binary + Relations |
 | `make monitoring-only` | Prometheus/Grafana/Alertmanager for ephemeral | Monitoring an ephemeral namespace |
@@ -29,7 +30,7 @@ Deploy the entire Kessel suite locally with a single command: Inventory API, Rel
 make kessel-up
 ```
 
-This starts all services using the compose file at `development/full-kessel/docker-compose.yaml`. The SpiceDB schema is automatically downloaded from the [stage rbac-config repo](https://raw.githubusercontent.com/RedHatInsights/rbac-config/refs/heads/master/configs/stage/schemas/schema.zed) at startup.
+This starts all services using the compose file at `development/full-kessel/docker-compose.yaml`. The SpiceDB schema is automatically downloaded from the [stage rbac-config repo](https://raw.githubusercontent.com/project-kessel/rbac-config/refs/heads/master/configs/stage/schemas/schema.zed) at startup.
 
 ### Ports
 
@@ -184,6 +185,24 @@ make get-token
 export TOKEN=<output>
 curl -H "Authorization: bearer ${TOKEN}" http://localhost:8081/api/kessel/v1/livez
 ```
+
+### With Embedded SpiceDB
+
+Deploys Inventory API with its own SpiceDB instance (and backing Postgres), Kafka, and the Inventory Consumer for testing the full embedded SpiceDB authz pipeline. Resources reported via `ReportResource` flow through the consumer to SpiceDB as tuples automatically. Also supports manual tuple management via `CreateTuples` and permission checks (Check, LookupObjects, LookupSubjects). Uses the compose overlay at `development/docker-compose.spicedb.yaml`.
+
+```shell
+make inventory-up-spicedb
+```
+
+The startup script downloads the SpiceDB schema from the [stage rbac-config repo](https://raw.githubusercontent.com/project-kessel/rbac-config/refs/heads/master/configs/stage/schemas/schema.zed) automatically. To use a local schema file instead, set `SCHEMA_ZED_FILE`:
+
+```shell
+SCHEMA_ZED_FILE=/path/to/schema.zed make inventory-up-spicedb
+```
+
+Inventory API is available at `localhost:8000` (HTTP) and `localhost:9000` (gRPC). SpiceDB gRPC is on port `50051`.
+
+For a full walkthrough of writing the schema, creating tuples, and checking permissions, see the [SpiceDB E2E test guide](embedded-spicedb-e2e-test.md).
 
 ---
 

--- a/docs/dev-guides/embedded-spicedb-e2e-test.md
+++ b/docs/dev-guides/embedded-spicedb-e2e-test.md
@@ -1,0 +1,134 @@
+# Local SpiceDB Compose Runbook
+
+Validates the embedded SpiceDB authz pipeline: direct tuple management, permission checks, and the consumer-driven resource flow through Kafka to SpiceDB.
+
+## 1. Start the stack
+
+```bash
+make inventory-up-spicedb
+```
+
+Builds inventory-api from source and starts it with SpiceDB, Kafka, and the inventory consumer.
+
+## 2. Verify services are healthy
+
+```bash
+curl -s http://localhost:8000/api/kessel/v1/livez
+podman ps | grep development-
+```
+
+Should show `{"status":"OK", "code":200}` and containers for inventory-api, invdatabase, spicedb, spicedb-database, kafka, zookeeper, and kafka-connect.
+
+## 3. Write the schema to SpiceDB
+
+```bash
+zed schema write development/configs/schema.zed --endpoint localhost:50051 --token foobar --insecure
+```
+
+The schema file is downloaded automatically during step 1. This loads it into SpiceDB.
+
+## 4. Create the permission chain via CreateTuples
+
+```bash
+grpcurl -plaintext -d '{
+  "upsert": true,
+  "tuples": [
+    {
+      "resource": {"type": {"namespace": "rbac", "name": "role"}, "id": "test-viewer-role"},
+      "relation": "t_inventory_hosts_read",
+      "subject": {"subject": {"type": {"namespace": "rbac", "name": "principal"}, "id": "*"}}
+    },
+    {
+      "resource": {"type": {"namespace": "rbac", "name": "role_binding"}, "id": "test-rb-1"},
+      "relation": "t_role",
+      "subject": {"subject": {"type": {"namespace": "rbac", "name": "role"}, "id": "test-viewer-role"}}
+    },
+    {
+      "resource": {"type": {"namespace": "rbac", "name": "role_binding"}, "id": "test-rb-1"},
+      "relation": "t_subject",
+      "subject": {"subject": {"type": {"namespace": "rbac", "name": "principal"}, "id": "test-user-1"}}
+    },
+    {
+      "resource": {"type": {"namespace": "rbac", "name": "workspace"}, "id": "test-ws-1"},
+      "relation": "t_binding",
+      "subject": {"subject": {"type": {"namespace": "rbac", "name": "role_binding"}, "id": "test-rb-1"}}
+    },
+    {
+      "resource": {"type": {"namespace": "hbi", "name": "host"}, "id": "test-host-1"},
+      "relation": "t_workspace",
+      "subject": {"subject": {"type": {"namespace": "rbac", "name": "workspace"}, "id": "test-ws-1"}}
+    }
+  ]
+}' localhost:9000 kessel.inventory.v1beta2.KesselTupleService/CreateTuples
+```
+
+Sets up a role granting `t_inventory_hosts_read`, binds a user to it, assigns the binding to a workspace, and places a host in that workspace.
+
+## 5. Verify tuples landed in SpiceDB
+
+```bash
+zed relationship read hbi/host --endpoint localhost:50051 --token foobar --insecure
+zed relationship read rbac/role_binding --endpoint localhost:50051 --token foobar --insecure
+```
+
+Confirms the tuples are stored. Note that `zed` outputs to stderr, so pipe with `2>&1` if redirecting.
+
+## 6. Check permission -- authorized user
+
+```bash
+grpcurl -plaintext -d '{
+  "object": {"resource_type": "host", "resource_id": "test-host-1", "reporter": {"type": "hbi"}},
+  "relation": "view",
+  "subject": {"resource": {"resource_type": "principal", "resource_id": "test-user-1", "reporter": {"type": "rbac"}}}
+}' localhost:9000 kessel.inventory.v1beta2.KesselInventoryService/Check
+```
+
+Should return `ALLOWED_TRUE`.
+
+## 7. Check permission -- unauthorized user
+
+```bash
+grpcurl -plaintext -d '{
+  "object": {"resource_type": "host", "resource_id": "test-host-1", "reporter": {"type": "hbi"}},
+  "relation": "view",
+  "subject": {"resource": {"resource_type": "principal", "resource_id": "unauthorized-user", "reporter": {"type": "rbac"}}}
+}' localhost:9000 kessel.inventory.v1beta2.KesselInventoryService/Check
+```
+
+Should return `ALLOWED_FALSE`.
+
+## 8. Report a resource and verify consumer pipeline
+
+```bash
+grpcurl -plaintext -d '{
+  "type": "host",
+  "reporter_type": "hbi",
+  "reporter_instance_id": "hbi-instance-01",
+  "representations": {
+    "metadata": {
+      "local_resource_id": "consumer-test-host-001",
+      "api_href": "/api/inventory/v1/hosts/consumer-test-host-001"
+    },
+    "common": {
+      "workspace_id": "test-ws-1"
+    },
+    "reporter": {
+      "fqdn": "consumer-test.example.com"
+    }
+  }
+}' localhost:9000 kessel.inventory.v1beta2.KesselInventoryService.ReportResource
+```
+
+Creates a resource through the normal API path. The inventory consumer picks up the outbox event from Kafka and writes the workspace tuple to SpiceDB automatically. Verify with:
+
+```bash
+zed relationship read hbi/host --endpoint localhost:50051 --token foobar --insecure
+```
+
+You should see a `t_workspace` relationship for the new host pointing at `test-ws-1`.
+
+## 9. Tear down
+
+```bash
+make inventory-down
+```

--- a/internal/config/relations/config.go
+++ b/internal/config/relations/config.go
@@ -2,6 +2,7 @@ package relations
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/project-kessel/inventory-api/internal/config/relations/kessel"
 	"github.com/project-kessel/inventory-api/internal/config/relations/spicedb"
@@ -53,6 +54,9 @@ func (c *Config) Complete(ctx context.Context) (CompletedConfig, []error) {
 	}
 
 	if c.Authz == SpiceDB {
+		if c.SpiceDB == nil {
+			return CompletedConfig{}, []error{fmt.Errorf("authz.spicedb config is required when authz.impl=%q", SpiceDB)}
+		}
 		if sdb, errs := c.SpiceDB.Complete(); errs != nil {
 			return CompletedConfig{}, errs
 		} else {

--- a/internal/config/relations/options.go
+++ b/internal/config/relations/options.go
@@ -37,6 +37,13 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 		prefix = prefix + "."
 	}
 
+	if o.Kessel == nil {
+		o.Kessel = kessel.NewOptions()
+	}
+	if o.SpiceDB == nil {
+		o.SpiceDB = spicedb.NewOptions()
+	}
+
 	fs.StringVar(&o.Authz, prefix+"impl", o.Authz, "Authz impl to use.  Options are 'allow-all', 'kessel', and 'spicedb'.")
 	o.Kessel.AddFlags(fs, prefix+"kessel")
 	o.SpiceDB.AddFlags(fs, prefix+"spicedb")
@@ -50,11 +57,19 @@ func (o *Options) Validate() []error {
 	}
 
 	if o.Authz == Kessel {
-		errs = append(errs, o.Kessel.Validate()...)
+		if o.Kessel == nil {
+			errs = append(errs, fmt.Errorf("authz.kessel config is required when authz.impl=%q", Kessel))
+		} else {
+			errs = append(errs, o.Kessel.Validate()...)
+		}
 	}
 
 	if o.Authz == SpiceDB {
-		errs = append(errs, o.SpiceDB.Validate()...)
+		if o.SpiceDB == nil {
+			errs = append(errs, fmt.Errorf("authz.spicedb config is required when authz.impl=%q", SpiceDB))
+		} else {
+			errs = append(errs, o.SpiceDB.Validate()...)
+		}
 	}
 
 	return errs

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -168,14 +168,18 @@ func (i *InventoryConsumer) Consume() error {
 	sigchan := make(chan os.Signal, 1)
 	signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
 
+	// Both gRPC (relations-api) and SpiceDB (direct) backends write tuples;
+	// only allow-all is a no-op. The type switch gates the consumer's tuple
+	// write path so new RelationsRepository implementations must opt-in here.
 	var relationsEnabled bool
 	switch i.Relations.(type) {
 	case *data.GRPCRelationsRepository:
 		relationsEnabled = true
+	case *data.SpiceDBRelationsRepository:
+		relationsEnabled = true
 	case *data.AllowAllRelationsRepository:
 		relationsEnabled = false
 	}
-
 	// Process messages
 	run := true
 	i.Logger.Info("Consumer ready: waiting for messages...")
@@ -292,7 +296,6 @@ func (i *InventoryConsumer) Consume() error {
 func (i *InventoryConsumer) ProcessMessage(headers map[string]string, relationsEnabled bool, msg *kafka.Message) (string, error) {
 	operation := headers["operation"]
 	txid := headers["txid"]
-
 	switch operation {
 	case string(model.OperationTypeCreated):
 		if relationsEnabled {

--- a/scripts/start-full-kessel.sh
+++ b/scripts/start-full-kessel.sh
@@ -42,7 +42,7 @@ if [ -n "${SCHEMA_ZED_FILE}" ]; then
   echo "Using local schema file: ${SCHEMA_ZED_FILE}"
   cp "${SCHEMA_ZED_FILE}" "${SCHEMA_DEST}"
 else
-  SCHEMA_URL="${SCHEMA_ZED_URL:-https://raw.githubusercontent.com/RedHatInsights/rbac-config/refs/heads/master/configs/stage/schemas/schema.zed}"
+  SCHEMA_URL="${SCHEMA_ZED_URL:-https://raw.githubusercontent.com/project-kessel/rbac-config/refs/heads/master/configs/stage/schemas/schema.zed}"
   echo "Downloading schema.zed from ${SCHEMA_URL}"
   curl -fsSL -o "${SCHEMA_DEST}" "${SCHEMA_URL}"
 fi
@@ -56,7 +56,7 @@ if [ -n "${RBAC_CONFIG_FILE}" ]; then
   echo "Using local RBAC config: ${RBAC_CONFIG_FILE}"
   RBAC_CONFIG_SRC="${RBAC_CONFIG_FILE}"
 else
-  RBAC_CONFIG_URL="${RBAC_CONFIG_URL:-https://raw.githubusercontent.com/RedHatInsights/rbac-config/refs/heads/master/_private/configmaps/stage/rbac-config.yml}"
+  RBAC_CONFIG_URL="${RBAC_CONFIG_URL:-https://raw.githubusercontent.com/project-kessel/rbac-config/refs/heads/master/_private/configmaps/stage/rbac-config.yml}"
   RBAC_CONFIG_SRC=$(mktemp)
   trap "rm -f ${RBAC_CONFIG_SRC}" EXIT
   echo "Downloading RBAC role definitions from ${RBAC_CONFIG_URL}"

--- a/scripts/start-inventory-spicedb.sh
+++ b/scripts/start-inventory-spicedb.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+source ./scripts/check_docker_podman.sh
+
+export CONFIG=local-w-spicedb
+export HTTP_PORT=8000
+export GRPC_PORT=9000
+
+SCHEMA_DEST="development/configs/schema.zed"
+
+if [ -n "${SCHEMA_ZED_FILE}" ]; then
+  echo "Using local schema file: ${SCHEMA_ZED_FILE}"
+  cp "${SCHEMA_ZED_FILE}" "${SCHEMA_DEST}"
+else
+  SCHEMA_URL="${SCHEMA_ZED_URL:-https://raw.githubusercontent.com/project-kessel/rbac-config/refs/heads/master/configs/stage/schemas/schema.zed}"
+  echo "Downloading schema.zed from ${SCHEMA_URL}"
+  curl -fsSL -o "${SCHEMA_DEST}" "${SCHEMA_URL}"
+fi
+
+NETWORK_CHECK=$(${DOCKER} network ls --filter name=kessel --format json)
+if [[ -z "${NETWORK_CHECK}" || "${NETWORK_CHECK}" == "[]" ]]; then ${DOCKER} network create kessel; fi
+
+${DOCKER} compose -f development/docker-compose.yaml -f development/docker-compose.spicedb.yaml up --build -d \
+  inventory-api spicedb-database spicedb-migrate spicedb kafka-connect-setup kafka-setup

--- a/scripts/stop-inventory.sh
+++ b/scripts/stop-inventory.sh
@@ -7,4 +7,4 @@ export GRPC_PORT=1
 
 # Function to check if a command is available
 source ./scripts/check_docker_podman.sh
-${DOCKER} compose -f development/docker-compose.yaml down
+${DOCKER} compose -f development/docker-compose.yaml -f development/docker-compose.spicedb.yaml down


### PR DESCRIPTION
- Adds compose file for SpiceDB dependencies
- Adds script for launching local spicedb compose and downloading stage zed schema
  - Adds gitignore for development zed schema
- Adds `inventory-up-w-spicedb` make target
- Adds e2e runbook file
- Bolsters config error handling for relations/spicedb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a one-command `make inventory-up-spicedb` flow to run Inventory with an embedded SpiceDB stack.
  * Added a local Docker Compose configuration for SpiceDB + Postgres + Kafka with schema wiring.
* **Bug Fixes**
  * Improved configuration validation to fail fast when the selected authorization backend is missing.
  * Enabled relations processing for the SpiceDB-backed relations repository.
* **Documentation**
  * Updated the local Docker Compose guide with embedded SpiceDB instructions and ports.
  * Added an embedded SpiceDB end-to-end developer runbook.
* **Chores**
  * Updated local schema/source URLs to use the correct `project-kessel/rbac-config` locations.
  * Updated ignore rules for the local embedded schema file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->