### PR TITLE
RHCLOUD-48927: Add manage-schema config option

### DIFF
--- a/deploy/kessel-inventory-ephem.yaml
+++ b/deploy/kessel-inventory-ephem.yaml
@@ -27,6 +27,7 @@ objects:
             enable-oidc-auth: false
           spicedb:
             schema-file: "/etc/spicedb-schema/schema.zed"
+            manage-schema: true
             use-tls: false
             fully-consistent: true
         selfsubjectstrategy:

--- a/internal/config/relations/options_test.go
+++ b/internal/config/relations/options_test.go
@@ -65,16 +65,40 @@ func TestOptions_Validate(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "spicedb impl",
+			name: "spicedb impl with manage-schema and schema-file",
 			options: &Options{
 				Authz: "spicedb",
 				SpiceDB: &spicedb.Options{
-					Endpoint:   "localhost:50051",
-					TokenFile:  "/tmp/token",
-					SchemaFile: "/tmp/schema.zed",
+					Endpoint:     "localhost:50051",
+					TokenFile:    "/tmp/token",
+					SchemaFile:   "/tmp/schema.zed",
+					ManageSchema: true,
 				},
 			},
 			expectError: false,
+		},
+		{
+			name: "spicedb impl without manage-schema does not require schema-file",
+			options: &Options{
+				Authz: "spicedb",
+				SpiceDB: &spicedb.Options{
+					Endpoint:  "localhost:50051",
+					TokenFile: "/tmp/token",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "spicedb impl with manage-schema requires schema-file",
+			options: &Options{
+				Authz: "spicedb",
+				SpiceDB: &spicedb.Options{
+					Endpoint:     "localhost:50051",
+					TokenFile:    "/tmp/token",
+					ManageSchema: true,
+				},
+			},
+			expectError: true,
 		},
 		{
 			name: "invalid impl",

--- a/internal/config/relations/spicedb/options.go
+++ b/internal/config/relations/spicedb/options.go
@@ -13,6 +13,7 @@ type Options struct {
 	SchemaFile      string `mapstructure:"schema-file"`
 	UseTLS          bool   `mapstructure:"use-tls"`
 	FullyConsistent bool   `mapstructure:"fully-consistent"`
+	ManageSchema    bool   `mapstructure:"manage-schema"`
 }
 
 func NewOptions() *Options {
@@ -32,6 +33,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 	fs.StringVar(&o.SchemaFile, prefix+"schema-file", o.SchemaFile, "Path to SpiceDB schema file")
 	fs.BoolVar(&o.UseTLS, prefix+"use-tls", o.UseTLS, "Enable TLS for SpiceDB connection")
 	fs.BoolVar(&o.FullyConsistent, prefix+"fully-consistent", o.FullyConsistent, "Use fully consistent reads (slower but strongest consistency)")
+	fs.BoolVar(&o.ManageSchema, prefix+"manage-schema", o.ManageSchema, "Call WriteSchema on startup to manage the SpiceDB schema lifecycle")
 }
 
 func (o *Options) Validate() []error {
@@ -45,8 +47,8 @@ func (o *Options) Validate() []error {
 		errs = append(errs, fmt.Errorf("either spicedb token or token-file must be provided"))
 	}
 
-	if len(o.SchemaFile) == 0 {
-		errs = append(errs, fmt.Errorf("spicedb schema-file may not be empty"))
+	if o.ManageSchema && len(o.SchemaFile) == 0 {
+		errs = append(errs, fmt.Errorf("spicedb schema-file is required when manage-schema is enabled"))
 	}
 
 	return errs

--- a/internal/data/spicedb_container.go
+++ b/internal/data/spicedb_container.go
@@ -160,6 +160,7 @@ type SpiceDBConfig struct {
 	SchemaFile      string
 	UseTLS          bool
 	FullyConsistent bool
+	ManageSchema    bool
 }
 
 // NewSpiceDBConfigFromCompleted builds a SpiceDBConfig from a completed spicedb config.
@@ -171,6 +172,7 @@ func NewSpiceDBConfigFromCompleted(c spicedb.CompletedConfig) *SpiceDBConfig {
 		SchemaFile:      c.SchemaFile,
 		UseTLS:          c.UseTLS,
 		FullyConsistent: c.FullyConsistent,
+		ManageSchema:    c.ManageSchema,
 	}
 }
 

--- a/internal/data/spicedb_relations_repository.go
+++ b/internal/data/spicedb_relations_repository.go
@@ -36,6 +36,7 @@ type SpiceDBRelationsRepository struct {
 	client                   *authzed.Client
 	healthClient             grpc_health_v1.HealthClient
 	schemaFilePath           string
+	manageSchema             bool
 	initOnce                 sync.Once
 	initErr                  error
 	fullyConsistentAsDefault bool
@@ -124,6 +125,7 @@ func NewSpiceDBRelationsRepository(config *SpiceDBConfig, logger log.Logger) (*S
 		client:                   client,
 		healthClient:             healthClient,
 		schemaFilePath:           config.SchemaFile,
+		manageSchema:             config.ManageSchema,
 		fullyConsistentAsDefault: config.FullyConsistent,
 		Logger:                   logHelper,
 		successCounter:           successCounter,
@@ -146,6 +148,10 @@ func (s *SpiceDBRelationsRepository) incrSuccessCounter(method string) {
 
 func (s *SpiceDBRelationsRepository) initialize(ctx context.Context) error {
 	s.initOnce.Do(func() {
+		if !s.manageSchema {
+			return
+		}
+
 		schema, err := readFile(s.schemaFilePath)
 		if err != nil {
 			s.initErr = fmt.Errorf("failed to load schema file: %w", err)

--- a/internal/data/spicedb_relations_repository_test.go
+++ b/internal/data/spicedb_relations_repository_test.go
@@ -272,6 +272,56 @@ func TestIsBackendUnavailable(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestManageSchemaFalse_DoesNotReadSchemaFile(t *testing.T) {
+	t.Parallel()
+
+	config := &SpiceDBConfig{
+		Endpoint:     "localhost:50051",
+		Token:        "foobar",
+		ManageSchema: false,
+		SchemaFile:   "/nonexistent/this-file-must-not-be-read.zed",
+	}
+	repo, _, err := NewSpiceDBRelationsRepository(config, log.GetLogger())
+	assert.NoError(t, err)
+
+	err = repo.initialize(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestManageSchemaTrue_FailsWithMissingFile(t *testing.T) {
+	t.Parallel()
+
+	config := &SpiceDBConfig{
+		Endpoint:     "localhost:50051",
+		Token:        "foobar",
+		ManageSchema: true,
+		SchemaFile:   "/nonexistent/schema.zed",
+	}
+	repo, _, err := NewSpiceDBRelationsRepository(config, log.GetLogger())
+	assert.NoError(t, err)
+
+	err = repo.initialize(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load schema file")
+}
+
+func TestManageSchemaTrue_LoadsValidSchemaFile(t *testing.T) {
+	t.Parallel()
+
+	config := &SpiceDBConfig{
+		Endpoint:     "localhost:50051",
+		Token:        "foobar",
+		ManageSchema: true,
+		SchemaFile:   "../../test/testdata/spicedb/basic_schema.zed",
+	}
+	repo, _, err := NewSpiceDBRelationsRepository(config, log.GetLogger())
+	assert.NoError(t, err)
+
+	err = repo.initialize(context.Background())
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "failed to load schema file")
+}
+
 func TestDoesNotCreateRelationshipWithSlashInSubjectType(t *testing.T) {
 	requireSpiceDBIntegration(t)
 


### PR DESCRIPTION
## What changed
<!-- Brief description. Use bullet points for multi-part changes. -->
* Adds config to control whether Inventory API manages spicedb schema

## Why
<!-- Context and motivation. -->
* Help control migration paths with relations api deprecation

## Validation
<!-- How you verified this works: test output, ephemeral env name, screenshots, etc. Write "N/A" for trivial changes. -->
```
## Local validation (podman compose)

### manage-schema: true (local dev / ephemeral mode)

Started compose stack with `manage-schema: true` in `local-w-spicedb.yaml`:
```bash
$ ./scripts/start-inventory-spicedb.sh
```

Confirmed SpiceDB received WriteSchema:
```bash
$ podman logs development-spicedb-1 2>&1 | grep "WriteSchema"
{"level":"info","grpc.service":"authzed.api.v1.SchemaService","grpc.method":"WriteSchema","grpc.code":"OK","grpc.time_ms":107,"message":"finished call"}
```

Health check passes:
```bash
$ curl -s http://localhost:8000/api/kessel/v1/readyz
{"status":"STORAGE postgres and RELATIONS-API (spicedb)","code":200}
```

Authz check works:
```bash
$ grpcurl -plaintext -d '{
  "object": {"resource_type": "workspace", "resource_id": "test-workspace-1", "reporter": {"type": "rbac"}},
  "relation": "view",
  "subject": {"resource": {"resource_type": "principal", "resource_id": "testuser", "reporter": {"type": "rbac"}}}
}' localhost:9000 kessel.inventory.v1beta2.KesselInventoryService.Check
{
  "allowed": "ALLOWED_FALSE",
  "consistencyToken": {"token": "GhAKBENPd0cSCGQ0YzE2ZDZh"}
}
```

### manage-schema: false (stage / prod mode)

Restarted inventory-api with `manage-schema: false`:
```bash
$ CONFIG=local-w-spicedb HTTP_PORT=8000 GRPC_PORT=9000 podman compose \
    -f development/docker-compose.yaml -f development/docker-compose.spicedb.yaml \
    up --build -d inventory-api
```

Confirmed no new WriteSchema call in SpiceDB (only the one from the previous run):
```bash
$ podman logs development-spicedb-1 2>&1 | grep "WriteSchema"
{"level":"info","grpc.method":"WriteSchema","grpc.start_time":"2026-07-23T17:22:23.528235799Z","grpc.code":"OK","message":"finished call"}
```

Health check still passes (uses existing schema in SpiceDB):
```bash
$ curl -s http://localhost:8000/api/kessel/v1/readyz
{"status":"STORAGE postgres and RELATIONS-API (spicedb)","code":200}
```

Authz check still works:
```bash
$ grpcurl -plaintext -d '{
  "object": {"resource_type": "workspace", "resource_id": "test-workspace-1", "reporter": {"type": "rbac"}},
  "relation": "view",
  "subject": {"resource": {"resource_type": "principal", "resource_id": "testuser", "reporter": {"type": "rbac"}}}
}' localhost:9000 kessel.inventory.v1beta2.KesselInventoryService.Check
{
  "allowed": "ALLOWED_FALSE",
  "consistencyToken": {"token": "GhQKCENJZ0hJSWNIEghkNGMxNmQ2YQ=="}
}
```

### Unit tests

```bash
$ go test ./internal/config/relations/... -v -count=1
# 20 passed in 3 packages

$ go test ./internal/data/ -run "TestManageSchema" -short -v -count=1
# 3 passed in 1 package
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to control whether authorization schemas are managed automatically.
  * Schema files are now required only when schema management is enabled.
  * Ephemeral deployments enable automatic schema management.

* **Bug Fixes**
  * Prevented disabled schema management from attempting to load or apply schema files.
  * Added validation for missing schema files when management is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->