### PR TITLE
NOJIRA-1234: Renovate: Disable go-kratos major updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,12 @@
     "schedule": ["* 0-7 * * 0"],
     "packageRules": [
       {
+        "matchManagers": ["gomod"],
+        "matchPackageNames": ["github.com/go-kratos/**"],
+        "matchUpdateTypes": ["major"],
+        "enabled": false
+      },
+      {
         "matchDatasources": ["go"],
         "enabled": true,
         "groupName": "Go updates",


### PR DESCRIPTION
## What changed
<!-- Brief description. Use bullet points for multi-part changes. -->
* Updated renovate config to exclude major updates for go-kratos 

## Why
<!-- Context and motivation. -->
* Major updates for go-kratos contain breaking changes and we do not want to block renovate updates for other packages before we get to the manual effort required for this

## Validation
<!-- How you verified this works: test output, ephemeral env name, screenshots, etc. Write "N/A" for trivial changes. -->
* N/A

Jira: <!-- RHCLOUD-XXXXX or N/A -->

<!-- Note any dependencies on other PRs or breaking changes here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to prevent automatic major-version updates for selected Go Kratos dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->