### PR TITLE
RHCLOUD-49294: Use kafka 4.3.1 for debug pod

### DIFF
--- a/tools/kessel-debug-container/Dockerfile
+++ b/tools/kessel-debug-container/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/hi/core-runtime:2.42-openssl-fips-builder
 USER root
 
 # Kafka/Scala versions are hard set to ensure compatibility with current Kafka infra
-# Kafka is hardcoded for 3.9.x in the installer script
+ENV KAFKA_VERSION=4.3.1
 ENV SCALA_VERSION=2.13
 
 # librdkafka is required by kcat -- versions below represent the latest from mirrors

--- a/tools/kessel-debug-container/installer.sh
+++ b/tools/kessel-debug-container/installer.sh
@@ -20,20 +20,8 @@ for URL in ${RPM_URLS[*]}; do
   dnf install -y $URL
 done
 
-# Download latest 3.9.x kafka tools
-# note currently hardcoded to only support kafka 3.9.x
-# this should remain until clusters move to 4.x
 echo "Installing Kafka tools..."
-BASE_URL="https://dlcdn.apache.org/kafka/"
-KAFKA_VERSION=$(
-  curl -fsSL "$BASE_URL" \
-    | grep -Eo 'href="3\.9\.[0-9]+/' \
-    | sed -E 's|href="||; s|/||' \
-    | sort -V \
-    | tail -n 1
-)
-
-curl -fLo /tmp/kafka.tgz https://dlcdn.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
+curl -fLo /tmp/kafka.tgz "https://dlcdn.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
 mkdir -pv /opt/kafka
 tar -xvf /tmp/kafka.tgz -C /opt/kafka --strip-components=1
 


### PR DESCRIPTION
## What changed
<!-- Brief description. Use bullet points for multi-part changes. -->

* Updating kafka version that we are pulling from the apache CDN

## Why
<!-- Context and motivation. -->
* 3.9.x versions were removed from the apache CDN

## Validation
<!-- How you verified this works: test output, ephemeral env name, screenshots, etc. Write "N/A" for trivial changes. -->

# Kafka 4.3.1 CLI Compatibility Validation

Validates that Kafka 4.3.1 CLI tools in the kessel-debug container are backward compatible with Kafka 3.8.0 brokers (Strimzi).

## Environment

- **Debug container image:** `localhost/kessel-debug:test` (built from updated Dockerfile pinning `KAFKA_VERSION=4.3.1`)
- **Broker:** `quay.io/strimzi/kafka:latest-kafka-3.8.0` running in the inventory-api compose stack
- **Network:** podman `kessel` network

## Build

```
$ podman build --platform linux/amd64 -t kessel-debug:test \
    -f tools/kessel-debug-container/Dockerfile tools/kessel-debug-container/
...
Successfully tagged localhost/kessel-debug:test
```

## Stack Deployment

```
$ cd inventory-api && make inventory-up-relations-ready
...

$ grpcurl -plaintext localhost:9081 grpc.health.v1.Health/Check
{
  "status": "SERVING"
}
```

## Kafka 4.3.1 CLI Against 3.8.0 Broker

```
$ podman run --rm --network kessel localhost/kessel-debug:test sh -c '
echo "=== Kafka CLI version ==="
/opt/kafka/bin/kafka-topics.sh --version

echo ""
echo "=== Broker API versions (4.3.1 client negotiating with 3.8.0 broker) ==="
/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server kafka:9093 2>&1 | head -5

echo ""
echo "=== List topics ==="
/opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9093 --list

echo ""
echo "=== Describe outbox topic ==="
/opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9093 --describe --topic outbox.event.kessel.resources

echo ""
echo "=== Consumer groups ==="
/opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server kafka:9093 --list

echo ""
echo "=== Describe consumer group ==="
/opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server kafka:9093 --describe --group inventory-consumer

echo ""
echo "=== Get offsets ==="
/opt/kafka/bin/kafka-get-offsets.sh --bootstrap-server kafka:9093 --topic outbox.event.kessel.resources
'

=== Kafka CLI version ===
4.3.1

=== Broker API versions (4.3.1 client negotiating with 3.8.0 broker) ===
kafka:9093 (id: 0 rack: null isFenced: false) -> (
	Produce(0): 0 to 11 [usable: 11],
	Fetch(1): 0 to 16 [usable: 16],
	ListOffsets(2): 0 to 8 [usable: 8],
	Metadata(3): 0 to 12 [usable: 12],

=== List topics ===
__consumer_offsets
kafka_connect_configs
kafka_connect_offsets
kafka_connect_statuses
outbox.event.kessel.resources
outbox.event.kessel.tuples

=== Describe outbox topic ===
Topic: outbox.event.kessel.resources	TopicId: E6ZJZ_80QfSQGcnHXkEuFA	PartitionCount: 1	ReplicationFactor: 1	Configs:
	Topic: outbox.event.kessel.resources	Partition: 0	Leader: 0	Replicas: 0	Isr: 0	Elr: N/A	LastKnownElr: N/A

=== Consumer groups ===
inventory-consumer

=== Describe consumer group ===
GROUP              TOPIC                      PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG             CONSUMER-ID                                             HOST            CLIENT-ID
inventory-consumer outbox.event.kessel.tuples 0          -               0               -               inventory-consumer-975de370-2752-4f79-bd41-6814f8bf4fe1 /10.89.0.12     inventory-consumer

=== Get offsets ===
outbox.event.kessel.resources:0:0
```

## Result

All Kafka 4.3.1 CLI tools successfully negotiate with the 3.8.0 broker. Topic listing, topic describe, consumer group enumeration, consumer group describe with lag, offset queries, and API version negotiation all pass.


Jira: RHCLOUD-49294

<!-- Note any dependencies on other PRs or breaking changes here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the Kafka tools installation to version 4.3.1.
  * Improved installation consistency by removing dynamic version discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->