### PR TITLE
RHCLOUD-48847: configures linked repos in coderabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -349,24 +349,9 @@ knowledge_base:
   pull_requests:
     scope: "auto"
   linked_repositories:
-    - repository: "project-kessel/kessel-sdk-go"
-      instructions: |
-        Go SDK. Generated from inventory-api protos via buf.gen.yaml (BSR module buf.build/project-kessel/inventory-api). Auto-regenerated every 6h by CI. Breaking changes to watch: renaming/removing proto messages or fields (ReportResourceRequest, DeleteResourceRequest, CheckRequest, ResourceReference, SubjectReference, etc.), renaming/removing RPCs (ReportResource, DeleteResource, Check, CheckForUpdate, StreamedListObjects, StreamedListSubjects), changing field types or numbers, removing services (KesselInventoryService, KesselTupleService, KesselInventoryHealthService). Also consumes buf.validate types -- changes to validation annotations affect generated code.
-    - repository: "project-kessel/kessel-sdk-java"
-      instructions: |
-        Java SDK. Generated from inventory-api protos via buf.gen.yaml (BSR module buf.build/project-kessel/inventory-api). Auto-regenerated every 6h by CI. Same breaking change surface as kessel-sdk-go: proto message/field/RPC renames or removals, field type changes, service removals. Java stubs live in org.project_kessel.api.inventory.v1beta2 package.
-    - repository: "project-kessel/kessel-sdk-node"
-      instructions: |
-        Node/TypeScript SDK. Generated from inventory-api protos via buf.gen.yaml using ts-proto plugin (BSR module buf.build/project-kessel/inventory-api). Auto-regenerated every 6h by CI. Same breaking change surface as other SDKs: proto message/field/RPC renames or removals, field type changes, service removals. Exports kessel/inventory/v1beta2 TypeScript modules.
-    - repository: "project-kessel/kessel-sdk-py"
-      instructions: |
-        Python SDK. Generated from inventory-api protos via buf.gen.yaml (BSR module buf.build/project-kessel/inventory-api). Auto-regenerated every 6h by CI. Same breaking change surface as other SDKs: proto message/field/RPC renames or removals, field type changes, service removals. Uses include_imports: true because buf.validate protos are not on PyPI.
-    - repository: "project-kessel/kessel-sdk-ruby"
-      instructions: |
-        Ruby SDK. Generated from inventory-api protos via buf.gen.yaml (BSR module buf.build/project-kessel/inventory-api). Auto-regenerated every 6h by CI. Same breaking change surface as other SDKs: proto message/field/RPC renames or removals, field type changes, service removals.
     - repository: "project-kessel/kessel-sdk-browser"
       instructions: |
-        Browser/React SDK (@project-kessel/react-kessel-access-check). Does NOT use proto codegen -- makes runtime HTTP calls to inventory-api's v1beta2 endpoints (checkself, checkselfbulk) with hand-written TypeScript types. Breaking changes to watch: HTTP endpoint path changes (/api/kessel/v1beta2/checkself, /api/kessel/v1beta2/checkselfbulk), request/response JSON shape changes for Check/CheckSelf operations, HTTP status code semantics, authentication flow changes affecting browser clients.
+        Browser/React SDK (@project-kessel/react-kessel-access-check). Does NOT use proto codegen -- makes runtime HTTP calls to inventory-api's v1beta2 endpoints (checkself, checkselfbulk) with hand-written TypeScript types. Breaking changes to watch: HTTP endpoint path changes (/api/kessel/v1beta2/checkself, /api/kessel/v1beta2/checkselfbulk), request/response JSON shape changes for Check/CheckSelf operations, HTTP status code semantics, authentication flow changes affecting browser clients. Not covered by buf breaking checks since it has no proto dependency.
     - repository: "project-kessel/inventory-consumer"
       instructions: |
-        Kafka consumer service that reads Debezium CDC messages and forwards them to inventory-api via gRPC (through kessel-sdk-go). Two dependency paths: (1) Go module dependency on inventory-api cmd/common package (ToPointer, InitLogger, GetLogLevel utilities -- used in tests only). (2) Runtime gRPC dependency via kessel-sdk-go on ReportResource, DeleteResource, GetLivez RPCs and their request/response types. Also depends on the Kafka/outbox event schema -- changes to outbox event format, Debezium message headers (operation, version), or CloudEvents payload structure would break message parsing.
+        Kafka consumer service that reads Debezium CDC messages and forwards them to inventory-api via gRPC (through kessel-sdk-go). Two dependency paths: (1) Go module dependency on inventory-api cmd/common package (ToPointer, InitLogger, GetLogLevel utilities -- used in tests only). (2) Runtime gRPC dependency via kessel-sdk-go on ReportResource, DeleteResource, GetLivez RPCs and their request/response types. Also depends on the Kafka/outbox event schema -- changes to outbox event format, Debezium message headers (operation, version), or CloudEvents payload structure would break message parsing. Proto-level breaking changes are caught by buf CI, but cmd/common and event schema changes are not.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -348,3 +348,25 @@ knowledge_base:
     scope: "auto"
   pull_requests:
     scope: "auto"
