### PR TITLE
Add PR performance regression test workflow

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -1,7 +1,4 @@
 ---
-# Copy this file to project-kessel/inventory-api as:
-#   .github/workflows/perf-test.yml
-#
 # Required GitHub secret (set at org or repo level):
 #   GOSMEE_WEBHOOK_SECRET  — shared HMAC secret, must match the value in the
 #                            Gosmee client configmap on the perf cluster.

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -21,6 +21,7 @@ jobs:
   trigger-perf-test:
     name: Trigger Jenkins Performance Test
     runs-on: ubuntu-latest
+    permissions: {}  # this job only calls external services; no GitHub API access needed
     steps:
       - name: Resolve image to test
         id: image

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -12,6 +12,10 @@ name: Performance Regression Test
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '.github/**'
+      - '**.md'
+      - 'docs/**'
 
 jobs:
   trigger-perf-test:

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -100,15 +100,14 @@ jobs:
           echo "SHA:       ${PR_SHA}"
           echo "Image tag: on-pr-${PR_SHA}"
 
-          HTTP_STATUS=$(curl -s -o /tmp/gosmee_response.json -w "%{http_code}" \
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
             -X POST \
             "https://gosmee-server-smee-proxy.apps.rhperfcluster.ptjz.p1.openshiftapps.com/JIrfcIXXVTBJ" \
             -H "Content-Type: application/json" \
             -H "X-Hub-Signature-256: sha256=${SIGNATURE}" \
             --data-raw "${PAYLOAD}")
 
-          echo "Gosmee response (HTTP $HTTP_STATUS):"
-          cat /tmp/gosmee_response.json
+          echo "Gosmee response: HTTP $HTTP_STATUS"
 
           if [[ "$HTTP_STATUS" != "202" ]]; then
             echo "ERROR: Expected HTTP 202 from gosmee, got $HTTP_STATUS"

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -1,0 +1,94 @@
+---
+# Copy this file to project-kessel/inventory-api as:
+#   .github/workflows/perf-test.yml
+#
+# Required GitHub secret (set at org or repo level):
+#   GOSMEE_WEBHOOK_SECRET  — shared HMAC secret, must match the value in the
+#                            Gosmee client configmap on the perf cluster.
+#
+# See ci-configs/jenkins/gh-pr-testing/README.md for the full onboarding guide.
+name: Performance Regression Test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  trigger-perf-test:
+    name: Trigger Jenkins Performance Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve image to test
+        id: image
+        run: |
+          # Wait for Konflux to build and push the PR image to Quay.
+          # Konflux publishes images as: quay.io/redhat-user-workloads/<org>/<component>:<tag>
+          # Tag format for PRs: on-pr-<full-commit-sha>
+          # Image path discovered from .tekton/inventory-api-pull-request.yaml
+          IMAGE_URL="quay.io/redhat-user-workloads/project-kessel-tenant/kessel-inventory/inventory-api:on-pr-${{ github.event.pull_request.head.sha }}"
+          echo "Waiting for Konflux image: $IMAGE_URL"
+
+          MAX_WAIT=1800
+          INTERVAL=30
+          elapsed=0
+          while [ $elapsed -lt $MAX_WAIT ]; do
+            if skopeo inspect --no-creds "docker://$IMAGE_URL" >/dev/null 2>&1; then
+              echo "Image ready after ${elapsed}s: $IMAGE_URL"
+              break
+            fi
+            echo "Not available yet — ${elapsed}s elapsed (max ${MAX_WAIT}s), retrying in ${INTERVAL}s..."
+            sleep $INTERVAL
+            elapsed=$((elapsed + INTERVAL))
+          done
+
+          if [ $elapsed -ge $MAX_WAIT ]; then
+            echo "ERROR: Timed out after ${MAX_WAIT}s waiting for Konflux image"
+            exit 1
+          fi
+
+          echo "image_url=$IMAGE_URL" >> $GITHUB_OUTPUT
+
+      - name: Build and sign webhook payload
+        id: payload
+        env:
+          WEBHOOK_SECRET: ${{ secrets.GOSMEE_WEBHOOK_SECRET }}
+        run: |
+          # Single-line JSON avoids multiline $GITHUB_OUTPUT issues.
+          # jenkins_job routes to the correct Jenkins pipeline for this service.
+          # image_tag_override carries the full Konflux image URL for deployment.
+          PAYLOAD=$(printf '{"jenkins_job":"InsightsKesselAPI_PRTest_builder","repo":"%s","pr_number":"%s","pr_sha":"%s","pr_branch":"%s","triggered_by":"%s","image_tag_override":"%s"}' \
+            "${{ github.repository }}" \
+            "${{ github.event.pull_request.number }}" \
+            "${{ github.event.pull_request.head.sha }}" \
+            "${{ github.head_ref }}" \
+            "${{ github.actor }}" \
+            "${{ steps.image.outputs.image_url }}")
+          SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | cut -d' ' -f2)
+          echo "signature=$SIGNATURE" >> $GITHUB_OUTPUT
+          echo "payload=$PAYLOAD" >> $GITHUB_OUTPUT
+
+      - name: Send webhook to gosmee
+        run: |
+          echo "Triggering perf test for PR #${{ github.event.pull_request.number }}"
+          echo "Repo:      ${{ github.repository }}"
+          echo "Branch:    ${{ github.head_ref }}"
+          echo "SHA:       ${{ github.event.pull_request.head.sha }}"
+          echo "Image tag: on-pr-${{ github.event.pull_request.head.sha }}"
+
+          HTTP_STATUS=$(curl -s -o /tmp/gosmee_response.json -w "%{http_code}" \
+            -X POST \
+            "https://gosmee-server-smee-proxy.apps.rhperfcluster.ptjz.p1.openshiftapps.com/JIrfcIXXVTBJ" \
+            -H "Content-Type: application/json" \
+            -H "X-Hub-Signature-256: sha256=${{ steps.payload.outputs.signature }}" \
+            -d '${{ steps.payload.outputs.payload }}')
+
+          echo "Gosmee response (HTTP $HTTP_STATUS):"
+          cat /tmp/gosmee_response.json
+
+          if [[ "$HTTP_STATUS" != "202" ]]; then
+            echo "ERROR: Expected HTTP 202 from gosmee, got $HTTP_STATUS"
+            exit 1
+          fi
+
+          echo "Webhook accepted. Jenkins job will start shortly."
+          echo "Monitor at: https://jenkins-csb-perf-master.dno.corp.redhat.com/job/InsightsKesselAPI_PRTest_builder/"

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -17,6 +17,10 @@ on:
       - '**.md'
       - 'docs/**'
 
