### PR TITLE
RHCLOUD-48946: moves KKC to dependencies

### DIFF
--- a/deploy/kessel-inventory-ephem.yaml
+++ b/deploy/kessel-inventory-ephem.yaml
@@ -207,7 +207,6 @@ objects:
           replicas: 3
       dependencies:
         - kessel-relations
-      optionalDependencies:
         - kessel-kafkaconnect
       deployments:
         - name: api


### PR DESCRIPTION
### PR Template:

## Describe your changes
Moves KKC to dependencies as it is required by Kessel and some services for Kessel to properly function

Note: this PR is dependent on https://github.com/project-kessel/kessel-kafka-connect/pull/100 merging first which itself relies on an App Interface PR merging. See the jira card for more info and PR links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s service requirements so a previously optional backend dependency is now required for deployment. This helps ensure the app starts with all needed components available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->