+  linked_repositories:
+    - repository: "project-kessel/kessel-sdk-go"
+      instructions: |
+        Go SDK. Generated from inventory-api protos via buf.gen.yaml (BSR module buf.build/project-kessel/inventory-api). Auto-regenerated every 6h by CI. Breaking changes to watch: renaming/removing proto messages or fields (ReportResourceRequest, DeleteResourceRequest, CheckRequest, ResourceReference, SubjectReference, etc.), renaming/removing RPCs (ReportResource, DeleteResource, Check, CheckForUpdate, StreamedListObjects, StreamedListSubjects), changing field types or numbers, removing services (KesselInventoryService, KesselTupleService, KesselInventoryHealthService). Also consumes buf.validate types -- changes to validation annotations affect generated code.
+    - repository: "project-kessel/kessel-sdk-java"
+      instructions: |
+        Java SDK. Generated from inventory-api protos via buf.gen.yaml (BSR module buf.build/project-kessel/inventory-api). Auto-regenerated every 6h by CI. Same breaking change surface as kessel-sdk-go: proto message/field/RPC renames or removals, field type changes, service removals. Java stubs live in org.project_kessel.api.inventory.v1beta2 package.
+    - repository: "project-kessel/kessel-sdk-node"
+      instructions: |
+        Node/TypeScript SDK. Generated from inventory-api protos via buf.gen.yaml using ts-proto plugin (BSR module buf.build/project-kessel/inventory-api). Auto-regenerated every 6h by CI. Same breaking change surface as other SDKs: proto message/field/RPC renames or removals, field type changes, service removals. Exports kessel/inventory/v1beta2 TypeScript modules.
+    - repository: "project-kessel/kessel-sdk-py"
+      instructions: |
+        Python SDK. Generated from inventory-api protos via buf.gen.yaml (BSR module buf.build/project-kessel/inventory-api). Auto-regenerated every 6h by CI. Same breaking change surface as other SDKs: proto message/field/RPC renames or removals, field type changes, service removals. Uses include_imports: true because buf.validate protos are not on PyPI.
+    - repository: "project-kessel/kessel-sdk-ruby"
+      instructions: |
+        Ruby SDK. Generated from inventory-api protos via buf.gen.yaml (BSR module buf.build/project-kessel/inventory-api). Auto-regenerated every 6h by CI. Same breaking change surface as other SDKs: proto message/field/RPC renames or removals, field type changes, service removals.
+    - repository: "project-kessel/kessel-sdk-browser"
+      instructions: |
+        Browser/React SDK (@project-kessel/react-kessel-access-check). Does NOT use proto codegen -- makes runtime HTTP calls to inventory-api's v1beta2 endpoints (checkself, checkselfbulk) with hand-written TypeScript types. Breaking changes to watch: HTTP endpoint path changes (/api/kessel/v1beta2/checkself, /api/kessel/v1beta2/checkselfbulk), request/response JSON shape changes for Check/CheckSelf operations, HTTP status code semantics, authentication flow changes affecting browser clients.
+    - repository: "project-kessel/inventory-consumer"
+      instructions: |
+        Kafka consumer service that reads Debezium CDC messages and forwards them to inventory-api via gRPC (through kessel-sdk-go). Two dependency paths: (1) Go module dependency on inventory-api cmd/common package (ToPointer, InitLogger, GetLogLevel utilities -- used in tests only). (2) Runtime gRPC dependency via kessel-sdk-go on ReportResource, DeleteResource, GetLivez RPCs and their request/response types. Also depends on the Kafka/outbox event schema -- changes to outbox event format, Debezium message headers (operation, version), or CloudEvents payload structure would break message parsing.


### PR DESCRIPTION
## What changed
<!-- Brief description. Use bullet points for multi-part changes. -->

* Adds CodeRabbit multi-repo analysis to inventory-api by configuring linked_repositories in `.coderabbit.yaml`

## Why
<!-- Context and motivation. -->

This enables CodeRabbit to pull context from 7 downstream repos during PR  reviews and flag changes that could break dependents. 

Linked repositories
* 5 gRPC SDKs (Go, Java, Node, Python, Ruby) generated from inventory-api protos via Buf Schema Registry (BSR); sensitive to proto message/RPC/field changes
* The Browser SDK runtime HTTP dependency with hand-written types; sensitive to endpoint path and payload changes
* KIC which has Go module dependency on cmd/common (tests) + gRPC client via kessel-sdk-go + Kafka/outbox event schema dependency

## Validation
<!-- How you verified this works: test output, ephemeral env name, screenshots, etc. Write "N/A" for trivial changes. -->

Via coderabbit configuration check to ensure it loads in this PR (see comment below, looking for `linked_repositories` section -- https://github.com/project-kessel/inventory-api/pull/1410#issuecomment-4961441457)

we can also run a test PR after merging if desired by intentionally tweaking something that would break SDK's

Jira: RHCLOUD-48847

<!-- Note any dependencies on other PRs or breaking changes here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration to include cross-repository compatibility guidance for downstream runtime HTTP integration and CDC event parsing, including key breaking-surface considerations (endpoints, payload/header formats, and request/response contract changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->