+concurrency:
+  group: perf-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   trigger-perf-test:
     name: Trigger Jenkins Performance Test

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -10,7 +10,7 @@
 name: Performance Regression Test
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/**'
@@ -24,12 +24,14 @@ jobs:
     steps:
       - name: Resolve image to test
         id: image
+        env:
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Wait for Konflux to build and push the PR image to Quay.
           # Konflux publishes images as: quay.io/redhat-user-workloads/<org>/<component>:<tag>
           # Tag format for PRs: on-pr-<full-commit-sha>
           # Image path discovered from .tekton/inventory-api-pull-request.yaml
-          IMAGE_URL="quay.io/redhat-user-workloads/project-kessel-tenant/kessel-inventory/inventory-api:on-pr-${{ github.event.pull_request.head.sha }}"
+          IMAGE_URL="quay.io/redhat-user-workloads/project-kessel-tenant/kessel-inventory/inventory-api:on-pr-${PR_SHA}"
           echo "Waiting for Konflux image: $IMAGE_URL"
 
           MAX_WAIT=1800
@@ -56,35 +58,53 @@ jobs:
         id: payload
         env:
           WEBHOOK_SECRET: ${{ secrets.GOSMEE_WEBHOOK_SECRET }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BRANCH: ${{ github.head_ref }}
+          TRIGGERED_BY: ${{ github.actor }}
+          IMAGE_URL: ${{ steps.image.outputs.image_url }}
         run: |
-          # Single-line JSON avoids multiline $GITHUB_OUTPUT issues.
-          # jenkins_job routes to the correct Jenkins pipeline for this service.
-          # image_tag_override carries the full Konflux image URL for deployment.
-          PAYLOAD=$(printf '{"jenkins_job":"InsightsKesselAPI_PRTest_builder","repo":"%s","pr_number":"%s","pr_sha":"%s","pr_branch":"%s","triggered_by":"%s","image_tag_override":"%s"}' \
-            "${{ github.repository }}" \
-            "${{ github.event.pull_request.number }}" \
-            "${{ github.event.pull_request.head.sha }}" \
-            "${{ github.head_ref }}" \
-            "${{ github.actor }}" \
-            "${{ steps.image.outputs.image_url }}")
+          if [[ -z "$WEBHOOK_SECRET" ]]; then
+            echo "ERROR: GOSMEE_WEBHOOK_SECRET is not set. Add it as a repository secret."
+            exit 1
+          fi
+          # Use jq --arg to safely build JSON from env vars.
+          # This prevents shell injection from crafted branch names or other PR values.
+          PAYLOAD=$(jq -cn \
+            --arg jenkins_job        "InsightsKesselAPI_PRTest_builder" \
+            --arg repo               "$GH_REPO" \
+            --arg pr_number          "$PR_NUMBER" \
+            --arg pr_sha             "$PR_SHA" \
+            --arg pr_branch          "$PR_BRANCH" \
+            --arg triggered_by       "$TRIGGERED_BY" \
+            --arg image_tag_override "$IMAGE_URL" \
+            '{jenkins_job: $jenkins_job, repo: $repo, pr_number: $pr_number, pr_sha: $pr_sha, pr_branch: $pr_branch, triggered_by: $triggered_by, image_tag_override: $image_tag_override}')
           SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | cut -d' ' -f2)
           echo "signature=$SIGNATURE" >> $GITHUB_OUTPUT
           echo "payload=$PAYLOAD" >> $GITHUB_OUTPUT
 
       - name: Send webhook to gosmee
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_REPO: ${{ github.repository }}
+          PR_BRANCH: ${{ github.head_ref }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          SIGNATURE: ${{ steps.payload.outputs.signature }}
+          PAYLOAD: ${{ steps.payload.outputs.payload }}
         run: |
-          echo "Triggering perf test for PR #${{ github.event.pull_request.number }}"
-          echo "Repo:      ${{ github.repository }}"
-          echo "Branch:    ${{ github.head_ref }}"
-          echo "SHA:       ${{ github.event.pull_request.head.sha }}"
-          echo "Image tag: on-pr-${{ github.event.pull_request.head.sha }}"
+          echo "Triggering perf test for PR #${PR_NUMBER}"
+          echo "Repo:      ${GH_REPO}"
+          echo "Branch:    ${PR_BRANCH}"
+          echo "SHA:       ${PR_SHA}"
+          echo "Image tag: on-pr-${PR_SHA}"
 
           HTTP_STATUS=$(curl -s -o /tmp/gosmee_response.json -w "%{http_code}" \
             -X POST \
             "https://gosmee-server-smee-proxy.apps.rhperfcluster.ptjz.p1.openshiftapps.com/JIrfcIXXVTBJ" \
             -H "Content-Type: application/json" \
-            -H "X-Hub-Signature-256: sha256=${{ steps.payload.outputs.signature }}" \
-            -d '${{ steps.payload.outputs.payload }}')
+            -H "X-Hub-Signature-256: sha256=${SIGNATURE}" \
+            --data-raw "${PAYLOAD}")
 
           echo "Gosmee response (HTTP $HTTP_STATUS):"
           cat /tmp/gosmee_response.json

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -6,7 +6,7 @@
 #   GOSMEE_WEBHOOK_SECRET  — shared HMAC secret, must match the value in the
 #                            Gosmee client configmap on the perf cluster.
 #
-# See ci-configs/jenkins/gh-pr-testing/README.md for the full onboarding guide.
+# See https://gitlab.cee.redhat.com/redhat-performance/ci-configs/-/tree/master/jenkins/gh-pr-testing for the full onboarding guide.
 name: Performance Regression Test
 
 on:


### PR DESCRIPTION
## What changed
Added `.github/workflows/perf-test.yml` — a GitHub Actions workflow that triggers an automated performance regression test on every PR.

## Why
Enables early detection of performance regressions by running a Jenkins perf test pipeline against the Konflux-built PR image before merging.

## Validation
- Workflow uses `pull_request_target` so fork PRs can access repo secrets
- All GitHub context values passed through `env:` to prevent shell injection
- `jq --arg` used to safely build the JSON payload
- `GITHUB_TOKEN` permissions set to `{}` (least privilege — no GitHub API access needed)
- `GOSMEE_WEBHOOK_SECRET` already set as a repo secret ✅

## Jira
https://redhat.atlassian.net/browse/HCEPERF-780

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated performance regression testing for pull requests.
  * Performance tests now wait for the corresponding build image, trigger the test run, and report a monitoring link.
  * Duplicate runs are automatically canceled when a newer update is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->