### PR TITLE
RHCLOUD-48927: Apply default pagination limit to spicedb repository

### DIFF
--- a/internal/data/spicedb_relations_repository.go
+++ b/internal/data/spicedb_relations_repository.go
@@ -25,10 +25,11 @@ import (
 )
 
 const (
-	relationPrefix      = "t_"
-	lockType            = "kessel/lock"
-	lockVersionType     = "kessel/lockversion"
-	lockVersionRelation = "version"
+	relationPrefix               = "t_"
+	lockType                     = "kessel/lock"
+	lockVersionType              = "kessel/lockversion"
+	lockVersionRelation          = "version"
+	defaultStreamingLimit uint32 = 1000
 )
 
 // SpiceDBRelationsRepository implements the Relations Repository interface using SpiceDB.
@@ -371,10 +372,7 @@ func (s *SpiceDBRelationsRepository) LookupObjects(
 		cursor = &v1.Cursor{Token: pagination.Continuation.Serialize()}
 	}
 
-	var limit uint32
-	if pagination != nil {
-		limit = pagination.Limit
-	}
+	limit := effectiveLimit(pagination, defaultStreamingLimit)
 
 	req := &v1.LookupResourcesRequest{
 		Consistency:        s.determineConsistency(consistency),
@@ -574,10 +572,7 @@ func (s *SpiceDBRelationsRepository) ReadTuples(
 		cursor = &v1.Cursor{Token: pagination.Continuation.Serialize()}
 	}
 
-	var limit uint32
-	if pagination != nil {
-		limit = pagination.Limit
-	}
+	limit := effectiveLimit(pagination, defaultStreamingLimit)
 
 	relationshipFilter, err := tupleFilterToSpiceDBFilter(filter)
 	if err != nil {
@@ -872,6 +867,13 @@ func (s *SpiceDBRelationsRepository) determineConsistency(consistency model.Cons
 			},
 		}
 	}
