### PR TITLE
fix: removes kubectl wait in favor of rollout for healthy pod check

### DIFF
--- a/scripts/start-inventory-kind.sh
+++ b/scripts/start-inventory-kind.sh
@@ -276,11 +276,7 @@ check_connector_readiness "kessel-inventory-source-connector"
 
 # Restart inventory pod to pick up new config
 kubectl rollout restart deployment kessel-inventory
-kubectl rollout status deployment kessel-inventory --timeout=120s
-
-echo "Waiting for inventory pod readiness after restart..."
-kubectl wait --for=condition=Ready pod -l app=kessel-inventory --timeout=600s
-echo "Inventory pod is ready."
+kubectl rollout status deployment kessel-inventory --timeout=300s
 
 # Submit table-mode e2e tests
 kubectl apply -f deploy/kind/e2e/e2e-batch-outbox-table.yaml


### PR DESCRIPTION
### PR Template:

## Describe your changes

The problem: kubectl wait with a label selector matches all pods with that label, including the old terminating pod from the previous ReplicaSet. The new pod is Ready immediately, but the old pod is shutting down and will never become Ready again. After 600s it times out.

This causes:
* The table-mode e2e tests never ran because the script exited before reaching them.
* The job reports failure even though every test that did run passed.

kubectl rollout status already waits for readyz to pass. The removed kubectl wait was a duplicate check that happened to hit a known kubectl pitfall with label selectors during rollouts. No need to add it back.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the wait time for inventory deployment restart checks, reducing the chance of premature timeout during rollout verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->