### PR TITLE
RHCLOUD-48786: sets coderabbit learnings to global

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -210,6 +210,8 @@ reviews:
         mode: "error"
 
 knowledge_base:
+  learnings:
+    scope: global
   code_guidelines:
     enabled: true
     filePatterns:


### PR DESCRIPTION
### PR Template:

## Describe your changes
Adds missing setting that should have been included in https://github.com/project-kessel/inventory-api/pull/1390 and got 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s AI review configuration to include a global learning scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->