+}
+
+func effectiveLimit(pagination *model.Pagination, defaultLimit uint32) uint32 {
+	if pagination != nil && pagination.Limit > 0 && pagination.Limit < defaultLimit {
+		return pagination.Limit
+	}
+	return defaultLimit
 }
 
 func optionalRelationToString(r *model.Relation) string {

--- a/internal/data/spicedb_relations_repository_test.go
+++ b/internal/data/spicedb_relations_repository_test.go
@@ -272,6 +272,55 @@ func TestIsBackendUnavailable(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestEffectiveLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		pagination   *model.Pagination
+		defaultLimit uint32
+		expected     uint32
+	}{
+		{
+			name:         "nil pagination uses default",
+			pagination:   nil,
+			defaultLimit: 1000,
+			expected:     1000,
+		},
+		{
+			name:         "zero limit uses default",
+			pagination:   model.NewPagination(0, nil),
+			defaultLimit: 1000,
+			expected:     1000,
+		},
+		{
+			name:         "client limit smaller than default is used",
+			pagination:   model.NewPagination(100, nil),
+			defaultLimit: 1000,
+			expected:     100,
+		},
+		{
+			name:         "client limit equal to default is used",
+			pagination:   model.NewPagination(1000, nil),
+			defaultLimit: 1000,
+			expected:     1000,
+		},
+		{
+			name:         "client limit larger than default uses default",
+			pagination:   model.NewPagination(5000, nil),
+			defaultLimit: 1000,
+			expected:     1000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := effectiveLimit(tt.pagination, tt.defaultLimit)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestDoesNotCreateRelationshipWithSlashInSubjectType(t *testing.T) {
 	requireSpiceDBIntegration(t)
 


### PR DESCRIPTION
## What changed
<!-- Brief description. Use bullet points for multi-part changes. -->
* Adds streaming defaults to spicedb repository layer

## Why
<!-- Context and motivation. -->

Relations defaulted `limit` to 1000 when clients omit it. Without that default in the direct Inventory->SpiceDB path, the initial call sends `limit=0` and the continuation sends `limit=1000`, causing SpiceDB to reject the cursor because the hash changed. This adds the same default for parity.

- LookupResources: https://github.com/project-kessel/relations-api/blob/main/internal/biz/lookup.go#L70
- ReadRelationships: https://github.com/project-kessel/relations-api/blob/main/internal/biz/relationships.go#L124

| Relations-api                            | Inventory-api                          | SpiceDB             |
| ---------------------------------------- | -------------------------------------- | ------------------- |
| `LookupResources` (limit=1000 default)   | `LookupObjects` (limit=1000 default)   | `LookupResources`   |
| `ReadRelationships` (limit=1000 default) | `ReadTuples` (limit=1000 default)      | `ReadRelationships` |
| `LookupSubjects` (limit=0, no default)   | `LookupSubjects` (limit=0, no default) | `LookupSubjects`    |

## Validation
<!-- How you verified this works: test output, ephemeral env name, screenshots, etc. Write "N/A" for trivial changes. -->

Before
```bash
# Step 1: Initial call with NO pagination (no limit) - get cursor from first result
$ CURSOR=$(grpcurl -plaintext -d '{
  "object_type": {"resource_type": "workspace", "reporter_type": "rbac"},
  "relation": "view",
  "subject": {"resource": {"resource_type": "principal", "resource_id": "paginateuser", "reporter": {"type": "rbac"}}},
  "consistency": {"minimize_latency": true}
}' localhost:9000 kessel.inventory.v1beta2.KesselInventoryService/StreamedListObjects 2>&1 | python3 -c "
import json, sys
for block in sys.stdin.read().split('\n{'):
    if block and not block.startswith('{'): block = '{' + block
    try:
        obj = json.loads(block)
        token = obj.get('pagination', {}).get('continuationToken', '')
        if token: print(token); break
    except: pass
")

# Step 2: Continuation with limit=1000 + cursor (simulating client adding limit on page 2)
$ grpcurl -plaintext -d "{
  \"object_type\": {\"resource_type\": \"workspace\", \"reporter_type\": \"rbac\"},
  \"relation\": \"view\",
  \"subject\": {\"resource\": {\"resource_type\": \"principal\", \"resource_id\": \"paginateuser\", \"reporter\": {\"type\": \"rbac\"}}},
  \"pagination\": {\"limit\": 1000, \"continuation_token\": \"$CURSOR\"},
  \"consistency\": {\"minimize_latency\": true}
}" localhost:9000 kessel.inventory.v1beta2.KesselInventoryService/StreamedListObjects

ERROR:
  Code: InvalidArgument
  Message: the cursor provided does not have the same arguments as the original API call;
           please ensure you are making the same API call, with the exact same parameters (besides the cursor)
  Details:
  1) { "reason": "ERROR_REASON_INVALID_CURSOR" }
```

Initial call sends no limit (inventory-api passes `limit=0` to SpiceDB). Client sends `limit=1000` on continuation. SpiceDB rejects because the limit changed.

After
```bash
# Step 1: Initial call with NO pagination (no limit) - get cursor from first result
$ CURSOR=$(grpcurl -plaintext -d '{
  "object_type": {"resource_type": "workspace", "reporter_type": "rbac"},
  "relation": "view",
  "subject": {"resource": {"resource_type": "principal", "resource_id": "paginateuser", "reporter": {"type": "rbac"}}},
  "consistency": {"minimize_latency": true}
}' localhost:9000 kessel.inventory.v1beta2.KesselInventoryService/StreamedListObjects 2>&1 | python3 -c "
import json, sys
for block in sys.stdin.read().split('\n{'):
    if block and not block.startswith('{'): block = '{' + block
    try:
        obj = json.loads(block)
        token = obj.get('pagination', {}).get('continuationToken', '')
        if token: print(token); break
    except: pass
")

# Step 2: Continuation with limit=1000 + cursor (same test as before)
$ grpcurl -plaintext -d "{
  \"object_type\": {\"resource_type\": \"workspace\", \"reporter_type\": \"rbac\"},
  \"relation\": \"view\",
  \"subject\": {\"resource\": {\"resource_type\": \"principal\", \"resource_id\": \"paginateuser\", \"reporter\": {\"type\": \"rbac\"}}},
  \"pagination\": {\"limit\": 1000, \"continuation_token\": \"$CURSOR\"},
  \"consistency\": {\"minimize_latency\": true}
}" localhost:9000 kessel.inventory.v1beta2.KesselInventoryService/StreamedListObjects

{
  "object": {
    "resourceType": "workspace",
    "resourceId": "test-ws-10",
    "reporter": { "type": "rbac" }
  },
  "pagination": {
    "continuationToken": "CmIKBENPVVcSAi0xEgEwEgASAi0xEgItMRIBMBICLTESAi0xEgEwEgItMRIBMBICLTESATASABICLTESAi0xEgEwEgEyGhBkZjJkM2Q3Yzg0OTUzMjk5IAEqCQoEbHJ2MhIBMQ=="
  }
}
{
  "object": {
    "resourceType": "workspace",
    "resourceId": "test-ws-11",
    "reporter": { "type": "rbac" }
  },
  ...
}
```

Cursor accepted, results returned. The `defaultStreamingLimit=1000` on the initial call matches the client's `limit=1000` on continuation, so the SpiceDB cursor hash is consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a safeguard that caps SpiceDB streaming requests at 1,000 results by default.
  * Smaller page sizes are still honored; larger or unspecified limits now fall back to the capped maximum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->