### PR TITLE
RHCLOUD-46118: Update ephemeral template for dedicated kessel spicedb…

### DIFF
--- a/deploy/kessel-inventory-ephem.yaml
+++ b/deploy/kessel-inventory-ephem.yaml
@@ -25,6 +25,10 @@ objects:
           kessel:
             insecure-client: true
             enable-oidc-auth: false
+          spicedb:
+            schema-file: "/etc/spicedb-schema/schema.zed"
+            use-tls: false
+            fully-consistent: true
         selfsubjectstrategy:
           redhatRbacSelfSubjectStrategy:
             enabled: true
@@ -59,6 +63,132 @@ objects:
       name: resources-tarball
     binaryData:
       resources.tar.gz: H4sIAAAAAAAAA+1c63OaShTP5/wVO97O9EuqvJQ7+WYNaZgYzfhIb+9tr0NwVVoEu0BvM53873dXxQACPorrJDm/L8jhAMueB+exWK6cHBwChVqtzrcUye38t6ioqiwokqiqlK6qUvUEVQ8/tJOTwPMNgtAJcV0/j2/T8WeKcmXiev5hlWAr+VcpjyirkkLlLwo1VQH588BS/qY7nbrOgOAZwR52fMO3XKf81XOdAu7BBFxTlEz5S+pC/jJVEkGVqPxrolo7QUIB996IVy7/X6cIld545gRPjdI5Kk18f3ZeqTDJv1tQyy4ZV4bEGPnvBLWyoP1ROmPn+Q8zzE5y779i01/QZsSdYeJb2KNH2NUp7T+XfPNmhokH1pBRn870fGI54xJ6pIyP8/MJ/h5YBDO+f1LOpqQvp4+np8eet5eClf07I2tcfjCmdvH32GT/Qi3p/2VBEsH+eYC6ezcg1LaYRZ4jpgynKxp9HbjEx8Q7p2b3Dk3uLbC7F4al/a8kfYhIcOf4X5RUSYX4jwfW5E+NvGgd2DL+r0k1kXp+kfl/pSqA/HkgVf6MVFTwf7Lx/U+tvTqXv8zURKR6IlZlWYH3Pw9wif89w8e2bflh/D+nUrrr4PZoFegzrKcGZ6g0csnU8BktCOgFFolCDv/M8KkqO4z47+fPw1+i8Pgm6ywnsO1F+sHwZb5dcpa84N4ziTVjufBgajjGGJMwgznII+QNxnI8azzxvaMNwKADuLfxgDmHPYQ4NX42sTP2J5QsVau7DCA1N2RZ4LGN5wUg1f8XnA1uzv9qifivWpPA/3NBev63UIaBY0wZjaZ97Ne8BnMOWeCLQrny7U9vMHNty3w4VBdgy/g/Uv+VaFQI8T8PxOR/oC7AJv+/Xv+nr4Iq+H8egPr/60bC/g/SBdg9/lNEBeI/LkjEf0/KkNkFqDduwPpeDGL2f6AuwFbxX9z+BbkG8R8PZMjfMKfF6cAe8q+qIH8uyJF/YdHARvmz+n9M/jUV6v98kPf+j1WBqEZEq0BsF8KA548c+3868JslgA3xvyhUk/E/9RYq2D8PcMn/h5Zn3Ns41vsLz713XRsbTilsB5WGeNV0Y8cv8MhysIesEfInGC0UElkeMgNCsOPbDwg786sjl6DwTtQ/EdfzkGHbiMp3jH2vXIo39/APTCz/IW1MYdcqpGMnmMY6XKWudqd19N6nQb/VvdUa+qWuXZTOUo63e1daJ3qk2f4Y3b3RLvT+TZRypX+4iu436HX0Rr1ZCptiWTPVo9MTPhWy6Q8budFJCycgp9SyElRykpZll2NrK6BolCuO61sjy5zXer2B5fh4TOY7hSUAW8X/sfpvVVSh/s8FefIvqh2wqf63Vv+XJEWF+j8XQP3/dSPf/ospAGyyf1FUk/G/LMP6fy5I5P8xZahElCGzHdBq92j026j39HarC2b53JBn/0W1A3av/6qSBPVfLthO/nG3sOs9dpa/JAkqfP/BBfvIP/OMjNxgU/1Pqipx+cuCxL7/gPf/4cEl/l+1EpYn7FFwi4UZW5XC2LVZASy8+RkaWT/xEPkuehu72ls0cgnyJ5aHlk8crxSuRm85VFccM/kVQ9ZDJMZUR4FjfQ8wsoY0l6YGhMnyxng1RhTe4gx5gTlBhocM5GHywzIxMkzTDRw/MTrbNQ17sIrO9hzaggGtUn22wwY2v3p0xMuKYni/LWqKceHnzWnmE0H18WBY9H9Mm7pBTA60AHj3+p8k1mR4//NAXP6HWQC8c/1PVJUa9P+4AOp/rxtJ+z/EAuBN/l8UkvU/RZag/s8FKet/lsqQuwB4se3Ot21YEPx8Ebf/wywA3r3+p0gS/P8DF2TJ3zCL04E95K/WoP7LBXnyL7L/t9v6X1WE77/5IPf9n1gA7MUXAHvw1n/+yLP/yJHfqgFssH9Zpjl/vP8jiDLk/1zAJf/HP9n/8Rh2qE3ZZYBlCTjko7LxA2+/jkGj2e/2tM6g26v3+t2shboJrrXluh2tfvEpSris6834JdqXl029pa2aErHyfPgkBBvevNie89Tfgns8+EGtz9qS0xm6ZL/Jue6/1wZ3Wuui3cmamSjL2rTUr7vRXS2+q8d327daq3ulX/aixA/XGTO2eKzt5sG03WA4mNmGz/7faF89afcvBrfNeu+y3bnJ1pMY19qEtNotbdC/1aO09/WOdqP16s2BnnUgcUb9YzfJy0hJrr/7HW2Nb05McOrvbxYD1zPoCX4m8zu900vyzyXYqzeusw8krvShcZvkZaQEV6vfq7f0v5KcITnBfde9pbO+9uQhOcHdXj1Iqpo57hCnehaDEOPhSWEsH0+jfOlub3kkxfktj7DIKVeXl3zmLNiGbYqnLnnIrqUuEDlnva4aHdjaENJutiJ9Wf56PN3Y/Evz/Ok+Pt1fpnnGFB+Y7jrSnQRUkKPIiv/cAj8A3if/h+9/+SBP/vzyf2Ut/5dliP95YPv8341/AEx3jz12wO8jz/6Pmf8rkP9zAeT/kP9D/g/5/5PMIf+H/B/y/9eC7P7PcfP/Gqz/4II8+fPL/9e+/xUl+P6HC3bp/6//ARg40eeOPPs/av8fvv/nAsj/If+H/B/y/yeZQ/4P+T/k/wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPCf8DzrcHBEAoAAA
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: kessel-spicedb-config
+    stringData:
+      preshared_key: "averysecretpresharedkey"
+      datastore_uri: postgres://authz:SuperSecretPassword@kessel-spicedb-postgres:5432/authz?sslmode=disable
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: kessel-spicedb-postgres-secret
+    stringData:
+      POSTGRESQL_DATABASE: authz
+      POSTGRESQL_USER: authz
+      POSTGRESQL_PASSWORD: SuperSecretPassword
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app: kessel-spicedb-postgres
+      name: kessel-spicedb-postgres
+    spec:
+      strategy:
+        type: Recreate
+      selector:
+        matchLabels:
+          app: kessel-spicedb-postgres
+      template:
+        metadata:
+          labels:
+            app: kessel-spicedb-postgres
+        spec:
+          containers:
+          - env:
+            - name: POSTGRESQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: kessel-spicedb-postgres-secret
+                  key: POSTGRESQL_DATABASE
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: kessel-spicedb-postgres-secret
+                  key: POSTGRESQL_USER
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kessel-spicedb-postgres-secret
+                  key: POSTGRESQL_PASSWORD
+            - name: PGDATA
+              value: /var/lib/pgsql/data
+            image: registry.redhat.io/rhel9/postgresql-16:9.5-1744136555
+            imagePullPolicy: Always
+            name: postgres
+            ports:
+            - containerPort: 5432
+              protocol: TCP
+            resources:
+              limits:
+                cpu: ${SPICEDB_POSTGRES_CPU_LIMIT}
+                memory: ${SPICEDB_POSTGRES_MEMORY_LIMIT}
+              requests:
+                cpu: ${SPICEDB_POSTGRES_CPU_REQUEST}
+                memory: ${SPICEDB_POSTGRES_MEMORY_REQUEST}
+            volumeMounts:
+            - name: kessel-spicedb-postgres-data
+              mountPath: /var/lib/pgsql/data
+          volumes:
+          - name: kessel-spicedb-postgres-data
+            persistentVolumeClaim:
+              claimName: kessel-spicedb-postgres-data
+          restartPolicy: Always
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: kessel-spicedb-postgres-data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: kessel-spicedb-postgres
+      name: kessel-spicedb-postgres
+    spec:
+      ports:
+      - name: http
+        port: 5432
+        protocol: TCP
+      selector:
+        app: kessel-spicedb-postgres
+  - apiVersion: authzed.com/v1alpha1
+    kind: SpiceDBCluster
+    metadata:
+      name: kessel-spicedb
+    spec:
+      config:
+        logLevel: debug
+        replicas: ${{SPICEDB_REPLICAS}}
+        datastoreEngine: postgres
+        image: ${{SPICEDB_IMAGE}}
+      secretName: kessel-spicedb-config
+      patches:
+      - kind: Deployment
+        patch:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: spicedb
+                  resources:
+                    requests:
+                      memory: ${SPICEDB_MEMORY_REQUEST}
+                      cpu: ${SPICEDB_CPU_REQUEST}
+                    limits:
+                      memory: ${SPICEDB_MEMORY_LIMIT}
+                      cpu: ${SPICEDB_CPU_LIMIT}
+                  env:
+                    - name: SPICEDB_DISPATCH_CLUSTER_ENABLED
+                      value: "false"
+                    - name: SPICEDB_DISPATCH_UPSTREAM_ADDR
+                      value: ""
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
     metadata:
