### PR TITLE
NOJIRA-45678 - disable go-kratos major updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,12 +7,6 @@
     "schedule": ["* 0-7 * * 0"],
     "packageRules": [
       {
-        "matchManagers": ["gomod"],
-        "matchPackageNames": ["github.com/go-kratos/**"],
-        "matchUpdateTypes": ["major"],
-        "enabled": false
-      },
-      {
         "matchDatasources": ["go"],
         "enabled": true,
         "groupName": "Go updates",
@@ -20,6 +14,13 @@
           "branchTopic": "go-updates",
           "commitMessageTopic": "go packages"
         }
+      },
+      {
+        "description": "Disable go-kratos major updates",
+        "matchManagers": ["gomod"],
+        "matchPackageNames": ["github.com/go-kratos/**"],
+        "matchUpdateTypes": ["major"],
+        "enabled": false
       }
     ]
   }


### PR DESCRIPTION
## What changed
<!-- Brief description. Use bullet points for multi-part changes. -->

Renovate config was setup to disable updating go-kratos to new major versions but because of the ordering of content the changes did not properly apply. 

- moves disable go-kratos major updates to end of renovate.json

```
If multiple rules match a dependency, configurations from matching rules will be merged together. 
The order of rules matters, because later rules may override configuration options from earlier ones, 
if they both specify the same option
```
https://docs.renovatebot.com/configuration-options/#packagerules:~:text=packageRules%20is%20a%20collection%20of%20rules%2C%20that%20are%20all%20evaluated.%20If%20multiple%20rules%20match%20a%20dependency%2C%20configurations%20from%20matching%20rules%20will%20be%20merged%20together.%20The%20order%20of%20rules%20matters%2C%20because%20later%20rules%20may%20override%20configuration%20options%20from%20earlier%20ones%2C%20if%20they%20both%20specify%20the%20same%20option.

## Why
<!-- Context and motivation. -->
https://github.com/project-kessel/inventory-api/pull/1417 is still pushing to update go-kratos from v2 -> v3 

https://github.com/project-kessel/inventory-api/pull/1409 didn't fully solve the issue

## Validation
<!-- How you verified this works: test output, ephemeral env name, screenshots, etc. Write "N/A" for trivial changes. -->

Jira: <!-- RHCLOUD-XXXXX or N/A -->

<!-- Note any dependencies on other PRs or breaking changes here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Clarified the description of an automated dependency update rule while preserving its existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->