### PR TITLE
RHCLOUD-48927: Add SpiceDB direct mode parameters to deployment template

### DIFF
--- a/deploy/kessel-inventory.yaml
+++ b/deploy/kessel-inventory.yaml
@@ -85,6 +85,11 @@ objects:
                   mountPath: "/data/schema/resources"
                 - name: resources-tarball
                   mountPath: "/mnt/resources"
+                - name: spicedb-schema
+                  mountPath: "/etc/spicedb-schema"
+                - name: spicedb-secret
+                  mountPath: "/etc/spicedb-secret"
+                  readOnly: true
             volumes:
               - name: config-volume
                 secret:
@@ -98,6 +103,17 @@ objects:
               - name: resources-tarball
                 configMap:
                   name: resources-tarball
+              - name: spicedb-schema
+                configMap:
+                  name: ${SPICEDB_SCHEMA_CONFIGMAP}
+                  optional: true
+              - name: spicedb-secret
+                secret:
+                  secretName: ${SPICEDB_SECRET_NAME}
+                  optional: true
+                  items:
+                    - key: preshared_key
+                      path: preshared_key
           webServices:
             public:
               enabled: true
@@ -256,3 +272,9 @@ parameters:
   - description: Suspend the metrics collection CronJob (set to true to disable)
     name: METRICS_CRONJOB_SUSPEND
     value: "false"
+  - description: K8s secret containing SpiceDB preshared key (mounted as token-file)
+    name: SPICEDB_SECRET_NAME
+    value: "spicedb-config"
+  - description: ConfigMap containing SpiceDB schema.zed
+    name: SPICEDB_SCHEMA_CONFIGMAP
+    value: "spicedb-schema"


### PR DESCRIPTION
## What changed

- Added two optional volume mounts to the deployment template: the spicedb-schema configmap at /etc/spicedb-schema and the spicedb-config secret at /etc/spicedb-secret (readOnly). Both use optional: true so pods start normally in environments where these resources don't exist.
- Added two template parameters (SPICEDB_SECRET_NAME, SPICEDB_SCHEMA_CONFIGMAP) to keep the mounted resource names configurable.

## Why

This is the deployment side of connecting inventory-api directly to SpiceDB as part of merging the relations service. The Go code for SpiceDB direct mode was wired in via #1386 and #1380 but the non-ephemeral template had no way to provide the schema file or preshared key to the process.

All SpiceDB configuration (impl, endpoint, token-file, schema path, TLS, consistency) is controlled through the inventory-api-config secret rather than template env vars. Viper gives env vars higher precedence than config file values, so using env vars would prevent the config secret from being the single control point. This matches how the existing kessel authz settings (sa-client-id, sso-token-endpoint, etc.) are already managed.

## Validation

- Processed the template locally with oc process using default parameters. Output shows the two optional volume mounts alongside existing resources, with the three original env vars unchanged.
- Verified optional: true on both the secret and configmap volumes prevents pod startup failures when the resources are absent.

Jira: RHCLOUD-48927

Depends on #1386 and #1380 being merged for the SpiceDB code path to be reachable at runtime. The template change itself is safe to merge independently. A follow-up app-interface MR will set authz.impl to spicedb in the stage config secret and add the spicedb subsection (endpoint, token-file, schema-file, use-tls, fully-consistent) to activate direct mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for optionally mounting a SpiceDB schema ConfigMap into the application container.
  * Added support for optionally mounting a SpiceDB secret into the application container as read-only.

* **Chores**
  * Extended deployment template parameters to customize the schema ConfigMap and secret names used for these mounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->