@@ -83,6 +213,18 @@ objects:
           replicas: ${{REPLICAS}}
           podSpec:
             initContainers:
+              - name: fetch-spicedb-schema
+                image: ${SCHEMA_INIT_IMAGE}
+                command:
+                  - sh
+                  - -c
+                  - |
+                    curl -sSfL -o /etc/spicedb-schema/schema.zed \
+                      "https://raw.githubusercontent.com/${SPICEDB_SCHEMA_REPO}/${SPICEDB_SCHEMA_REF}/${SPICEDB_SCHEMA_PATH}"
+                inheritEnv: false
+                volumeMounts:
+                  - name: spicedb-schema
+                    mountPath: /etc/spicedb-schema
               - name: copy-resources
                 image: registry.access.redhat.com/ubi9
                 imagePullPolicy: Always
@@ -123,6 +265,15 @@ objects:
                 value: "/inventory/inventory-api-config.yaml"
               - name: PGDATA
                 value: /temp/data
+              - name: INVENTORY_API_AUTHZ_IMPL
+                value: ${AUTHZ_IMPL}
+              - name: INVENTORY_API_AUTHZ_SPICEDB_ENDPOINT
+                value: "kessel-spicedb:50051"
+              - name: INVENTORY_API_AUTHZ_SPICEDB_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: kessel-spicedb-config
+                    key: preshared_key
             volumeMounts:
               - name: config-volume
                 mountPath: "/inventory"
