### PR TITLE
RHCLOUD-48782: migrates kessel-debug to hummingbird, updates docs and tooling with it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,14 @@ inventory-down:
 inventory-down-kind:
 	./scripts/stop-inventory-kind.sh
 
+.PHONY: update-kessel-debug
+update-kessel-debug:
+	./scripts/update-kessel-debug.sh
+
+.PHONY: build-kessel-debug
+build-kessel-debug:
+	$(DOCKER) build -t localhost/kessel-debug:latest -f tools/kessel-debug-container/Dockerfile tools/kessel-debug-container
+
 .PHONY: update-local-dashboards
 update-local-dashboards:
 	./scripts/update-local-dashboards.sh

--- a/scripts/update-kessel-debug.sh
+++ b/scripts/update-kessel-debug.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+DOCKERFILE="tools/kessel-debug-container/Dockerfile"
+
+LIBRDKAFKA_MIRROR="https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/"
+KCAT_MIRROR="https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/k/"
+
+echo "Checking for latest librdkafka x86_64 RPM..."
+LIBRDKAFKA_LATEST=$(curl -fsSL "$LIBRDKAFKA_MIRROR" \
+  | grep -oP 'href="librdkafka-\K[^"]+(?=\.el9\.x86_64\.rpm")' \
+  | sort -V \
+  | tail -n 1)
+
+if [ -z "$LIBRDKAFKA_LATEST" ]; then
+  echo "ERROR: Could not determine latest librdkafka version" >&2
+  exit 1
+fi
+
+echo "Checking for latest kcat x86_64 RPM..."
+KCAT_LATEST=$(curl -fsSL "$KCAT_MIRROR" \
+  | grep -oP 'href="kcat-\K[^"]+(?=\.el9\.x86_64\.rpm")' \
+  | sort -V \
+  | tail -n 1)
+
+if [ -z "$KCAT_LATEST" ]; then
+  echo "ERROR: Could not determine latest kcat version" >&2
+  exit 1
+fi
+
+LIBRDKAFKA_CURRENT=$(grep -oP 'LIBRDKAFKA_VERSION=\K.+' "$DOCKERFILE")
+KCAT_CURRENT=$(grep -oP 'KCAT_VERSION=\K.+' "$DOCKERFILE")
+
+echo ""
+echo "librdkafka: current=${LIBRDKAFKA_CURRENT} latest=${LIBRDKAFKA_LATEST}"
+echo "kcat:       current=${KCAT_CURRENT} latest=${KCAT_LATEST}"
+
+UPDATED=0
+
+if [ "$LIBRDKAFKA_CURRENT" != "$LIBRDKAFKA_LATEST" ]; then
+  sed -i "s/LIBRDKAFKA_VERSION=${LIBRDKAFKA_CURRENT}/LIBRDKAFKA_VERSION=${LIBRDKAFKA_LATEST}/" "$DOCKERFILE"
+  echo "Updated librdkafka: ${LIBRDKAFKA_CURRENT} -> ${LIBRDKAFKA_LATEST}"
+  UPDATED=1
+fi
+
+if [ "$KCAT_CURRENT" != "$KCAT_LATEST" ]; then
+  sed -i "s/KCAT_VERSION=${KCAT_CURRENT}/KCAT_VERSION=${KCAT_LATEST}/" "$DOCKERFILE"
+  echo "Updated kcat: ${KCAT_CURRENT} -> ${KCAT_LATEST}"
+  UPDATED=1
+fi
+
+if [ "$UPDATED" -eq 0 ]; then
+  echo "Already up to date."
+fi

--- a/scripts/update-kessel-debug.sh
+++ b/scripts/update-kessel-debug.sh
@@ -8,7 +8,7 @@ KCAT_MIRROR="https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/
 
 echo "Checking for latest librdkafka x86_64 RPM..."
 LIBRDKAFKA_LATEST=$(curl -fsSL "$LIBRDKAFKA_MIRROR" \
-  | grep -oP 'href="librdkafka-\K[^"]+(?=\.el9\.x86_64\.rpm")' \
+  | grep -oP 'href="librdkafka-\K[0-9][^"]+(?=\.el9\.x86_64\.rpm")' \
   | sort -V \
   | tail -n 1)
 

--- a/tools/kessel-debug-container/Dockerfile
+++ b/tools/kessel-debug-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1779809423
+FROM registry.access.redhat.com/hi/core-runtime:2.42-openssl-fips-builder
 
 USER root
 
@@ -6,12 +6,17 @@ USER root
 # Kafka is hardcoded for 3.9.x in the installer script
 ENV SCALA_VERSION=2.13
 
