### PR TITLE
moves relations to dependency vs optional

### DIFF
--- a/deploy/kessel-inventory-ephem.yaml
+++ b/deploy/kessel-inventory-ephem.yaml
@@ -205,7 +205,7 @@ objects:
         - topicName: outbox.event.kessel.resources
           partitions: 1
           replicas: 3
-      optionalDependencies:
+      dependencies:
         - kessel-relations
         - kessel-kafkaconnect
       deployments:


### PR DESCRIPTION
### PR Template:

## Describe your changes
While Relations is listed as an optional dep, teams that reference kessel-inventory as a dep do not get all optional deps defined by Kessel unless they deploy kessel specifically. This is causing clowder injection to fail setting the kessel URL needed to talk to relations. This addresses the issue

Also moves KKC into deps for the same reaons
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the deployment template so a previously optional backend connection is now required, ensuring the app starts with the expected supporting service available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->