@@ -130,6 +281,8 @@ objects:
                 mountPath: "/data/schema/resources"
               - name: resources-tarball
                 mountPath: "/mnt/resources"
+              - name: spicedb-schema
+                mountPath: /etc/spicedb-schema
             volumes:
               - name: config-volume
                 configMap:
@@ -139,6 +292,8 @@ objects:
               - name: resources-tarball
                 configMap:
                   name: resources-tarball
+              - name: spicedb-schema
+                emptyDir: {}
           webServices:
             public:
               enabled: true
@@ -280,3 +435,48 @@ parameters:
   - description: Suspend the metrics collection CronJob (set to true to disable)
     name: METRICS_CRONJOB_SUSPEND
     value: "true"
+  - name: AUTHZ_IMPL
+    description: Authz implementation (allow-all, kessel, spicedb)
+    value: "kessel"
+  - name: SPICEDB_IMAGE
+    description: SpiceDB container image
+    value: quay.io/redhat-services-prod/project-kessel-tenant/kessel-relations/spicedb:latest
+  - name: SPICEDB_REPLICAS
+    description: Number of SpiceDB pods
+    value: "1"
+  - name: SPICEDB_CPU_REQUEST
+    description: SpiceDB CPU Request
+    value: 200m
+  - name: SPICEDB_CPU_LIMIT
+    description: SpiceDB CPU Limit
+    value: 500m
+  - name: SPICEDB_MEMORY_REQUEST
+    description: SpiceDB Memory Request
+    value: 128Mi
+  - name: SPICEDB_MEMORY_LIMIT
+    description: SpiceDB Memory Limit
+    value: 128Mi
+  - name: SPICEDB_POSTGRES_CPU_REQUEST
+    description: SpiceDB Postgres CPU Request
+    value: 200m
+  - name: SPICEDB_POSTGRES_CPU_LIMIT
+    description: SpiceDB Postgres CPU Limit
+    value: 500m
+  - name: SPICEDB_POSTGRES_MEMORY_REQUEST
+    description: SpiceDB Postgres Memory Request
+    value: 128Mi
+  - name: SPICEDB_POSTGRES_MEMORY_LIMIT
+    description: SpiceDB Postgres Memory Limit
+    value: 128Mi
+  - name: SCHEMA_INIT_IMAGE
+    description: Image for the schema init container
+    value: registry.access.redhat.com/ubi9/ubi-minimal:latest
+  - name: SPICEDB_SCHEMA_REPO
+    description: GitHub org/repo for SpiceDB schema
+    value: project-kessel/rbac-config
+  - name: SPICEDB_SCHEMA_REF
+    description: Git ref for SpiceDB schema
+    value: master
+  - name: SPICEDB_SCHEMA_PATH
+    description: Path to schema.zed within the repo
+    value: configs/stage/schemas/schema.zed


### PR DESCRIPTION
* Deploys a new `SpiceDB` definition and postgres instance for use by Inventory when running in `SpiceDB` authz mode
  * Completely separate from relations and existing spicedb instance
  * This means two spicedb instances will be deployed (using separate DBs) until we deprecate relations
* Ported over new SpiceDB stage schema fetching code in init container 

Validated in ephemeral instance `ephemeral-zs9btz`

Once merged, use the following to deploy with the new setup `bonfire deploy kessel --source appsre --ref-env insights-stage -p kessel-inventory/AUTHZ_IMPL=spicedb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inventory in ephemeral environments now uses SpiceDB for authorization.
  * Added automatic schema loading so the service can start with the correct access rules.
  * Provisioned the supporting database and authorization services needed for a complete ephemeral setup.

* **Bug Fixes**
  * Improved authorization consistency by enabling fully consistent checks.
  * Updated service configuration to better support secure and reliable authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->