+# librdkafka is required by kcat -- versions below represent the latest from mirrors
+# see the README tools/kessel-debug-container/README.md for details on updating
+ENV LIBRDKAFKA_VERSION=1.6.1-102
+ENV KCAT_VERSION=1.7.1-1
+
+
 COPY ./installer.sh /tmp
 COPY ./scripts/* /usr/local/bin/
 
 RUN /tmp/installer.sh
 
-# starts in Kafka Home for shorter command paths
 WORKDIR /opt/kafka
 
 CMD ["sleep", "7200"]

--- a/tools/kessel-debug-container/Dockerfile
+++ b/tools/kessel-debug-container/Dockerfile
@@ -19,4 +19,6 @@ RUN /tmp/installer.sh
 
 WORKDIR /opt/kafka
 
+USER 1001
+
 CMD ["sleep", "7200"]

--- a/tools/kessel-debug-container/README.md
+++ b/tools/kessel-debug-container/README.md
@@ -92,3 +92,26 @@ oc process --local \
     -f https://raw.githubusercontent.com/project-kessel/inventory-api/refs/heads/main/tools/kessel-debug-container/kessel-debug-deploy.yaml \
     -p ENV=<target-environment (stage/prod)> | oc delete -f -
 ```
+
+### Updating Kessel Debug
+
+Packages installed via the package manager (`dnf`) are automatically updated on each build. However, some packages installed from external RPM mirrors are pinned to specific versions in the Dockerfile and must be updated manually:
+
+- **librdkafka** — installed from the CentOS 9-stream AppStream mirror
+- **kcat** — installed from the Fedora EPEL 9 mirror
+
+To check for newer versions and update the Dockerfile:
+
+```shell
+make update-kessel-debug
+```
+
+This fetches the latest x86_64 RPM versions from each mirror and updates the `LIBRDKAFKA_VERSION` and `KCAT_VERSION` environment variables in the Dockerfile if newer versions are available. If versions are already current, no changes are made.
+
+After updating, rebuild the debug image to verify the new versions install correctly:
+
+```shell
+make build-kessel-debug
+```
+
+This builds the image locally as `localhost/kessel-debug:latest`. Once verified, push the updated Dockerfile changes and the image will be rebuilt in CI.

--- a/tools/kessel-debug-container/installer.sh
+++ b/tools/kessel-debug-container/installer.sh
@@ -2,26 +2,28 @@
 
 set -euo pipefail
 
-echo "Setting up pre-reqs..."
-microdnf install -y jq
+echo "Installing DNF available packages..."
+dnf install -y jq curl tar gzip vim-minimal bind-utils java-21-openjdk util-linux less
 
-echo "Fetching required packages and RPM files..."
+echo "Installing remaining packages via RPMs from mirrors..."
 ZED_VERSION=$(curl -sSfL https://api.github.com/repos/authzed/zed/releases/latest | jq -er '.tag_name')
 # the tag fetched for zed will be in the format of 'vX.Y.Z', so bash substring is used below to strip the 'v'
 ZED_VERSION=${ZED_VERSION#v}
 
-# Download zed RPM and checksums
-curl -fLo /tmp/zed_${ZED_VERSION}_linux_amd64.rpm https://github.com/authzed/zed/releases/download/v${ZED_VERSION}/zed_${ZED_VERSION}_linux_amd64.rpm
-curl -fLo /tmp/zed_checksums.txt https://github.com/authzed/zed/releases/download/v${ZED_VERSION}/checksums.txt
+RPM_URLS=(
+  "https://github.com/authzed/zed/releases/download/v${ZED_VERSION}/zed_${ZED_VERSION}_linux_amd64.rpm"
+  "https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/librdkafka-${LIBRDKAFKA_VERSION}.el9.x86_64.rpm"
+  "https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/k/kcat-${KCAT_VERSION}.el9.x86_64.rpm"
+)
 
-# Verify zed checksum
-pushd /tmp
-grep "zed_${ZED_VERSION}_linux_amd64.rpm" zed_checksums.txt | sha256sum -c -
-popd
+for URL in ${RPM_URLS[*]}; do
+  dnf install -y $URL
+done
 
 # Download latest 3.9.x kafka tools
 # note currently hardcoded to only support kafka 3.9.x
 # this should remain until clusters move to 4.x
+echo "Installing Kafka tools..."
 BASE_URL="https://dlcdn.apache.org/kafka/"
 KAFKA_VERSION=$(
   curl -fsSL "$BASE_URL" \
@@ -32,14 +34,6 @@ KAFKA_VERSION=$(
 )
 
 curl -fLo /tmp/kafka.tgz https://dlcdn.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
-
-echo "Setting up EPEL Repository..."
-rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-
-echo "Installing packages..."
-microdnf install -y tar gzip wget bind-utils nmap-ncat openssl vim java-21-openjdk kcat util-linux less
-rpm -ivh /tmp/zed_${ZED_VERSION}_linux_amd64.rpm
-
 mkdir -pv /opt/kafka
 tar -xvf /tmp/kafka.tgz -C /opt/kafka --strip-components=1
 
@@ -48,6 +42,4 @@ mv /usr/bin/zed /usr/bin/zed.original
 mv /usr/local/bin/zed-wrapper.sh /usr/local/bin/zed
 
 echo "Clean up..."
-microdnf clean all -y
-rm /tmp/*.rpm
-rm /tmp/*.txt
+dnf clean all -y


### PR DESCRIPTION
### PR Template:

## Describe your changes
Migrates Kessel Debug to using Hummingbird images and reduce CVE patching needs over time
* Updates the base image to hummingbird core-runtime builder which uses dnf, not microdnf
* Adds new env vars for defining kcat/librdkafka versions as these must not be installed for rpm mirrors (no EPEL in hummingbird)
* Updates the installer script to use dnf and remove some extra steps since dnf can install rpm's directly via URL
* Updates the readme on how to update pinned versions of rpms and adds make targets to simplify updating and testing the build locally so you don't have to figure it out!
- ...

## Ticket reference (if applicable)
For RHCLOUD-48782


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local build commands to refresh pinned `librdkafka`/`kcat` package versions used by the Kessel debug container and rebuild the image.
* **Documentation**
  * Added a guide explaining how to update those pinned versions and rebuild locally for CI.
* **Bug Fixes**
  * Improved the debug container’s installation flow for more reliable dependency provisioning and cleaner installation/cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->